### PR TITLE
WIP: Add an OpenAPI documentation of the trRouting API

### DIFF
--- a/docs/API.yml
+++ b/docs/API.yml
@@ -1,0 +1,568 @@
+openapi: '3.0.2'
+info:
+  title: TrRouting
+  version: '1.0'
+servers:
+  - url: http://localhost:4000
+
+paths:
+  /route/v1/transit:
+    get:
+      description: Calculate transit route results from a given origin/destination, or ODTrip, or accessibility map
+      parameters:
+        - in: query
+          name: origin
+          schema:
+            type: string
+            pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          required: false
+          description: Comma-separated latitude/longitude coordinates of the origin, in the WSG84 coordinates system
+        - in: query
+          name: destination
+          schema:
+            type: string
+            pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          required: false
+          description: Comma-separated latitude/longitude coordinates of the destination, in the WSG84 coordinates system
+        - in: query
+          name: od_trip_uuid
+          schema:
+            type: string
+          required: false
+          description: UUID of the OD trip to query. Either this or origin and destination should be specified.
+        - in: query
+          name: scenario_uuid
+          schema:
+            type: string
+          required: true
+          # TODO: Scenario is very transition centric. Can't trRouting be used with a GTFS or some other type, without a scenario
+          description: UUID of the scenario to query. A scenario defines the services, agencies and lines to use for this transit calculation
+        - in: query
+          name: alternatives
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+            default: 0
+          required: false
+          description: Whether the results should return various alternatives if available or just a single result.
+        - in: query
+          name: departure_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: departure time in seconds since midnight
+        - in: query
+          name: arrival_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: arrival time in seconds since midnight
+        - in: query
+          name: min_waiting_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: "The minimum time to wait at a stop/station, to cope with uncertainties in the vehicle arrival times. Suggested value: 180"
+        - in: query
+          name: max_access_travel_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: "Maximum time, in seconds, to reach the first stop/station in the trip"
+        - in: query
+          name: max_egress_travel_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: "Maximum time, in seconds, from the last stop/station, to reach the destination"
+        - in: query
+          name: max_transfer_travel_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: "Maximum time, in seconds, for each transfer between stop/station during the trip"
+        - in: query
+          name: max_travel_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: The maximum total travel time between origin and destination, including access, transfer and egress times
+        - in: query
+          name: max_first_waiting_time_seconds
+          schema:
+            type: integer
+          required: false
+          description: The maximum time, in seconds, one can wait at first stop/station to consider this trip valid
+        - in: query
+          name: all_nodes
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+            default: 0
+          required: false
+          # TODO: This will become 2 different endpoints since the return values are so much different.
+          description: If set to 0, the query returns the routes between origin and destination. If set to 1, the query will return all the nodes accessible with the given parameter. Only the origin is required for this query.
+      # The parameters above are those used in the Transition queries, already ported to typescript
+      # Still undocumented parameters. See if they are all required and remove any reference to them if they are not. Parameters on the same line are in the same if condition in the code, so identical
+      # Some parameters differ only with the unit, consider using a single parameter, and if really required, add a parameter that contains the units. Otherwise, one can specify 2 such parameters, which one to take?
+      # - starting_node_uuid, start_node_uuid, origin_node_uuid
+      # - ending_node_uuid, end_node_uuid,destination_node_uuid
+      # - return_all_nodes_results, return_all_nodes_result (same as all_nodes)
+      # - time, departure, departure_time, start_time (redundant with departure_time_seconds, different format)
+      # - arrival_time, arrival, end_time (redundant with arrival_time_seconds, different format)
+      # - departure_seconds, start_time_seconds (same as departure_time_seconds)
+      # - arrival_seconds, end_time_seconds (same as arrival_time_seconds)
+      # - data_source_uuid
+      # - reverse
+      # - min_waiting_time, min_waiting_time_minutes (redundant with min_waiting_time_seconds, different units)
+      # - max_travel_time, max_travel_time_seconds (redundent with max_travel_time_secods, different units)
+      # - max_acces_travel_time, max_access_travel_time_minutes (redundant with max_access_travel_time_seconds, different units)
+      # - max_egress_travel_time, max_egress_travel_time_minutes (redundant with max_egress_travel_time_seconds, different units)
+      # - max_transfer_travel_time, max_transfer_travel_time_minutes (redundant with max_transfer_travel_time_seconds, different units)
+      # - max_only_walking_access_travel_time_ratio
+      # - od_trips
+      # - od_trips_sample_size, sample_size, sample
+      # - sample_ratio, od_trips_sample_ratio
+      # - od_trips_periods
+      # - od_trips_genders
+      # - od_trips_age_groups
+      # - od_trips_occupations
+      # - od_trips_activities
+      # - od_trips_modes
+      # - alt (same as alternatives)
+      # - max_alternatives, max_alt
+      # - alternatives_max_added_travel_time_minutes, alt_max_added_travel_time
+      # - alt_max_added_travel_time_seconds, alternatives_max_added_travel_time_seconds
+      # - alternatives_max_travel_time_ratio, alt_max_ratio
+      # - alternatives_min_max_travel_time_minutes, alt_min_max_travel_time
+      # - alternatives_min_max_travel_time_seconds, alt_min_max_travel_time_seconds
+      # - transfer_penalty, transfer_penalty_minutes
+      # - walking_speed_factor, walk_factor
+      # - transfer_only_at_same_station, transfer_only_at_station
+      # - detailed, detailed_results, detailed_result
+      # - profiles, calculate_profiles
+      # - transfer_between_same_line, allow_same_line_transfer, transfers_between_same_line, allow_same_line_transfers
+      # - seed, random_seed
+      # - max_number_of_transfers, max_transfers
+      # - calculate_by_number_of_transfers, by_num_transfers
+      # - only_service_uuids,
+      # - only_node_uuids
+      # - except_node_uuids
+      # - only_line_uuids
+      # - except_line_uuids
+      # - only_modes
+      # - except_modes
+      # - only_agency_uuids
+      # - except_agency_uuids
+      # - date
+      # - calculation_name, name
+      # - file_format, format, response_format, response
+      # - batch
+      # - num_batches
+      # - debug
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  # TODO Some of the error schemas should be under a 4xx response, but that is not how it is in this endpoint
+                  - $ref: '#/components/schemas/error'
+                  - $ref: '#/components/schemas/no_routing_found'
+                  - $ref: '#/components/schemas/success'
+                  - $ref: '#/components/schemas/data_error'
+                discriminator:
+                  propertyName: status
+        
+components:
+  schemas:
+    statusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum: [error, success, no_routing_found, data_error]
+      discriminator:
+        propertyName: status
+    
+    error: # 'error' is a value for the status (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/statusResponse'
+        - type: object
+          properties:
+            error: 
+              oneOf:
+                - type: string
+                  enum: 
+                  - 'Wrong or malformed query'
+                - type: object
+                  properties:
+                  # TODO: error and code are redundant and need to match, consider having only one of the 2
+                    error:
+                      type: string
+                      enum:
+                        - 'No agencies found'
+                        - 'No services found'
+                        - 'No nodes found'
+                        - 'No lines found'
+                        - 'No paths found'
+                        - 'No scenarios found'
+                        - 'No schedules found'
+                    code:
+                      type: string
+                      enum:
+                        - 'MISSING_DATA_AGENCIES'
+                        - 'MISSING_DATA_SERVICES'
+                        - 'MISSING_DATA_NODES'
+                        - 'MISSING_DATA_LINES'
+                        - 'MISSING_DATA_PATHS'
+                        - 'MISSING_DATA_SCENARIOS'
+                        - 'MISSING_DATA_SCHEDULES'
+    no_routing_found:
+      allOf:
+      - $ref: '#/components/schemas/statusResponse'
+      - $ref: '#/components/schemas/baseRouteResponse'
+      - type: object
+        properties:
+            arrivalTime:
+              type: string
+              # TODO: Why? it's a no routing response...
+              description: Arrival time
+            arrivalTimeSeconds:
+              type: number
+              # TODO: Why? it's a no routing response...
+              description: Arrival time in seconds
+
+    success: # TODO: There's a lot of data returned, document it all, but from the code, not from transition
+      allOf:
+      - $ref: '#/components/schemas/statusResponse'
+      - $ref: '#/components/schemas/routeOrAlternativesResponse'
+
+    data_error: # 'data_error' is a value for the status (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/statusResponse'
+    
+    routeOrAlternativesResponse:
+      oneOf:
+      - $ref: '#/components/schemas/routeResponse'
+      - $ref: '#/components/schemas/alternativesResponse'
+
+    baseRouteResponse:
+      type: object
+      properties:
+        origin: 
+          type: string
+          pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          description: Comma-separated latitude/longitude coordinates of the origin, in the WSG84 coordinates system
+        destination:
+          type: string
+          pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          description: Comma-separated latitude/longitude coordinates of the destination, in the WSG84 coordinates system
+
+    routeResponse:
+      allOf:
+        - $ref: '#/components/schemas/baseRouteResponse'
+        - type: object
+          properties:
+            departureTime:
+              type: string
+              description: Optimized departure time in HH:MM format
+            departureTimeSeconds:
+              type: number
+              description: same as departureTime, in seconds since midnight
+            initialDepartureTime:
+              type: string
+              description: Departure time as specified in the request, in HH:MM format, or -1 if the departure time was not specified
+            initialDepartureTimeSeconds:
+              type: number
+              description: same as initialDepartureTime, in seconds since midnight
+            initialLostTimeAtDepartureSeconds:
+              type: number
+              description: Difference between queries and actual departure times, in seconds
+            initialLostTimeAtDepartureMinutes:
+              type: number
+              description: same as initialLostTimeAtDepartureSeconds, in minutes
+            arrivalTime:
+              type: string
+              description: Arrival time in HH:MM format
+            arrivalTimeSeconds:
+              type: number
+              description: same as arrivalTime, in seconds since midnight
+            totalTravelTimeMinutes:
+              type: number
+              description: Total travel time, from the optimized departure time to the arrival time, in minutes
+            totalTravelTimeSeconds:
+              type: number
+              description: same as totalTravelTimeMinutes, in seconds
+            totalDistanceMeters:
+              type: number
+              description: Total distance traveled, from departure to arrival
+            totalInVehicleTimeMinutes:
+              type: number
+              description: Total time spent in a transit vehicle, in minutes
+            totalInVehicleTimeSeconds:
+              type: number
+              description: same as totalInVehicleTimeMinutes, in seconds
+            totalInVehicleDistanceMeters:
+              type: number
+              description: Total distance traveled in a vehicle, in meters
+            totalNonTransitTravelTimeMinutes:
+              type: number
+              description: Total time spent traveling, but not in a transit vehicle. This excludes waiting time. In minutes
+            totalNonTransitTravelTimeSeconds:
+              type: number
+              description: same as totalNonTransitTravelTimeMinutes, in seconds
+            totalNonTransitDistanceMeters:
+              type: number
+              description: Total distance traveled not in a vehicle, in meters
+            numberOfBoardings:
+              type: number
+              description: Number of times a vehicle is boarded in the trip
+            numberOfTransfers:
+              type: number
+              description: Number of transfers in this trip
+            transferWalkingTimeMinutes:
+              type: number
+              description: Time spent walking to transfer from a transit route to another transit route, in minutes
+            transferWalkingTimeSeconds:
+              type: number
+              description: same as transferWalkingTimeMinutes, in seconds
+            transferWalkingDistanceMeters:
+              type: number
+              description: Distance traveled to transfer between transit trips, in meters
+            accessTravelTimeMinutes:
+              type: number
+              description: Time spent traveling to access the first transit stop of the trip, in minutes
+            accessTravelTimeSeconds:
+              type: number
+              description: same as accessTravelTimeMinutes, in seconds
+            accessDistanceMeters:
+              type: number
+              description: Distance traveled to access the first transit stop of the trip, in meters
+            egressTravelTimeMinutes:
+              type: number
+              description: Time spent traveling from the last transit stop of the trip, to the destination, in minutes
+            egressTravelTimeSeconds:
+              type: number
+              description: same as egressTravelTimeMinutes, in seconds
+            egressDistanceMeters:
+              type: number
+              description: Distance traveled from the last transit stop of the trip to the destination, in meters            
+            transferWaitingTimeMinutes:
+              type: number
+              description: Time spent waiting at a transit stop for a transfer (ie exluding the time spent waiting at the first stop), in minutes
+            transferWaitingTimeSeconds:
+              type: number
+              description: same as transferWaitingTimeMinutes, in seconds
+            firstWaitingTimeMinutes:
+              type: number
+              description: Time spent waiting at the first transit stop of the trip, in minutes
+            firstWaitingTimeSeconds:
+              type: number
+              description: same as firstWaitingTimeMinutes, in seconds
+            totalWaitingTimeMinutes:
+              type: number
+              description: Total time spent waiting for a transit vehicle, in minutes
+            totalWaitingTimeSeconds:
+              type: number
+              description: same as totalWaitingTimeMinutes, in seconds
+            steps:
+              type: array
+              items:
+                $ref: '#/components/schemas/tripStep'
+
+    alternativesResponse:
+      type: object
+      properties:
+        alternatives:
+          type: array
+          items: 
+            $ref: '#/components/schemas/routeResponse'
+
+    tripStepObject:
+      oneOf:
+      - $ref: '#/components/schemas/tripStepWalking'
+      - $ref: '#/components/schemas/tripStepBoarding'
+      - $ref: '#/components/schemas/tripStepUnboarding'
+      discriminator:
+        propertyName: action
+
+    tripStep:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum: [walking, boarding, unboarding]
+      discriminator:
+        propertyName: action
+        mapping:
+          walking: tripStepWalking
+          boarding: tripStepBoarding
+          unboarding: tripStepUnboarding
+
+    tripStepWalking:
+      oneOf:
+      - $ref: '#/components/schemas/tripStepWalkingBaseEgress'
+      - $ref: '#/components/schemas/tripStepWalkingWithBoarding'
+      discriminator:
+        propertyName: type
+        mapping:
+          access: tripStepWalkingWithBoarding
+          egress: tripStepWalkingBaseEgress
+          transfer: tripStepWalkingWithBoarding
+
+    tripStepWalkingBase:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [access, egress, transfer]
+      discriminator:
+        propertyName: type
+
+    tripStepWalkingBaseEgress: # 'walking' is a value for the action (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/tripStep'
+        - $ref: '#/components/schemas/tripStepWalkingBase'
+        - type: object
+          properties:
+            travelTimeSeconds:
+              type: number
+              description: Time spent walking in this step, in seconds
+            travelTimeMinutes:
+              type: number
+              description: same as travelTimeSeconds, in minutes
+            distanceMeters:
+              type: number
+              description: Distance traveled in this step, in meters
+            departureTime:
+              type: string
+              description: Time of the beginning of this step, in HH:MM format
+            arrivalTime:
+              type: string
+              description: Time of arrival to destination for this step, in HH:MM format
+            departureTimeSeconds:
+              type: number
+              description: same as departureTime, in seconds since midnight
+            arrivalTimeSeconds:
+              type: number
+              description: same as arrivalTime, in seconds since midnight
+
+    tripStepWalkingWithBoarding:
+      allOf:
+      - $ref: '#/components/schemas/tripStepWalkingBaseEgress'
+      - type: object
+        properties:
+          readyToBoardAt:
+            type: string
+            description: Time at which boarding is possible, this includes a waiting time buffer at the stop, so is usually arrival_time + minimum waiting time. Time format is HH:MM.
+
+    tripStepTripEnterOrExit:
+      allOf:
+      - $ref: '#/components/schemas/tripStep'
+      - type: object
+        properties:
+          agencyAcronym:
+            type: string
+            description: Acronym of the agency serving the route being boarded/unboarded
+          agencyName:
+            type: string
+            description: Name of the agency serving the route being boarded/unboarded
+          agencyUuid:
+            type: string
+            description: UUID of the agency serving the route being boarded/unboarded
+          lineShortname:
+            type: string
+            description: Shortname of the route being boarded/unboarded
+          lineLongname:
+            type: string
+            description: Long name of the route being boarded/unboarded
+          lineUuid:
+            type: string
+            description: UUID of the line being boarded/unboarded
+          pathUuid:
+            type: string
+            description: UUID of the path being boarded/unboarded
+          modeName:
+            type: string
+            description: Full name of the route's mode
+          mode:
+            type: string
+            description: Code name of the route's mode
+          tripUuid:
+            type: string
+            description: UUID of the route's trip involved in this action
+          legSequenceInTrip:
+            type: number 
+            description: Sequence number, in the complete trip, of the sequence starting at the stop to be boarded/unboarded. 1 would mean the first sequence.
+          stopSequenceInTrip:
+            type: number
+            description: Sequence number, in the complete trip, of the stop boarded/unboarded at. 1 would mean the first stop
+          nodeName:
+            type: string
+            description: Name of the node where the action takes place
+          nodeCode:
+            type: string
+            description: Code of the node where the action takes place
+          nodeUuid:
+            type: string
+            description: UUID of the node where the action takes place
+          nodeCoordinates:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+            description: latitude and longitude of the node where the action takes place, in the WSG84 coordinates system
+
+    tripStepBoarding: # 'boarding' is a value for the action (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/tripStepTripEnterOrExit'
+        - type: object
+          properties:
+            departureTime:
+              type: string
+              description: Departure time of the vehicle, in HH:MM format
+            departureTimeSeconds:
+              type: string
+              description: same as departureTime, in seconds
+            waitingTimeSeconds:
+              type: number
+              description: Time spent waiting for the vehicle at the stops. Includes the minimal wait period specified in the query parameters
+            waitingTimeMinutes:
+              type: number
+              description: Same as waitingTimeSeconds, in minutes
+
+    tripStepUnboarding: # 'unboarding' is a value for the action (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/tripStep'
+        - type: object
+          properties:
+            arrivalTime:
+              type: string
+              description: Arrival time of the vehicle, in HH:MM format
+            arrivalTimeSeconds:
+              type: string
+              description: same as arrivalTime, in seconds
+            inVehicleTimeSeconds:
+              type: number
+              description: Time spent in the vehicle, in seconds
+            inVehicleTimeMinutes:
+              type: number
+              description: Same as inVehicleTimeSeconds, in minutes
+            inVehicleDistanceMeters:
+              type: number
+              description: Distance covered in the vehicle, in meters
+
+


### PR DESCRIPTION
This commit starts a `docs/API.yml` API documentation file using the
OpenAPI 3.0.2 specification. It describe the routing parameters, for now
only those used by the transition query in typescript.

Other parameters are listed in comments in the file, it is to be
discussed whether they are all required or not.

Responses for error and no_routing_found are documented, but the details
of the success responses are not there yet.