### PR TITLE
Rename the Parameters class to ServerParameters

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -100,7 +100,7 @@ namespace TrRouting
     std::map<std::string, int> benchmarking;
     std::string projectShortname;
     
-    Calculator(Parameters& theParams);
+    Calculator(ServerParameters& theParams);
 
     /**
      * Prepare the data for the calculator and validate that there are at least
@@ -130,22 +130,22 @@ namespace TrRouting
      * -EINVAL For any other data related error
      * -(error codes from the open system call)
      */
-    int                    updateDataSourcesFromCache(Parameters&  params, std::string customPath = "");
-    int                    updateHouseholdsFromCache (Parameters&  params, std::string customPath = "");
-    int                    updatePersonsFromCache    (Parameters&  params, std::string customPath = "");
-    int                    updateOdTripsFromCache    (Parameters&  params, std::string customPath = "");
-    int                    updatePlacesFromCache     (Parameters&  params, std::string customPath = "");
+    int                    updateDataSourcesFromCache(ServerParameters&  params, std::string customPath = "");
+    int                    updateHouseholdsFromCache (ServerParameters&  params, std::string customPath = "");
+    int                    updatePersonsFromCache    (ServerParameters&  params, std::string customPath = "");
+    int                    updateOdTripsFromCache    (ServerParameters&  params, std::string customPath = "");
+    int                    updatePlacesFromCache     (ServerParameters&  params, std::string customPath = "");
 
-    int                    updateStationsFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateAgenciesFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateServicesFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateNodesFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updateStopsFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updateLinesFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updatePathsFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updateScenariosFromCache  (Parameters&  params, std::string customPath = "");
-    int                    updateNetworksFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateSchedulesFromCache  (Parameters&  params, std::string customPath = "");
+    int                    updateStationsFromCache   (ServerParameters&  params, std::string customPath = "");
+    int                    updateAgenciesFromCache   (ServerParameters&  params, std::string customPath = "");
+    int                    updateServicesFromCache   (ServerParameters&  params, std::string customPath = "");
+    int                    updateNodesFromCache      (ServerParameters&  params, std::string customPath = "");
+    int                    updateStopsFromCache      (ServerParameters&  params, std::string customPath = "");
+    int                    updateLinesFromCache      (ServerParameters&  params, std::string customPath = "");
+    int                    updatePathsFromCache      (ServerParameters&  params, std::string customPath = "");
+    int                    updateScenariosFromCache  (ServerParameters&  params, std::string customPath = "");
+    int                    updateNetworksFromCache   (ServerParameters&  params, std::string customPath = "");
+    int                    updateSchedulesFromCache  (ServerParameters&  params, std::string customPath = "");
 
     int                    setConnections(std::vector<std::shared_ptr<ConnectionTuple>> connections);
     
@@ -222,8 +222,8 @@ namespace TrRouting
     std::vector<std::vector<std::unique_ptr<int>>>   tripConnectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;        // tripIndex: [connectionIndex (sequence in trip): sum of od trips weights using this connection (demand)]
     //std::vector<std::unique_ptr<std::vector<std::unique_ptr<int>>>>   tripIndexesByPathIndex;
-
-    Parameters& params;
+  
+    ServerParameters& params;
     CalculationTime algorithmCalculationTime;
     
     Point  * origin;

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -3,7 +3,7 @@
 namespace TrRouting
 {
 
-  Calculator::Calculator(Parameters& theParams) :
+  Calculator::Calculator(ServerParameters& theParams) :
     projectShortname(""),
     params(theParams),
     odTrip(nullptr),

--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -3,7 +3,7 @@
 namespace TrRouting
 {
   
-  bool Parameters::isCompleteForCalculation()
+  bool ServerParameters::isCompleteForCalculation()
   {
     if (debugDisplay)
     {
@@ -48,7 +48,7 @@ namespace TrRouting
     return false;
   }
 
-  void Parameters::setDefaultValues()
+  void ServerParameters::setDefaultValues()
   {
     odTripsPeriods.clear();
     odTripsGenders.clear();
@@ -131,7 +131,7 @@ namespace TrRouting
     
   }
 
-  void Parameters::update(std::vector<std::string> &parameters, std::map<boost::uuids::uuid, int> &scenarioIndexesByUuid, std::vector<std::unique_ptr<Scenario>> &scenarios, std::map<boost::uuids::uuid, int> &nodeIndexesByUuid, std::map<boost::uuids::uuid, int> &agencyIndexesByUuid, std::map<boost::uuids::uuid, int> &lineIndexesByUuid, std::map<boost::uuids::uuid, int> &serviceIndexesByUuid, std::map<std::string, int> &modeIndexesByShortname, std::map<boost::uuids::uuid, int> &dataSourceIndexesByUuid)
+  void ServerParameters::update(std::vector<std::string> &parameters, std::map<boost::uuids::uuid, int> &scenarioIndexesByUuid, std::vector<std::unique_ptr<Scenario>> &scenarios, std::map<boost::uuids::uuid, int> &nodeIndexesByUuid, std::map<boost::uuids::uuid, int> &agencyIndexesByUuid, std::map<boost::uuids::uuid, int> &lineIndexesByUuid, std::map<boost::uuids::uuid, int> &serviceIndexesByUuid, std::map<std::string, int> &modeIndexesByShortname, std::map<boost::uuids::uuid, int> &dataSourceIndexesByUuid)
   {
     
     setDefaultValues();

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -3,77 +3,77 @@
 namespace TrRouting
 {
 
-  /*void Calculator::updateStationsFromCache(Parameters& params, std::string customPath)
+  /*void Calculator::updateStationsFromCache(ServerParameters& params, std::string customPath)
   {
     params.cacheFetcher->getStations(stations, stationIndexesByUuid, params, customPath);
   }*/
 
-  /*void Calculator::updateStopsFromCache(Parameters& params, std::string customPath)
+  /*void Calculator::updateStopsFromCache(ServerParameters& params, std::string customPath)
   {
     params.cacheFetcher->getStops(stops, stopIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }*/
 
-  int Calculator::updateNodesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateNodesFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateDataSourcesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateDataSourcesFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getDataSources(dataSources, dataSourceIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateHouseholdsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateHouseholdsFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getHouseholds(households, householdIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updatePersonsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updatePersonsFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getPersons(persons, personIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }
   
-  int Calculator::updateOdTripsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateOdTripsFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getOdTrips(odTrips, odTripIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updatePlacesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updatePlacesFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getPlaces(places, placeIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateAgenciesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateAgenciesFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getAgencies(agencies, agencyIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateServicesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateServicesFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getServices(services, serviceIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateLinesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateLinesFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, params, customPath);
   }
 
-  int Calculator::updatePathsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updatePathsFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateScenariosFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateScenariosFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, params, customPath);
   }
 
-  int Calculator::updateNetworksFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateNetworksFromCache(ServerParameters& params, std::string customPath)
   {
     return params.cacheFetcher->getNetworks(networks, networkIndexesByUuid, agencyIndexesByUuid, serviceIndexesByUuid, scenarioIndexesByUuid, params, customPath);
   }
 
-  int Calculator::updateSchedulesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateSchedulesFromCache(ServerParameters& params, std::string customPath)
   {
     std::vector<std::shared_ptr<ConnectionTuple>> connections;
     int ret =  params.cacheFetcher->getSchedules(

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
   // Set params:
   ProgramOptions programOptions;
   programOptions.parseOptions(argc, argv);
-  Parameters algorithmParams;
+  ServerParameters algorithmParams;
   
   // setup program options:
   

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -86,7 +86,7 @@ namespace TrRouting
      * 
      * Returns the complete file path in the cache
      */
-    static std::string getFilePath  (         std::string cacheFilePath, Parameters& params, std::string customPath = "");
+    static std::string getFilePath  (         std::string cacheFilePath, ServerParameters& params, std::string customPath = "");
     
     const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes();
     
@@ -102,7 +102,7 @@ namespace TrRouting
     int getDataSources(
       std::vector<std::unique_ptr<DataSource>>& ts, 
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -120,7 +120,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -139,7 +139,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
       std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -159,7 +159,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& personIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -177,7 +177,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -193,7 +193,7 @@ namespace TrRouting
     int getAgencies(
       std::vector<std::unique_ptr<Agency>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -209,7 +209,7 @@ namespace TrRouting
     int getServices(
       std::vector<std::unique_ptr<Service>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -225,7 +225,7 @@ namespace TrRouting
     int getStations(
       std::vector<std::unique_ptr<Station>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -242,7 +242,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Node>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& stationIndexesById,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -260,7 +260,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       std::map<std::string, int>& modeIndexesByShortname,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -278,7 +278,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -299,7 +299,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::map<std::string, int>& modeIndexesByShortname,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -318,7 +318,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       std::map<boost::uuids::uuid, int>& scenarioIndexesByUuid,
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
 
@@ -345,7 +345,7 @@ namespace TrRouting
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
-      Parameters& params,
+      ServerParameters& params,
       std::string customPath = ""
     );
         

--- a/include/csv_fetcher.hpp
+++ b/include/csv_fetcher.hpp
@@ -47,8 +47,8 @@ namespace TrRouting
     //const std::pair<std::vector<Trip> , std::map<unsigned long long, int>> getTrips( std::string projectShortname);
     //const std::pair<std::vector<std::tuple<int,int,int,int,int,short,short,int>>, std::vector<std::tuple<int,int,int,int,int,short,short,int>>> getConnections(std::string projectShortname, std::map<unsigned long long, int> stopIndexesById, std::map<unsigned long long, int> tripIndexesById);
     //const std::pair<std::vector<std::tuple<int,int,int>>, std::vector<std::pair<long long,long long>>> getFootpaths(std::string projectShortname, std::map<unsigned long long, int> stopIndexesById);
-    //const std::vector<std::pair<int,int>> getOdTripFootpaths(std::string projectShortname, Parameters& params);
-    //const std::pair<std::vector<OdTrip>, std::map<unsigned long long, int>> getOdTrips(std::string projectShortname, std::vector<Stop> stops, Parameters& params);
+    //const std::vector<std::pair<int,int>> getOdTripFootpaths(std::string projectShortname, ServerParameters& params);
+    //const std::pair<std::vector<OdTrip>, std::map<unsigned long long, int>> getOdTrips(std::string projectShortname, std::vector<Stop> stops, ServerParameters& params);
 
     
   };

--- a/include/gtfs_fetcher.hpp
+++ b/include/gtfs_fetcher.hpp
@@ -48,8 +48,8 @@ namespace TrRouting
     //const std::pair<std::vector<Trip> , std::map<unsigned long long, int>> getTrips( std::string projectShortname);
     //const std::pair<std::vector<std::tuple<int,int,int,int,int,short,short,int>>, std::vector<std::tuple<int,int,int,int,int,short,short,int>>> getConnections(std::string projectShortname, std::map<unsigned long long, int> stopIndexesById, std::map<unsigned long long, int> tripIndexesById);
     //const std::pair<std::vector<std::tuple<int,int,int>>, std::vector<std::pair<long long,long long>>> getFootpaths(std::string projectShortname, std::map<unsigned long long, int> stopIndexesById);
-    //const std::vector<std::pair<int,int>> getOdTripFootpaths(std::string projectShortname, Parameters& params);
-    //const std::pair<std::vector<OdTrip>, std::map<unsigned long long, int>> getOdTrips(std::string projectShortname, std::vector<Stop> stops, Parameters& params);
+    //const std::vector<std::pair<int,int>> getOdTripFootpaths(std::string projectShortname, ServerParameters& params);
+    //const std::pair<std::vector<OdTrip>, std::map<unsigned long long, int>> getOdTrips(std::string projectShortname, std::vector<Stop> stops, ServerParameters& params);
 
     
   };

--- a/include/osrm_fetcher.hpp
+++ b/include/osrm_fetcher.hpp
@@ -31,11 +31,11 @@ namespace TrRouting
     {
     }
 
-    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
+    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, ServerParameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
 
   protected:
-    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
-    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
+    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, ServerParameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
+    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, ServerParameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
 
     static std::tuple<float, float> calculateLengthOfOneDegree(const Point &point);
     static float calculateMaxDistanceSquared(int maxWalkingTravelTime, float walkingSpeed);

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -30,7 +30,7 @@ namespace TrRouting
   class GtfsFetcher;
   class CsvFetcher;
 
-  class Parameters {
+  class ServerParameters {
 
     public:
 

--- a/src/agencies_cache_fetcher.cpp
+++ b/src/agencies_cache_fetcher.cpp
@@ -17,7 +17,7 @@ namespace TrRouting
   int CacheFetcher::getAgencies(
     std::vector<std::unique_ptr<Agency>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/cache_fetcher.cpp
+++ b/src/cache_fetcher.cpp
@@ -37,7 +37,7 @@ namespace TrRouting
     return count;
   }
   
-  std::string CacheFetcher::getFilePath(std::string cacheFilePath, Parameters& params, std::string customPath) {
+  std::string CacheFetcher::getFilePath(std::string cacheFilePath, ServerParameters& params, std::string customPath) {
     std::string filePath = "";
     if (!params.cacheDirectoryPath.empty()) {
       filePath += params.cacheDirectoryPath + "/";

--- a/src/data_sources_cache_fetcher.cpp
+++ b/src/data_sources_cache_fetcher.cpp
@@ -18,7 +18,7 @@ namespace TrRouting
   int CacheFetcher::getDataSources(
     std::vector<std::unique_ptr<DataSource>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/households_cache_fetcher.cpp
+++ b/src/households_cache_fetcher.cpp
@@ -22,7 +22,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -20,7 +20,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     std::map<std::string, int>& modeIndexesByShortname,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/networks_cache_fetcher.cpp
+++ b/src/networks_cache_fetcher.cpp
@@ -20,7 +20,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& scenarioIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/nodes_cache_fetcher.cpp
+++ b/src/nodes_cache_fetcher.cpp
@@ -23,7 +23,7 @@ namespace TrRouting
     std::vector<std::unique_ptr<Node>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& stationIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/od_trips_cache_fetcher.cpp
+++ b/src/od_trips_cache_fetcher.cpp
@@ -22,7 +22,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
     std::map<boost::uuids::uuid, int>& personIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/osrm_fetcher.cpp
+++ b/src/osrm_fetcher.cpp
@@ -3,7 +3,7 @@
 
 namespace TrRouting
 {
-  std::vector<std::tuple<int, int, int>> OsrmFetcher::getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed)
+  std::vector<std::tuple<int, int, int>> OsrmFetcher::getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, ServerParameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed)
   {
     if (params.birdDistanceAccessibilityEnabled)
     {
@@ -15,7 +15,7 @@ namespace TrRouting
     }
   }
 
-  std::vector<std::tuple<int, int, int>> OsrmFetcher::getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond)
+  std::vector<std::tuple<int, int, int>> OsrmFetcher::getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, ServerParameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond)
   {
     std::vector<std::tuple<int, int, int>> accessibleNodesFootpaths;
 
@@ -46,7 +46,7 @@ namespace TrRouting
     return accessibleNodesFootpaths;
   }
 
-  std::vector<std::tuple<int, int, int>> OsrmFetcher::getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed)
+  std::vector<std::tuple<int, int, int>> OsrmFetcher::getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, ServerParameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed)
   {
     std::vector<int> birdDistanceAccessibleNodeIndexes;
     std::vector<std::tuple<int, int, int>> accessibleNodesFootpaths;

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -21,7 +21,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/persons_cache_fetcher.cpp
+++ b/src/persons_cache_fetcher.cpp
@@ -21,7 +21,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   { 

--- a/src/places_cache_fetcher.cpp
+++ b/src/places_cache_fetcher.cpp
@@ -20,7 +20,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -23,7 +23,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::map<std::string, int>& modeIndexesByShortname,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   ) {
 

--- a/src/services_cache_fetcher.cpp
+++ b/src/services_cache_fetcher.cpp
@@ -18,7 +18,7 @@ namespace TrRouting
   int CacheFetcher::getServices(
     std::vector<std::unique_ptr<Service>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/src/stations_cache_fetcher.cpp
+++ b/src/stations_cache_fetcher.cpp
@@ -19,7 +19,7 @@ namespace TrRouting
   int CacheFetcher::getStations(
     std::vector<std::unique_ptr<Station>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   ) 
   {

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -32,7 +32,7 @@ namespace TrRouting
     std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
     std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
     std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
-    Parameters& params,
+    ServerParameters& params,
     std::string customPath
   )
   {

--- a/tests/benchmark_csa/benchmark_CSA_test.cpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.cpp
@@ -37,9 +37,9 @@ class BenchmarkCSATests : public ConstantBenchmarkCSATests
 protected:
   int numberOfRequests = 0;
 
-  Parameters setupAlgorithmParams()
+  ServerParameters setupAlgorithmParams()
   {
-    Parameters algorithmParams;
+    ServerParameters algorithmParams;
 
     algorithmParams.projectShortname = "demo_transition";
     algorithmParams.cacheDirectoryPath = "cache";
@@ -165,7 +165,7 @@ protected:
 TEST_F(BenchmarkCSATests, TestGetFilePath)
 {
 
-  Parameters algorithmParams = setupAlgorithmParams();
+  ServerParameters algorithmParams = setupAlgorithmParams();
 
   Calculator calculator(algorithmParams);
 

--- a/tests/benchmark_csa/benchmark_CSA_test.hpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.hpp
@@ -10,7 +10,7 @@ using namespace TrRouting;
 class ConstantBenchmarkCSATests : public ::testing::Test
 {
 protected:
-    TrRouting::Parameters setupAlgorithmParams();
+    TrRouting::ServerParameters setupAlgorithmParams();
     bool updateCalculatorFromCache(TrRouting::Calculator *calculator);
     int assertCacheOk(TrRouting::Calculator *calculator);
     

--- a/tests/cache_fetch/cache_fetcher_test.hpp
+++ b/tests/cache_fetch/cache_fetcher_test.hpp
@@ -8,7 +8,7 @@
 class ConstantCacheFetcherFixtureTests : public ::testing::Test 
 {
 protected:
-    TrRouting::Parameters params;
+    TrRouting::ServerParameters params;
     std::string cacheFile = "cacheFile.capnpbin";
     const std::string INVALID_CUSTOM_PATH = "invalidCacheFiles";
     const std::string VALID_CUSTOM_PATH = "validCacheFiles";

--- a/tests/connection_scan_algorithm/csa_test_base.hpp
+++ b/tests/connection_scan_algorithm/csa_test_base.hpp
@@ -47,7 +47,7 @@ protected:
 
     // Parameter object is required to build the calculator.
     // TODO As code evolves, it won't be necessary anymore
-    TrRouting::Parameters params;
+    TrRouting::ServerParameters params;
     // Calculator is the entry point to run the algorithm, it is part of the test object since (for now) there is nothing specific for its initialization.
     TrRouting::Calculator calculator;
 
@@ -63,7 +63,7 @@ protected:
     void setUpSchedules(std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> &connections);
 
 public:
-    BaseCsaFixtureTests() : params(TrRouting::Parameters()), calculator(TrRouting::Calculator(params)) {}
+    BaseCsaFixtureTests() : params(TrRouting::ServerParameters()), calculator(TrRouting::Calculator(params)) {}
     void SetUp();
 
 };

--- a/trip_based_algorithm/include/trip_based_algorithm.hpp
+++ b/trip_based_algorithm/include/trip_based_algorithm.hpp
@@ -46,14 +46,14 @@ namespace TrRouting
     
     std::string projectShortname;
     TripBasedAlgorithm();
-    TripBasedAlgorithm(Parameters& theParams);
+    TripBasedAlgorithm(ServerParameters& theParams);
     void setup();
     void setParamsFromYaml(std::string yamlFilePath = "");
     json calculate();
     void refresh();
     void destroy();
-    void updateParams(Parameters& theParams);
-    Parameters params;
+    void updateParams(ServerParameters& theParams);
+    ServerParameters params;
     void resetAccessEgressModes();
     CalculationTime algorithmCalculationTime;
     

--- a/trip_based_algorithm/src/trip_based_algorithm.cpp
+++ b/trip_based_algorithm/src/trip_based_algorithm.cpp
@@ -5,7 +5,7 @@ using json = nlohmann::json;
 namespace TrRouting
 {
   
-  TripBasedAlgorithm::TripBasedAlgorithm(Parameters& theParams) : params(theParams)
+  TripBasedAlgorithm::TripBasedAlgorithm(ServerParameters& theParams) : params(theParams)
   {
     algorithmCalculationTime = CalculationTime();
     setup();
@@ -401,7 +401,7 @@ namespace TrRouting
   }
   
   // Call before each calculation
-  void TripBasedAlgorithm::updateParams(Parameters& theParams)
+  void TripBasedAlgorithm::updateParams(ServerParameters& theParams)
   {
     params = theParams;
   }

--- a/trip_based_algorithm/src/trip_based_http_server.cpp
+++ b/trip_based_algorithm/src/trip_based_http_server.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
   std::cerr << dataShortname << std::endl << std::endl;
   
   // Set params:
-  Parameters algorithmParams;
+  ServerParameters algorithmParams;
   TripBasedAlgorithm calculator;
   algorithmParams.projectShortname = dataShortname;
   algorithmParams.dataFetcher          = dataFetcher;


### PR DESCRIPTION
This will allow to eventually have another class for RouteParameters
where the part of the parameters that are specific for a single route query
will be moved.

Note that the ServerParameters class still contains a lot of non-server
parameters.