### PR TITLE
Use LTLIBRARY instead of LIBRARY to build libcsa

### DIFF
--- a/connection_scan_algorithm/src/Makefile.am
+++ b/connection_scan_algorithm/src/Makefile.am
@@ -1,8 +1,8 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include 
 
-noinst_LIBRARIES = libcsa.a
+noinst_LTLIBRARIES = libcsa.la
 
-libcsa_a_SOURCES = alternatives_routing.cpp \
+libcsa_la_SOURCES = alternatives_routing.cpp \
 		   calculator.cpp \
 		   forward_calculation.cpp \
 		   forward_journey.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,4 +26,4 @@ stops_cache_fetcher.cpp \
 trips_and_connections_cache_fetcher.cpp
 
 
-trRouting_LDADD = ../connection_scan_algorithm/src/libcsa.a
+trRouting_LDADD = ../connection_scan_algorithm/src/libcsa.la


### PR DESCRIPTION
The static lib was creating relocation issues when linking with boost libraries.

Fixes: #57

Tested on debian only