### PR TITLE
osrm_fetcher: Pass the max travel time and walking speed as parameter

### DIFF
--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -110,7 +110,7 @@ namespace TrRouting
             std::cout << "  fetching nodes with osrm with mode " << params.accessMode << std::endl;
 
           if (params.hasOrigin)
-            accessFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(params.origin, nodes, params.accessMode, params));
+            accessFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(params.origin, nodes, params.accessMode, params, params.maxAccessWalkingTravelTimeSeconds, params.walkingSpeedMetersPerSecond));
         }
       }
 
@@ -178,7 +178,7 @@ namespace TrRouting
         else
         {
           if (params.hasDestination)
-            egressFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(params.destination, nodes, params.accessMode, params));
+            egressFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(params.destination, nodes, params.accessMode, params, params.maxEgressWalkingTravelTimeSeconds, params.walkingSpeedMetersPerSecond));
         }
       }
       

--- a/include/osrm_fetcher.hpp
+++ b/include/osrm_fetcher.hpp
@@ -31,14 +31,14 @@ namespace TrRouting
     {
     }
 
-    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, bool reversed = false);
+    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
 
   protected:
-    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, Parameters &params);
-    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, bool reversed);
+    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
+    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
 
     static std::tuple<float, float> calculateLengthOfOneDegree(const Point &point);
-    static float calculateMaxDistanceSquared(Parameters &params);
+    static float calculateMaxDistanceSquared(int maxWalkingTravelTime, float walkingSpeed);
     static float calculateNodeDistanceSquared(const Point *node, const Point &point, const std::tuple<float, float> &lengthOfOneDegree);
   };
 

--- a/tests/connection_scan_algorithm/csa_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_simple_calculation_test.cpp
@@ -175,8 +175,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
 // Same as SimpleODCalculation, but with max_egress_travel_time_seconds lower than egress time
 TEST_F(RouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
 {
-    // This test does not work, see issue https://github.com/chairemobilite/trRouting/issues/97
-    /* int departureTime = getTimeInSeconds(9, 45);
+    int departureTime = getTimeInSeconds(9, 45);
     // This is where mocking would be interesting. Those were taken from the first run of the test
     int egressTime = 138;
 
@@ -187,7 +186,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
     parametersWithValues.push_back("max_egress_travel_time_seconds=" + std::to_string(egressTime - 5));
 
     TrRouting::RoutingResult result = calculateOd(parametersWithValues);
-    assertNoRouting(result); */
+    assertNoRouting(result);
 }
 
 // Same as SimpleODCalculation, but with max_first_waiting_time_seconds lower than should be


### PR DESCRIPTION
Fixes #97

The Parameters object is the server parameters' main object, that
contains the connection information. The speed and max travel time will
soon be extracted out of this class. Also, depending on the calling
context, the max travel time may not be the access time, but the egress
or any other time. This makes these methods more flexible.

Unit test for max egress time is brought back as it now works.