### PR TITLE
Add a configure flag to enable benchmarks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,17 @@ LDFLAGS+=" $BOOST_LDFLAGS $BOOST_REGEX_LIB $BOOST_FILESYSTEM_LIB $BOOST_IOSTREAM
 LDFLAGS+=" $CURSES_LIBS"
 LDFLAGS+=" $CAPNP_LIBS"
 
+# Do not enable benchmark in the make check by default
+AC_ARG_ENABLE([benchmark],
+    [  --enable-benchmark      Benchmarks will be run when running make check],
+    [case "${enableval}" in
+        yes) benchmark=true ;;
+        no)  benchmark=false ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-benchmark]) ;;
+    esac],[benchmark=false])
+AS_IF([test x"$benchmark" = xfalse], [AC_MSG_NOTICE([Benchmarks are disabled. Enable them by adding the --enable-benchmark flag to configure.])])
+AM_CONDITIONAL([RUN_BENCHMARK], [test x$benchmark = xtrue])
+
 AC_CONFIG_FILES([
  Makefile
  src/Makefile

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,8 +3,13 @@ libgtest_la_SOURCES = ../googletest/googletest/src/gtest-all.cc
 libgtest_la_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest
 libgtest_la_LDFLAGS = -pthread
 
+if RUN_BENCHMARK
+MAYBE_BENCHMARK = benchmark_csa
+else
+MAYBE_BENCHMARK =
+endif
+
 SUBDIRS = . \
           cache_fetch \
-          benchmark_csa \
-          connection_scan_algorithm
+          connection_scan_algorithm $(MAYBE_BENCHMARK)
 


### PR DESCRIPTION
The --enable-benchmark flag when running ./configure will enable the
benchmark compilation and execution when running `make check`. By
default, the benchmarks are disabled.

Fixes #92. It's not a different target, but at least the benchmarks
won't run when running unit tests by default.