### PR TITLE
csa: Refactor/split methods for more modularity and simplicity

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -68,7 +68,9 @@ extern std::string consoleResetColor;
 
 namespace TrRouting
 {
-  
+  // tuple representing a connection: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, lineIndex, blockIndex, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
+  using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>;
+
   class Calculator {
   
   public:
@@ -121,7 +123,7 @@ namespace TrRouting
     int                    updateNetworksFromCache   (Parameters&  params, std::string customPath = "");
     int                    updateSchedulesFromCache  (Parameters&  params, std::string customPath = "");
 
-    int                    setConnections(std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections);
+    int                    setConnections(std::vector<std::shared_ptr<ConnectionTuple>> connections);
     
     int               countStations();
     int               countAgencies();
@@ -238,8 +240,8 @@ namespace TrRouting
     std::vector<int> tripsUsable; // after forward calculation, keep a list of usable trips in time range for reverse calculation
     std::vector<std::tuple<int,int,int>> accessFootpaths; // pair: accessNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
     std::vector<std::tuple<int,int,int>> egressFootpaths; // pair: egressNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> forwardConnections; // tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, lineIndex, blockIndex, canTransferSameLine, minWaitingTimeSeconds
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> reverseConnections; // tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, lineIndex, blockIndex, canTransferSameLine, minWaitingTimeSeconds
+    std::vector<std::shared_ptr<ConnectionTuple>> forwardConnections; // Forward connections, sorted by departure time ascending
+    std::vector<std::shared_ptr<ConnectionTuple>> reverseConnections; // Reverse connections, sorted by arrival time descending
     std::vector<std::tuple<int,int,int,int,int,short,int>> forwardJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
     std::vector<std::tuple<int,int,int,int,int,short,int>> forwardEgressJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
     std::vector<std::tuple<int,int,int,int,int,short,int>> reverseJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -133,6 +133,9 @@ namespace TrRouting
     long long         countConnections();
     int               countNetworks();
 
+    // Public for testing, this function initializes the calculation vectors and should be called whenever nodes and schedules are updated
+    // TODO As part of issue https://github.com/chairemobilite/trRouting/issues/95, this will be removed
+    void initializeCalculationData();
 
 
     std::vector<Mode>                        modes;

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -120,6 +120,8 @@ namespace TrRouting
     int                    updateScenariosFromCache  (Parameters&  params, std::string customPath = "");
     int                    updateNetworksFromCache   (Parameters&  params, std::string customPath = "");
     int                    updateSchedulesFromCache  (Parameters&  params, std::string customPath = "");
+
+    int                    setConnections(std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections);
     
     int               countStations();
     int               countAgencies();
@@ -194,7 +196,7 @@ namespace TrRouting
     std::vector<std::vector<std::unique_ptr<int>>>   tripConnectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;        // tripIndex: [connectionIndex (sequence in trip): sum of od trips weights using this connection (demand)]
     //std::vector<std::unique_ptr<std::vector<std::unique_ptr<int>>>>   tripIndexesByPathIndex;
-  
+
     Parameters& params;
     CalculationTime algorithmCalculationTime;
     

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -39,8 +39,8 @@ namespace TrRouting
       std::deque<std::tuple<int,int,int,int,int,short,int>> journey;
       std::tuple<int,int,int,int,int,short,int>         resultingNodeJourneyStep;
       std::tuple<int,int,int,int,int,short,int>         emptyJourneyStep {-1,-1,-1,-1,-1,-1,-1};
-      std::tuple<int,int,int,int,int,short,short,int,int,int,short,short> * journeyStepEnterConnection; // connection tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequenceinTrip
-      std::tuple<int,int,int,int,int,short,short,int,int,int,short,short> * journeyStepExitConnection;
+      ConnectionTuple * journeyStepEnterConnection; // connection tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequenceinTrip
+      ConnectionTuple * journeyStepExitConnection;
       std::vector<boost::uuids::uuid>                   lineUuids;
       std::vector<int>                                  linesIdx;
       std::vector<std::string>                          modeShortnames;

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -15,7 +15,7 @@ namespace TrRouting
     int              reachableNodesCount  {0};
     bool             foundLine            {false};
     
-    int transferableModeIdx {modeIndexesByShortname["transferable"]};
+    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname["transferable"] : -1};
 
     std::vector<int> resultingNodes;
     if (params.returnAllNodesResult)

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -9,6 +9,103 @@ namespace TrRouting
     algorithmCalculationTime = CalculationTime();
 
   }
+
+  void Calculator::initializeCalculationData() {
+    nodesTentativeTime.clear();
+    nodesTentativeTime.shrink_to_fit();
+    nodesTentativeTime.resize(nodes.size());
+    nodesReverseTentativeTime.clear();
+    nodesReverseTentativeTime.shrink_to_fit();
+    nodesReverseTentativeTime.resize(nodes.size());
+    nodesAccessTravelTime.clear();
+    nodesAccessTravelTime.shrink_to_fit();
+    nodesAccessTravelTime.resize(nodes.size());
+    nodesAccessDistance.clear();
+    nodesAccessDistance.shrink_to_fit();
+    nodesAccessDistance.resize(nodes.size());
+    nodesEgressTravelTime.clear();
+    nodesEgressTravelTime.shrink_to_fit();
+    nodesEgressTravelTime.resize(nodes.size());
+    nodesEgressDistance.clear();
+    nodesEgressDistance.shrink_to_fit();
+    nodesEgressDistance.resize(nodes.size());
+    forwardJourneysSteps.clear();
+    forwardJourneysSteps.shrink_to_fit();
+    forwardJourneysSteps.resize(nodes.size());
+    forwardEgressJourneysSteps.clear();
+    forwardEgressJourneysSteps.shrink_to_fit();
+    forwardEgressJourneysSteps.resize(nodes.size());
+    reverseJourneysSteps.clear();
+    reverseJourneysSteps.shrink_to_fit();
+    reverseJourneysSteps.resize(nodes.size());
+    reverseAccessJourneysSteps.clear();
+    reverseAccessJourneysSteps.shrink_to_fit();
+    reverseAccessJourneysSteps.resize(nodes.size());
+
+    tripsEnabled.clear();
+    tripsEnabled.shrink_to_fit();
+    tripsEnabled.resize(trips.size());
+    tripsUsable.clear();
+    tripsUsable.shrink_to_fit();
+    tripsUsable.resize(trips.size());
+    tripsEnterConnection.clear();
+    tripsEnterConnection.shrink_to_fit();
+    tripsEnterConnection.resize(trips.size());
+    tripsExitConnection.clear();
+    tripsExitConnection.shrink_to_fit();
+    tripsExitConnection.resize(trips.size());
+    tripsEnterConnectionTransferTravelTime.clear();
+    tripsEnterConnectionTransferTravelTime.shrink_to_fit();
+    tripsEnterConnectionTransferTravelTime.resize(trips.size());
+    tripsExitConnectionTransferTravelTime.clear();
+    tripsExitConnectionTransferTravelTime.shrink_to_fit();
+    tripsExitConnectionTransferTravelTime.resize(trips.size());
+
+    std::cout << forwardConnections.size() << " connections" << std::endl; 
+
+    //int benchmarkingStart = algorithmCalculationTime.getEpoch();
+
+    int lastConnectionIndex = forwardConnections.size() - 1;
+
+    forwardConnectionsIndexPerDepartureTimeHour = std::vector<int>(32, -1);
+    reverseConnectionsIndexPerArrivalTimeHour   = std::vector<int>(32, lastConnectionIndex);
+    
+    int hour {0};
+    int i = 0;
+    for (auto & connection : forwardConnections)
+    {
+      while (std::get<connectionIndexes::TIME_DEP>(*connection) >= hour * 3600 && forwardConnectionsIndexPerDepartureTimeHour[hour] == -1 && hour < 32)
+      {
+        forwardConnectionsIndexPerDepartureTimeHour[hour] = i;
+        //std::cout << hour << ":" << i << ":" << std::get<connectionIndexes::TIME_DEP>(connection) << std::endl;
+        hour++;
+      }
+      i++;
+    }
+
+    hour = 31;
+    i = 0;
+    for (auto & connection : reverseConnections)
+    {
+      while (std::get<connectionIndexes::TIME_ARR>(*connection) <= hour * 3600 && reverseConnectionsIndexPerArrivalTimeHour[hour] == lastConnectionIndex && hour >= 0)
+      {
+        reverseConnectionsIndexPerArrivalTimeHour[hour] = i;
+        //std::cout << hour << ":" << i << ":" << std::get<connectionIndexes::TIME_ARR>(connection) << std::endl;
+        hour--;
+      }
+      i++;
+    }
+
+    for (int h = 0; h < 32; h++)
+    {
+      if (forwardConnectionsIndexPerDepartureTimeHour[h] == -1)
+      {
+        forwardConnectionsIndexPerDepartureTimeHour[h] = lastConnectionIndex;
+      }
+      //std::cout << h << ": " << forwardConnectionsIndexPerDepartureTimeHour[h] << std::endl;
+    }
+
+  }
   
 
 }

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -107,10 +107,9 @@ namespace TrRouting
 
   }
 
-  int Calculator::setConnections(std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections)
+  int Calculator::setConnections(std::vector<std::shared_ptr<ConnectionTuple>> connections)
   {
-    using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>;
-
+  
     // Copy the connections to both forward and reverse vectors
     forwardConnections.clear();
     reverseConnections.clear();

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -75,7 +75,7 @@ namespace TrRouting
 
   int Calculator::updateSchedulesFromCache(Parameters& params, std::string customPath)
   {
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections;
+    std::vector<std::shared_ptr<ConnectionTuple>> connections;
     int ret =  params.cacheFetcher->getSchedules(
       trips,
       lines,

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -13,47 +13,9 @@ namespace TrRouting
     params.cacheFetcher->getStops(stops, stopIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }*/
 
-
   int Calculator::updateNodesFromCache(Parameters& params, std::string customPath)
   {
-    int ret = params.cacheFetcher->getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, customPath);
-    if (ret < 0)
-    {
-      return ret;
-    }
-
-    nodesTentativeTime.clear();
-    nodesTentativeTime.shrink_to_fit();
-    nodesTentativeTime.resize(nodes.size());
-    nodesReverseTentativeTime.clear();
-    nodesReverseTentativeTime.shrink_to_fit();
-    nodesReverseTentativeTime.resize(nodes.size());
-    nodesAccessTravelTime.clear();
-    nodesAccessTravelTime.shrink_to_fit();
-    nodesAccessTravelTime.resize(nodes.size());
-    nodesAccessDistance.clear();
-    nodesAccessDistance.shrink_to_fit();
-    nodesAccessDistance.resize(nodes.size());
-    nodesEgressTravelTime.clear();
-    nodesEgressTravelTime.shrink_to_fit();
-    nodesEgressTravelTime.resize(nodes.size());
-    nodesEgressDistance.clear();
-    nodesEgressDistance.shrink_to_fit();
-    nodesEgressDistance.resize(nodes.size());
-    forwardJourneysSteps.clear();
-    forwardJourneysSteps.shrink_to_fit();
-    forwardJourneysSteps.resize(nodes.size());
-    forwardEgressJourneysSteps.clear();
-    forwardEgressJourneysSteps.shrink_to_fit();
-    forwardEgressJourneysSteps.resize(nodes.size());
-    reverseJourneysSteps.clear();
-    reverseJourneysSteps.shrink_to_fit();
-    reverseJourneysSteps.resize(nodes.size());
-    reverseAccessJourneysSteps.clear();
-    reverseAccessJourneysSteps.shrink_to_fit();
-    reverseAccessJourneysSteps.resize(nodes.size());
-
-    return ret;
+    return params.cacheFetcher->getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, customPath);
   }
 
   int Calculator::updateDataSourcesFromCache(Parameters& params, std::string customPath)
@@ -113,7 +75,7 @@ namespace TrRouting
 
   int Calculator::updateSchedulesFromCache(Parameters& params, std::string customPath)
   {
-    int ret = params.cacheFetcher->getSchedules(
+    return params.cacheFetcher->getSchedules(
       trips,
       lines,
       paths,
@@ -131,88 +93,7 @@ namespace TrRouting
       params,
       customPath
     );
-    if (ret < 0)
-    {
-      return ret;
-    }
 
-    tripsEnabled.clear();
-    tripsEnabled.shrink_to_fit();
-    tripsEnabled.resize(trips.size());
-    tripsUsable.clear();
-    tripsUsable.shrink_to_fit();
-    tripsUsable.resize(trips.size());
-    tripsEnterConnection.clear();
-    tripsEnterConnection.shrink_to_fit();
-    tripsEnterConnection.resize(trips.size());
-    tripsExitConnection.clear();
-    tripsExitConnection.shrink_to_fit();
-    tripsExitConnection.resize(trips.size());
-    tripsEnterConnectionTransferTravelTime.clear();
-    tripsEnterConnectionTransferTravelTime.shrink_to_fit();
-    tripsEnterConnectionTransferTravelTime.resize(trips.size());
-    tripsExitConnectionTransferTravelTime.clear();
-    tripsExitConnectionTransferTravelTime.shrink_to_fit();
-    tripsExitConnectionTransferTravelTime.resize(trips.size());
-
-    std::cout << forwardConnections.size() << " connections" << std::endl; 
-
-    //int benchmarkingStart = algorithmCalculationTime.getEpoch();
-
-    int lastConnectionIndex = forwardConnections.size() - 1;
-
-    forwardConnectionsIndexPerDepartureTimeHour = std::vector<int>(32, -1);
-    reverseConnectionsIndexPerArrivalTimeHour   = std::vector<int>(32, lastConnectionIndex);
-    
-    int hour {0};
-    int i = 0;
-    for (auto & connection : forwardConnections)
-    {
-      while (std::get<connectionIndexes::TIME_DEP>(*connection) >= hour * 3600 && forwardConnectionsIndexPerDepartureTimeHour[hour] == -1 && hour < 32)
-      {
-        forwardConnectionsIndexPerDepartureTimeHour[hour] = i;
-        //std::cout << hour << ":" << i << ":" << std::get<connectionIndexes::TIME_DEP>(connection) << std::endl;
-        hour++;
-      }
-      i++;
-    }
-
-    hour = 31;
-    i = 0;
-    for (auto & connection : reverseConnections)
-    {
-      while (std::get<connectionIndexes::TIME_ARR>(*connection) <= hour * 3600 && reverseConnectionsIndexPerArrivalTimeHour[hour] == lastConnectionIndex && hour >= 0)
-      {
-        reverseConnectionsIndexPerArrivalTimeHour[hour] = i;
-        //std::cout << hour << ":" << i << ":" << std::get<connectionIndexes::TIME_ARR>(connection) << std::endl;
-        hour--;
-      }
-      i++;
-    }
-
-    for (int h = 0; h < 32; h++)
-    {
-      if (forwardConnectionsIndexPerDepartureTimeHour[h] == -1)
-      {
-        forwardConnectionsIndexPerDepartureTimeHour[h] = lastConnectionIndex;
-      }
-      //std::cout << h << ": " << forwardConnectionsIndexPerDepartureTimeHour[h] << std::endl;
-    }
-    /*for (int h = 0; h < 32; h++)
-    {
-      std::cout << h << ": " << reverseConnectionsIndexPerArrivalTimeHour[h] << std::endl;
-    }*/
-
-    /*for (auto & node : nodes)
-    {
-      std::cout << node.toString() << std::endl;
-      for (int transferableNodeIdx : node.transferableNodesIdx)
-      {
-        std::cout << "    " << transferableNodeIdx << " (" << nodes[transferableNodeIdx].get()->uuid << ")" << std::endl;
-      }
-      std::cout << std::endl;
-    }*/
-    return ret;
   }
 
   int Calculator::prepare()
@@ -314,6 +195,7 @@ namespace TrRouting
       // not yet implemented
     }
     
+    initializeCalculationData();
     std::cout << "preparing nodes tentative times, trips enter connections and journeys..." << std::endl;
     return ret;
   }

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -75,7 +75,8 @@ namespace TrRouting
 
   int Calculator::updateSchedulesFromCache(Parameters& params, std::string customPath)
   {
-    return params.cacheFetcher->getSchedules(
+    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections;
+    int ret =  params.cacheFetcher->getSchedules(
       trips,
       lines,
       paths,
@@ -88,12 +89,15 @@ namespace TrRouting
       modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
-      forwardConnections,
-      reverseConnections,
+      connections,
       params,
       customPath
     );
-
+    if (ret < 0)
+    {
+      return ret;
+    }
+    return setConnections(connections);
   }
 
   int Calculator::prepare()

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -39,8 +39,8 @@ namespace TrRouting
       std::deque<std::tuple<int,int,int,int,int,short,int>> journey;
       std::tuple<int,int,int,int,int,short,int>         resultingNodeJourneyStep;
       std::tuple<int,int,int,int,int,short,int>         emptyJourneyStep {-1,-1,-1,-1,-1,-1,-1};
-      std::tuple<int,int,int,int,int,short,short,int,int,int,short,short> * journeyStepEnterConnection; // connection tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequenceinTrip
-      std::tuple<int,int,int,int,int,short,short,int,int,int,short,short> * journeyStepExitConnection;
+      ConnectionTuple * journeyStepEnterConnection; // connection tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequenceinTrip
+      ConnectionTuple * journeyStepExitConnection;
       std::vector<boost::uuids::uuid>                   lineUuids;
       std::vector<int>                                  linesIdx;
       std::vector<std::string>                          modeShortnames;

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -15,7 +15,7 @@ namespace TrRouting
     int              reachableNodesCount  {0};
     bool             foundRoute           {false};
 
-    int transferableModeIdx {modeIndexesByShortname["transferable"]};
+    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname["transferable"] : -1};
 
     std::vector<int> resultingNodes;
     if (params.returnAllNodesResult)

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -344,8 +344,7 @@ namespace TrRouting
       std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& forwardConnections, 
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& reverseConnections,
+      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
       Parameters& params,
       std::string customPath = ""
     );

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -36,7 +36,7 @@ namespace TrRouting
     std::string customPath
   )
   {
-
+    // FIXME ConnectionTuple is defined in calculator.hpp. Should it be elsewhere? Cache fetcher should work for any algorithm, is this tuple csa-specific or should it go somewhere common.
     using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>;
 
     trips.clear();

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -52,7 +52,7 @@ namespace TrRouting
     reverseConnections.clear();
     reverseConnections.shrink_to_fit();
 
-    int transferableModeIdx {modeIndexesByShortname["transferable"]};
+    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname["transferable"] : -1};
 
     //std::vector<Block> blocks;
     //std::map<boost::uuids::uuid, int> blockIndexesByUuid;

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -30,8 +30,7 @@ protected:
     std::map<std::string, int> modeIndexesByShortname;
     std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> forwardConnections;
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> reverseConnections;
+    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections;
 
 public:
     void SetUp( ) override
@@ -71,8 +70,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
-      forwardConnections,
-      reverseConnections,
+      connections,
       params,
       INVALID_CUSTOM_PATH
     );
@@ -96,8 +94,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
-      forwardConnections,
-      reverseConnections,
+      connections,
       params,
       INVALID_CUSTOM_PATH
     );
@@ -120,8 +117,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
-      forwardConnections,
-      reverseConnections,
+      connections,
       params,
       VALID_CUSTOM_PATH
     );


### PR DESCRIPTION
Preparation work for #94.

These changes extract code that was previously executed in the cache_fetcher or along with cache_fetching, in some cases exposing private fields of the calculator and operating on them without its owning object knowing about it.

The new methods can thus be called independently form different locations. This makes unit tests not only easier, but even possible!