### PR TITLE
Add customEndAtSeconds and uuid fields to Period

### DIFF
--- a/include/capnp/line.capnp
+++ b/include/capnp/line.capnp
@@ -29,6 +29,8 @@ struct Period {
   numberOfUnits        @7 :Int16;
   trips                @8 :List(Trip);
   isFrozen             @9 :Int8;
+  customEndAtSeconds  @10 :Int32;
+  uuid                @11 :Text;
 }
 
 struct Schedule {


### PR DESCRIPTION
In transition, those fields are being added to allow to customize when a
period should end and the uuid field is useful to save the period in the
database.