### PR TITLE
Test for capnp binary presence in configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ AX_BOOST_FILESYSTEM
 AX_WITH_CURSES
 
 PKG_CHECK_MODULES(CAPNP, capnp)
+# Check for the capnp binary presence
+AC_PATH_PROG(CAPNP_BIN, capnp, no)
+AS_IF([test x"$CAPNP_BIN" = x"no"], [AC_MSG_ERROR([Please install capnp binary.])])
 
 # TODO There's probably a cleaner way to add -lrt required by boost::interprocess
 AC_CHECK_LIB(rt, shm_open)

--- a/include/capnp/Makefile.am
+++ b/include/capnp/Makefile.am
@@ -1,7 +1,7 @@
 SUFFIXES = .capnp .capnp.h
 
 .capnp.capnp.h:
-	capnp compile -oc++ $<
+	$(CAPNP_BIN) compile -oc++ $<
 
 clean-local:
 	rm *.capnp.h *.capnp.c++


### PR DESCRIPTION
We need the binary, not just the library to be able to generate the capnp objects
header files

Fix #64

Second commit also use the found path in the Makefile

Tested by changing the capnp binary name to something non existant. The configure
step failed properly then.
