### PR TITLE
Document a new endpoint for origin/destination routing queries

### DIFF
--- a/docs/API.yml
+++ b/docs/API.yml
@@ -105,7 +105,11 @@ paths:
             default: 0
           required: false
           # TODO: This will become 2 different endpoints since the return values are so much different.
-          description: If set to 0, the query returns the routes between origin and destination. If set to 1, the query will return all the nodes accessible with the given parameter. Only the origin is required for this query.
+          description: |
+            If set to 0, the query returns the routes between origin and destination.
+            If set to 1, the query will return all the nodes accessible with the given parameter.
+            Only the origin is required for this query that will calculate all nodes accessible
+            from this point. There can also be only the destination for all nodes to this point.
       # The parameters above are those used in the Transition queries, already ported to typescript
       # Still undocumented parameters. See if they are all required and remove any reference to them if they are not. Parameters on the same line are in the same if condition in the code, so identical
       # Some parameters differ only with the unit, consider using a single parameter, and if really required, add a parameter that contains the units. Otherwise, one can specify 2 such parameters, which one to take?

--- a/docs/APIv2.yml
+++ b/docs/APIv2.yml
@@ -1,0 +1,449 @@
+openapi: '3.0.2'
+info:
+  title: TrRouting
+  version: '2.0-beta'
+servers:
+  - url: http://localhost:4000
+
+paths:
+  /versions:
+    get:
+      description: Get the versions of the API supported by this inVehicleDistanceMeters
+      responses:
+        '200':
+          description: Return the current and supported versions of the API
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  current:
+                    type: string
+                    description: Current (latest) version of the API
+                  supported:
+                    type: array
+                    items:
+                      type: string
+                    description: All supported versions of the API
+
+  /v2/route:
+    get:
+      description: Calculate transit route results for a given origin/destination pair
+      parameters:
+        - in: query
+          name: origin
+          schema:
+            type: string
+            pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          required: true
+          description: Comma-separated longitude/latitude coordinates of the origin, in the WSG84 coordinates system
+        - in: query
+          name: destination
+          schema:
+            type: string
+            pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          required: true
+          description: Comma-separated longitude/latitude coordinates of the destination, in the WSG84 coordinates system
+        - in: query
+          name: scenario_id
+          schema:
+            type: string
+          required: true
+          # TODO: Scenario is very transition centric. Can't trRouting be used with a GTFS or some other type, without a scenario
+          description: ID of the scenario to query. A scenario defines the services, agencies and lines to use for this transit calculation
+        - in: query
+          name: time_of_trip
+          schema:
+            type: integer
+          required: true
+          description: |
+            time of the trip, in seconds since midnight.
+            The time_type field will determine if it represents a departure or arrival time.
+            There is no timezone associated with the time, trRouting is timezone agnostic as a scenario
+            typically covers a single timezone and the 0 is the midnight in the agency of that scenario.
+        - in: query
+          name: time_type
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+          required: false
+          description: The type of the time_of_trip. 0 means it is the departure time; 1 means arrival time. Defaults to 0.
+        - in: query
+          name: alternatives
+          schema:
+            type: boolean
+          required: false
+          description: Whether the results should return various alternatives if available or just a single result. Defaults to false, no alternatives
+        - in: query
+          name: min_waiting_time
+          schema:
+            type: integer
+          required: false
+          description: "The minimum time to wait at a stop/station, in seconds, to cope with uncertainties in the vehicle arrival times. Suggested value: 180"
+        - in: query
+          name: max_access_travel_time
+          schema:
+            type: integer
+          required: false
+          description: "Maximum time, in seconds, to reach the first stop/station in the trip"
+        - in: query
+          name: max_egress_travel_time
+          schema:
+            type: integer
+          required: false
+          description: "Maximum time, in seconds, from the last stop/station, to reach the destination"
+        - in: query
+          name: max_transfer_travel_time
+          schema:
+            type: integer
+          required: false
+          description: "Maximum time, in seconds, for each transfer between stop/station during the trip"
+        - in: query
+          name: max_travel_time
+          schema:
+            type: integer
+          required: false
+          description: The maximum total travel time between origin and destination, including access, transfer and egress times
+        - in: query
+          name: max_first_waiting_time
+          schema:
+            type: integer
+          required: false
+          description: The maximum time, in seconds, one can wait at first stop/station to consider this trip valid
+      responses:
+        '200':
+          description: Successful query, but may not have returned a routing result
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/data_error'
+                  - $ref: '#/components/schemas/NoRoutingFound'
+                  - $ref: '#/components/schemas/success'
+                discriminator:
+                  propertyName: status
+        '400':
+          description: Query parameters are invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/query_error'
+
+components:
+  schemas:
+    statusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum: [success, no_routing_found, data_error, query_error]
+      discriminator:
+        propertyName: status
+        mapping:
+          success: success
+          no_routing_found: NoRoutingFound
+          data_error: data_error
+          query_error: query_error
+
+    data_error: # 'data_error' is a value for the status (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/statusResponse'
+        - type: object
+          properties:
+            errorCode:
+              type: string
+              enum:
+                - 'DATA_ERROR'
+                - 'MISSING_DATA_AGENCIES'
+                - 'MISSING_DATA_SERVICES'
+                - 'MISSING_DATA_NODES'
+                - 'MISSING_DATA_LINES'
+                - 'MISSING_DATA_PATHS'
+                - 'MISSING_DATA_SCENARIOS'
+                - 'MISSING_DATA_SCHEDULES'
+
+    query_error: # 'query_error' is a value for the status (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/statusResponse'
+        - type: object
+          properties:
+            errorCode:
+              type: string
+              enum:
+                - 'EMPTY_SCENARIO'
+                - 'MISSING_PARAM_SCENARIO'
+                - 'MISSING_PARAM_ORIGIN'
+                - 'MISSING_PARAM_DESTINATION'
+                - 'MISSING_PARAM_TIME_OF_TRIP'
+                - 'INVALID_ORIGIN'
+                - 'INVALID_DESTINATION'
+                - 'INVALID_NUMERICAL_DATA'
+                - 'PARAM_ERROR_UNKNOWN'
+
+    NoRoutingFound:
+      allOf:
+      - $ref: '#/components/schemas/statusResponse'
+      - $ref: '#/components/schemas/baseRouteResponse'
+      - type: object
+
+    success: # TODO: There's a lot of data returned, document it all, but from the code, not from transition
+      allOf:
+      - $ref: '#/components/schemas/statusResponse'
+      - $ref: '#/components/schemas/routeOrAlternativesResponse'
+
+    routeOrAlternativesResponse:
+      oneOf:
+      - $ref: '#/components/schemas/routeResponse'
+      - $ref: '#/components/schemas/alternativesResponse'
+
+    baseRouteResponse:
+      type: object
+      properties:
+        origin:
+          type: string
+          pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          description: Comma-separated longitude/latitude coordinates of the origin, in the WSG84 coordinates system
+        destination:
+          type: string
+          pattern: '^\-?\d{1,3}(\.\d+)?,\-?\d{1,3}(\.\d+)?$'
+          description: Comma-separated longitude/latitude coordinates of the destination, in the WSG84 coordinates system
+        requestTime:
+          type: integer
+          description: |
+            The requested time of the trip, in seconds since midnight.
+            The time_type field will determine if it represents a departure or arrival time.
+        timeType:
+          type: integer
+          enum:
+            - 0
+            - 1
+          description: The type of the requestTime. 0 means it is the departure time; 1 means arrival time
+
+    routeResponse:
+      allOf:
+        - $ref: '#/components/schemas/baseRouteResponse'
+        - type: object
+          properties:
+            departureTime:
+              type: string
+              description: Optimized departure time in seconds since midnight
+            arrivalTime:
+              type: string
+              description: Arrival time in seconds since midnight
+            totalTravelTime:
+              type: number
+              description: Total travel time, from the optimized departure time to the arrival time, in seconds
+            totalDistanceMeters:
+              type: number
+              description: Total distance traveled, from departure to arrival
+            totalInVehicleTime:
+              type: number
+              description: Total time spent in a transit vehicle, in seconds
+            totalInVehicleDistanceMeters:
+              type: number
+              description: Total distance traveled in a vehicle, in meters
+            totalNonTransitTravelTime:
+              type: number
+              description: Total time spent traveling, but not in a transit vehicle. This excludes waiting time. In seconds
+            totalNonTransitDistanceMeters:
+              type: number
+              description: Total distance traveled not in a vehicle, in meters
+            numberOfBoardings:
+              type: number
+              description: Number of times a vehicle is boarded in the trip
+            numberOfTransfers:
+              type: number
+              description: Number of transfers in this trip
+            transferWalkingTime:
+              type: number
+              description: Time spent walking to transfer from a transit route to another transit route, in seconds
+            transferWalkingDistanceMeters:
+              type: number
+              description: Distance traveled to transfer between transit trips, in meters
+            accessTravelTime:
+              type: number
+              description: Time spent traveling to access the first transit stop of the trip, in seconds
+            accessDistanceMeters:
+              type: number
+              description: Distance traveled to access the first transit stop of the trip, in meters
+            egressTravelTime:
+              type: number
+              description: Time spent traveling from the last transit stop of the trip, to the destination, in seconds
+            egressDistanceMeters:
+              type: number
+              description: Distance traveled from the last transit stop of the trip to the destination, in meters
+            transferWaitingTime:
+              type: number
+              description: Time spent waiting at a transit stop for a transfer (ie exluding the time spent waiting at the first stop), in seconds
+            firstWaitingTime:
+              type: number
+              description: Time spent waiting at the first transit stop of the trip, in seconds
+            totalWaitingTime:
+              type: number
+              description: Total time spent waiting for a transit vehicle, in seconds
+            steps:
+              type: array
+              items:
+                $ref: '#/components/schemas/tripStep'
+
+    alternativesResponse:
+      type: object
+      properties:
+        alternatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/routeResponse'
+
+    tripStep:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum: [walking, boarding, unboarding]
+      discriminator:
+        propertyName: action
+        mapping:
+          walking: tripStepWalking
+          boarding: tripStepBoarding
+          unboarding: tripStepUnboarding
+
+    tripStepWalking:
+      oneOf:
+      - $ref: '#/components/schemas/tripStepWalkingBaseEgress'
+      - $ref: '#/components/schemas/tripStepWalkingWithBoarding'
+      discriminator:
+        propertyName: type
+        mapping:
+          access: tripStepWalkingWithBoarding
+          egress: tripStepWalkingBaseEgress
+          transfer: tripStepWalkingWithBoarding
+
+    tripStepWalkingBase:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [access, egress, transfer]
+      discriminator:
+        propertyName: type
+
+    tripStepWalkingBaseEgress:
+      allOf:
+        - $ref: '#/components/schemas/tripStep'
+        - $ref: '#/components/schemas/tripStepWalkingBase'
+        - type: object
+          properties:
+            travelTime:
+              type: number
+              description: Time spent walking in this step, in seconds
+            distanceMeters:
+              type: number
+              description: Distance traveled in this step, in meters
+            departureTime:
+              type: string
+              description: Time of the beginning of this step, in seconds since midnight
+            arrivalTime:
+              type: string
+              description: Time of arrival to destination for this step, in seconds since midnight
+
+    tripStepWalkingWithBoarding:
+      allOf:
+      - $ref: '#/components/schemas/tripStepWalkingBaseEgress'
+      - type: object
+        properties:
+          readyToBoardAt:
+            type: string
+            description: Time at which boarding is possible, this includes a waiting time buffer at the stop, so is usually arrival_time + minimum waiting time. Time format is seconds since midnight.
+
+    tripStepTripEnterOrExit:
+      allOf:
+      - $ref: '#/components/schemas/tripStep'
+      - type: object
+        properties:
+          agencyAcronym:
+            type: string
+            description: Acronym of the agency serving the route being boarded/unboarded
+          agencyName:
+            type: string
+            description: Name of the agency serving the route being boarded/unboarded
+          agencyUuid:
+            type: string
+            description: UUID of the agency serving the route being boarded/unboarded
+          lineShortname:
+            type: string
+            description: Shortname of the route being boarded/unboarded
+          lineLongname:
+            type: string
+            description: Long name of the route being boarded/unboarded
+          lineUuid:
+            type: string
+            description: UUID of the line being boarded/unboarded
+          pathUuid:
+            type: string
+            description: UUID of the path being boarded/unboarded
+          modeName:
+            type: string
+            description: Full name of the route's mode
+          mode:
+            type: string
+            description: Code name of the route's mode
+          tripUuid:
+            type: string
+            description: UUID of the route's trip involved in this action
+          legSequenceInTrip:
+            type: number
+            description: Sequence number, in the complete trip, of the sequence starting at the stop to be boarded/unboarded. 1 would mean the first sequence.
+          stopSequenceInTrip:
+            type: number
+            description: Sequence number, in the complete trip, of the stop boarded/unboarded at. 1 would mean the first stop
+          nodeName:
+            type: string
+            description: Name of the node where the action takes place
+          nodeCode:
+            type: string
+            description: Code of the node where the action takes place
+          nodeUuid:
+            type: string
+            description: UUID of the node where the action takes place
+          nodeCoordinates:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+            description: longitude and latitude of the node where the action takes place, in the WSG84 coordinates system
+
+    tripStepBoarding: # 'boarding' is a value for the action (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/tripStepTripEnterOrExit'
+        - type: object
+          properties:
+            departureTime:
+              type: string
+              description: Departure time of the vehicle, in seconds since midnight
+            waitingTime:
+              type: number
+              description: Time spent waiting for the vehicle at the stops. Includes the minimal wait period specified in the query parameters. In seconds
+
+    tripStepUnboarding: # 'unboarding' is a value for the action (discriminator)
+      allOf:
+        - $ref: '#/components/schemas/tripStep'
+        - type: object
+          properties:
+            arrivalTime:
+              type: string
+              description: Arrival time of the vehicle, in seconds since midnight
+            inVehicleTime:
+              type: number
+              description: Time spent in the vehicle, in seconds
+            inVehicleDistanceMeters:
+              type: number
+              description: Distance covered in the vehicle, in meters


### PR DESCRIPTION
This commit is the start of v2 of the trRouting API, where each query
will give access to a single functionality and parameters are
well-defined and for each query, all of the parameters can be set.

This endpoint returns a single transit routing calculation for the
origin/destination in parameter. It is a subset of the route/v1/transit
query, so return types are kept as they are in the original endpoint.

Note that this endpoint reverses the coordinates order of the
parameters. Origin and destination are now lon/lat, instead of lat/lon,
as mentioned in #100.