### PR TITLE
When using od trips routing, initial lost time at departure was not

### DIFF
--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -430,6 +430,7 @@ namespace TrRouting
             result.arrivalTimeSeconds            = arrivalTime;
             result.departureTimeSeconds          = minimizedDepartureTime;
             result.initialDepartureTimeSeconds   = departureTimeSeconds;
+            result.initialLostTimeAtDepartureSeconds = minimizedDepartureTime - departureTimeSeconds;
             result.numberOfTransfers             = numberOfTransfers;
             result.inVehicleTravelTimeSeconds    = totalInVehicleTime;
             result.transferTravelTimeSeconds     = totalTransferWalkingTime;
@@ -466,6 +467,8 @@ namespace TrRouting
       result.travelTimeSeconds           = -1;
       result.arrivalTimeSeconds          = -1;
       result.departureTimeSeconds        = departureTimeSeconds;
+      result.initialDepartureTimeSeconds = -1;
+      result.initialLostTimeAtDepartureSeconds = -1;
       result.numberOfTransfers           = -1;
       result.inVehicleTravelTimeSeconds  = -1;
       result.transferTravelTimeSeconds   = -1;
@@ -475,6 +478,7 @@ namespace TrRouting
       result.transferWaitingTimeSeconds  = -1;
       result.firstWaitingTimeSeconds     = -1;
       result.nonTransitTravelTimeSeconds = -1;
+
     }
 
     if (params.returnAllNodesResult)

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -348,6 +348,7 @@ namespace TrRouting
           odTripJson["declaredMode"]                  = odTrip->mode;
           odTripJson["expansionFactor"]               = correctedExpansionFactor;
           odTripJson["travelTimeSeconds"]             = routingResult.travelTimeSeconds;
+          odTripJson["initialLostTimeAtDepartureSeconds"] = routingResult.initialLostTimeAtDepartureSeconds;
           odTripJson["onlyWalkingTravelTimeSeconds"]  = odTrip->walkingTravelTimeSeconds;
           odTripJson["onlyCyclingTravelTimeSeconds"]  = odTrip->cyclingTravelTimeSeconds;
           odTripJson["onlyDrivingTravelTimeSeconds"]  = odTrip->drivingTravelTimeSeconds;

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -523,6 +523,7 @@ namespace TrRouting
             result.arrivalTimeSeconds            = arrivalTime;
             result.departureTimeSeconds          = bestDepartureTime;
             result.initialDepartureTimeSeconds   = initialDepartureTimeSeconds;
+            result.initialLostTimeAtDepartureSeconds = initialDepartureTimeSeconds != -1 ? bestDepartureTime - initialDepartureTimeSeconds: -1;
             result.numberOfTransfers             = numberOfTransfers;
             result.inVehicleTravelTimeSeconds    = totalInVehicleTime;
             result.transferTravelTimeSeconds     = totalTransferWalkingTime;
@@ -558,6 +559,9 @@ namespace TrRouting
       result.status                      = STATUS_NO_ROUTING_FOUND;
       result.travelTimeSeconds           = -1;
       result.arrivalTimeSeconds          = arrivalTimeSeconds;
+      result.departureTimeSeconds        = -1;
+      result.initialDepartureTimeSeconds = -1;
+      result.initialLostTimeAtDepartureSeconds = -1;
       result.numberOfTransfers           = -1;
       result.inVehicleTravelTimeSeconds  = -1;
       result.transferTravelTimeSeconds   = -1;

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -13,6 +13,7 @@ namespace TrRouting
     int arrivalTimeSeconds;
     int departureTimeSeconds;
     int initialDepartureTimeSeconds;
+    int initialLostTimeAtDepartureSeconds;
     int numberOfTransfers;
     int inVehicleTravelTimeSeconds;
     int transferTravelTimeSeconds;


### PR DESCRIPTION
available in the routing results. This commit adds the variable so we
can export it for each routed od trip