### PR TITLE
Add a RouteParameters class to store route query specific parameters

### DIFF
--- a/connection_scan_algorithm/src/Makefile.am
+++ b/connection_scan_algorithm/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include 
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include
 
 noinst_LTLIBRARIES = libcsa.la
 
@@ -10,9 +10,10 @@ libcsa_la_SOURCES = alternatives_routing.cpp \
 		   od_trips_routing.cpp \
 		   optimize_journey.cpp \
 		   parameters.cpp \
-	           preparations.cpp \
+		   preparations.cpp \
 		   program_options.cpp \
 		   resets.cpp \
 		   reverse_calculation.cpp \
 		   reverse_journey.cpp \
-	           transit_routing_http_server.cpp
+		   route_parameters.cpp \
+		   transit_routing_http_server.cpp

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -1,0 +1,280 @@
+#include "parameters.hpp"
+
+namespace TrRouting
+{
+  static int DEFAULT_MIN_WAITING_TIME = 3 * 60;
+  static int DEFAULT_MAX_TOTAL_TIME = MAX_INT;
+  static int DEFAULT_MAX_ACCESS_TRAVEL_TIME = 20 * 60;
+  static int DEFAULT_MAX_EGRESS_TRAVEL_TIME = 20 * 60;
+  static int DEFAULT_MAX_TRANSFER_TRAVEL_TIME = 20 * 60;
+  static int DEFAULT_FIRST_WAITING_TIME = 30 * 60;
+
+  RouteParameters::RouteParameters(std::unique_ptr<Point> orig_,
+    std::unique_ptr<Point> dest_,
+    Scenario& scenario_,
+    int _timeOfTrip,
+    int minWaitingTime,
+    int maxTotalTime,
+    int maxAccessTime,
+    int maxEgressTime,
+    int maxTransferTime,
+    int maxFirstWaitingTime,
+    bool alt,
+    bool forward) :
+        origin(std::move(orig_)),
+        destination(std::move(dest_)),
+        scenario(scenario_),
+        timeOfTrip(_timeOfTrip),
+        minWaitingTimeSeconds(minWaitingTime),
+        maxTotalTravelTimeSeconds(maxTotalTime),
+        maxAccessWalkingTravelTimeSeconds(maxAccessTime),
+        maxEgressWalkingTravelTimeSeconds(maxEgressTime),
+        maxTransferWalkingTravelTimeSeconds(maxTransferTime),
+        maxFirstWaitingTimeSeconds(maxFirstWaitingTime),
+        withAlternatives(alt),
+        forwardCalculation(forward)
+  {
+    scenarioUuid = scenario.uuid;
+    onlyServicesIdx = scenario.servicesIdx;
+    onlyLinesIdx = scenario.onlyLinesIdx;
+    onlyAgenciesIdx = scenario.onlyAgenciesIdx;
+    onlyNodesIdx = scenario.onlyNodesIdx;
+    onlyModesIdx = scenario.onlyModesIdx;
+    exceptLinesIdx = scenario.exceptLinesIdx;
+    exceptAgenciesIdx = scenario.exceptAgenciesIdx;
+    exceptNodesIdx = scenario.exceptNodesIdx;
+    exceptModesIdx = scenario.exceptModesIdx;
+  }
+
+  RouteParameters::RouteParameters(const RouteParameters& routeParams):
+    origin(std::make_unique<Point>(routeParams.origin.get()->latitude, routeParams.origin.get()->longitude)),
+    destination(std::make_unique<Point>(routeParams.destination.get()->latitude, routeParams.destination.get()->longitude)),
+    scenario(routeParams.scenario),
+    timeOfTrip(routeParams.timeOfTrip),
+    minWaitingTimeSeconds(routeParams.minWaitingTimeSeconds),
+    maxTotalTravelTimeSeconds(routeParams.maxTotalTravelTimeSeconds),
+    maxAccessWalkingTravelTimeSeconds(routeParams.maxAccessWalkingTravelTimeSeconds),
+    maxEgressWalkingTravelTimeSeconds(routeParams.maxEgressWalkingTravelTimeSeconds),
+    maxTransferWalkingTravelTimeSeconds(routeParams.maxTransferWalkingTravelTimeSeconds),
+    maxFirstWaitingTimeSeconds(routeParams.maxFirstWaitingTimeSeconds),
+    withAlternatives(routeParams.withAlternatives),
+    forwardCalculation(routeParams.forwardCalculation),
+    scenarioUuid(routeParams.scenarioUuid),
+    onlyServicesIdx(routeParams.onlyServicesIdx),
+    onlyLinesIdx(routeParams.onlyLinesIdx),
+    onlyAgenciesIdx(routeParams.onlyAgenciesIdx),
+    onlyNodesIdx(routeParams.onlyNodesIdx),
+    onlyModesIdx(routeParams.onlyModesIdx),
+    exceptLinesIdx(routeParams.exceptLinesIdx),
+    exceptAgenciesIdx(routeParams.exceptAgenciesIdx),
+    exceptNodesIdx(routeParams.exceptNodesIdx),
+    exceptModesIdx(routeParams.exceptModesIdx)
+  {
+  }
+
+  static int getIntegerValue(std::string strValue) {
+    try
+    {
+      return std::stoi(strValue);
+    }
+    catch (...)
+    {
+      // Throwing an error, but do we want to fallback to default and just ignore this one?
+      throw ParameterException(ParameterException::Type::INVALID_NUMERICAL_DATA);
+    }
+  }
+
+  RouteParameters RouteParameters::createRouteODParameter(std::vector<std::pair<std::string, std::string>> &parameters, std::map<boost::uuids::uuid, int> &scenarioIndexesByUuid, std::vector<std::unique_ptr<Scenario>> &scenarios)
+  {
+
+    boost::uuids::string_generator uuidGenerator;
+
+    Scenario * scenario = nullptr;
+    boost::optional<boost::uuids::uuid> scenarioUuid = boost::none;
+    boost::uuids::uuid originNodeUuid;
+    boost::uuids::uuid destinationNodeUuid;
+
+    // Initialize default values
+    int timeOfTrip = -1;
+    int minWaitingTimeSeconds = DEFAULT_MIN_WAITING_TIME;
+    int maxTotalTravelTimeSeconds = DEFAULT_MAX_TOTAL_TIME;
+    int maxAccessWalkingTravelTimeSeconds = DEFAULT_MAX_ACCESS_TRAVEL_TIME;
+    int maxEgressWalkingTravelTimeSeconds = DEFAULT_MAX_EGRESS_TRAVEL_TIME;
+    int maxTransferWalkingTravelTimeSeconds = DEFAULT_MAX_TRANSFER_TRAVEL_TIME;
+    int maxFirstWaitingTimeSeconds = DEFAULT_FIRST_WAITING_TIME; // Ignore all connections at access nodes if waiting time would be more than this value.
+    boost::optional<Point> origin = boost::none;
+    boost::optional<Point> destination = boost::none;
+    bool alternatives = false;
+    bool forwardCalculation = true;
+
+    std::vector<std::string> latitudeLongitudeVector;
+
+    // TODO Replace manually parsing parameters by a library that does this
+    for (auto & parameterWithValue : parameters)
+    {
+      // origin and destination:
+      if (parameterWithValue.first == "origin")
+      {
+        try
+        {
+          boost::split(latitudeLongitudeVector, parameterWithValue.second, boost::is_any_of(","));
+          if (latitudeLongitudeVector.size() != 2)
+          {
+            throw ParameterException(ParameterException::Type::INVALID_ORIGIN);
+          }
+          origin = Point(std::stod(latitudeLongitudeVector[1]), std::stod(latitudeLongitudeVector[0]));
+        }
+        catch (...)
+        {
+          throw ParameterException(ParameterException::Type::INVALID_ORIGIN);
+        }
+      }
+      else if (parameterWithValue.first == "destination")
+      {
+        try
+        {
+          boost::split(latitudeLongitudeVector, parameterWithValue.second, boost::is_any_of(","));
+          if (latitudeLongitudeVector.size() != 2)
+          {
+            throw ParameterException(ParameterException::Type::INVALID_DESTINATION);
+          }
+          destination = Point(std::stod(latitudeLongitudeVector[1]), std::stod(latitudeLongitudeVector[0]));
+        }
+        catch (...)
+        {
+          throw ParameterException(ParameterException::Type::INVALID_DESTINATION);
+        }
+      }
+
+      // times and date:
+      else if (parameterWithValue.first == "time_of_trip")
+      {
+        timeOfTrip = getIntegerValue(parameterWithValue.second);
+        if (timeOfTrip < 0)
+        {
+          timeOfTrip = -1;
+        }
+      }
+      else if (parameterWithValue.first == "time_type")
+      {
+        if (parameterWithValue.second == "1")
+        {
+          forwardCalculation = false;
+        }
+        continue;
+      }
+
+      // scenario:
+      else if (parameterWithValue.first == "scenario_id")
+      {
+        scenarioUuid = uuidGenerator(parameterWithValue.second);
+        if (scenarioIndexesByUuid.count(*scenarioUuid) == 1)
+        {
+          scenario = scenarios[scenarioIndexesByUuid[*scenarioUuid]].get();
+        }
+        continue;
+      }
+
+      // min and max parameters:
+      else if (parameterWithValue.first == "min_waiting_time")
+      {
+        minWaitingTimeSeconds = getIntegerValue(parameterWithValue.second);
+        if (minWaitingTimeSeconds < 0)
+        {
+          minWaitingTimeSeconds = 0;
+        }
+        continue;
+      }
+      else if (parameterWithValue.first == "max_travel_time")
+      {
+        maxTotalTravelTimeSeconds = getIntegerValue(parameterWithValue.second);
+        if (maxTotalTravelTimeSeconds <= 0)
+        {
+          maxTotalTravelTimeSeconds = MAX_INT;
+        }
+        continue;
+      }
+      else if (parameterWithValue.first == "max_access_travel_time")
+      {
+        maxAccessWalkingTravelTimeSeconds = getIntegerValue(parameterWithValue.second);
+        if (maxAccessWalkingTravelTimeSeconds <= 0)
+        {
+          maxAccessWalkingTravelTimeSeconds = MAX_INT;
+        }
+        continue;
+      }
+      else if (parameterWithValue.first == "max_egress_travel_time")
+      {
+        maxEgressWalkingTravelTimeSeconds = getIntegerValue(parameterWithValue.second);
+        if (maxEgressWalkingTravelTimeSeconds <= 0)
+        {
+          maxEgressWalkingTravelTimeSeconds = MAX_INT;
+        }
+        continue;
+      }
+      else if (parameterWithValue.first == "max_transfer_travel_time")
+      {
+        maxTransferWalkingTravelTimeSeconds = getIntegerValue(parameterWithValue.second);
+        if (maxTransferWalkingTravelTimeSeconds <= 0)
+        {
+          maxTransferWalkingTravelTimeSeconds = MAX_INT;
+        }
+        continue;
+      }
+      else if (parameterWithValue.first == "max_first_waiting_time")
+      {
+        maxFirstWaitingTimeSeconds = getIntegerValue(parameterWithValue.second);
+        if (maxFirstWaitingTimeSeconds <= 0)
+        {
+          maxFirstWaitingTimeSeconds = -1;
+        }
+        continue;
+      }
+
+      else if (parameterWithValue.first == "alternatives")
+      {
+        if (parameterWithValue.second == "true" || parameterWithValue.second == "1")
+        {
+          alternatives = true;
+        }
+        continue;
+      }
+    }
+
+    // Validate scenario parameters
+    if (scenario == nullptr)
+    {
+      throw ParameterException(ParameterException::Type::MISSING_SCENARIO);
+    }
+    else if (scenario->servicesIdx.size() <= 0)
+    {
+      throw ParameterException(ParameterException::Type::EMPTY_SCENARIO);
+    }
+    else if (!origin.has_value())
+    {
+      throw ParameterException(ParameterException::Type::MISSING_ORIGIN);
+    }
+    else if (!destination.has_value())
+    {
+      throw ParameterException(ParameterException::Type::MISSING_DESTINATION);
+    }
+    else if (timeOfTrip < 0)
+    {
+      throw ParameterException(ParameterException::Type::MISSING_TIME_OF_TRIP);
+    }
+
+    return RouteParameters(std::make_unique<TrRouting::Point>(origin.get().latitude, origin.get().longitude),
+      std::make_unique<TrRouting::Point>(destination.get().latitude, destination.get().longitude),
+      *scenario,
+      timeOfTrip,
+      minWaitingTimeSeconds,
+      maxTotalTravelTimeSeconds,
+      maxAccessWalkingTravelTimeSeconds,
+      maxEgressWalkingTravelTimeSeconds,
+      maxTransferWalkingTravelTimeSeconds,
+      maxFirstWaitingTimeSeconds,
+      alternatives,
+      forwardCalculation);
+  }
+
+}

--- a/tests/connection_scan_algorithm/Makefile.am
+++ b/tests/connection_scan_algorithm/Makefile.am
@@ -8,8 +8,8 @@ csa_test_SOURCES = gtest.cpp \
     csa_simple_calculation_test.cpp \
     csa_transfer_and_alternatives_test.cpp \
     csa_access_map_test.cpp \
-    csa_odtrips_calculation_test.cpp
-
+    csa_odtrips_calculation_test.cpp \
+    route_parameters_test.cpp
 
 csa_test_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 

--- a/tests/connection_scan_algorithm/parameters_test.hpp
+++ b/tests/connection_scan_algorithm/parameters_test.hpp
@@ -1,0 +1,13 @@
+#ifndef _PARAMETERS_TEST_H
+#define _PARAMETERS_TEST_H
+
+#include "gtest/gtest.h"
+#include "parameters.hpp"
+
+class BaseParametersFixtureTests : public ::testing::Test 
+{
+protected:
+
+};
+
+#endif // _PARAMETERS_TEST_H

--- a/tests/connection_scan_algorithm/route_parameters_test.cpp
+++ b/tests/connection_scan_algorithm/route_parameters_test.cpp
@@ -1,0 +1,181 @@
+#include <errno.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "gtest/gtest.h" // we will add the path to C preprocessor later
+#include "parameters.hpp"
+#include "parameters_test.hpp"
+#include "scenario.hpp"
+
+const std::string EMPTY_SCENARIO_UUID = "acdcef12-1111-2222-3333-444455558888";
+
+class RouteParametersFixtureTests : public BaseParametersFixtureTests
+{
+protected:
+    std::vector<std::unique_ptr<TrRouting::Scenario>> scenarios;
+    std::map<boost::uuids::uuid, int> scenarioIndexesByUuid;
+
+public:
+    void SetUp( ) override
+    {
+
+        const boost::uuids::string_generator uuidGenerator;
+
+        // Create a valid scenario, services and other data don't have to exist, we are creating parameters, not using them
+        std::unique_ptr<TrRouting::Scenario> scenario = std::make_unique<TrRouting::Scenario>();
+        scenario->uuid = uuidGenerator("12345678-9999-0000-1111-ababbabaabab");
+
+        scenario->name = "Test valid scenario";
+        scenario->servicesIdx.push_back(0);
+        scenario->servicesIdx.push_back(3);
+
+        scenarioIndexesByUuid[scenario->uuid] = scenarios.size();
+        scenarios.push_back(std::move(scenario));
+
+        // Create an empty scenario
+        scenario = std::make_unique<TrRouting::Scenario>();
+        scenario->uuid = uuidGenerator(EMPTY_SCENARIO_UUID);
+        scenario->name = "Test empty scenario";
+
+        scenarioIndexesByUuid[scenario->uuid] = scenarios.size();
+        scenarios.push_back(std::move(scenario));
+    }
+
+    void TearDown( ) override
+    {
+        // Nothing to do? Shoud we delete the scenarios?
+        scenarios.clear();
+        scenarioIndexesByUuid.clear();
+    }
+};
+
+class InvalidParamTestSuite : public RouteParametersFixtureTests,
+                              public testing::WithParamInterface<std::tuple<std::string, std::string, TrRouting::ParameterException::Type>> {
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    InvalidRouteParamsStringValues, InvalidParamTestSuite,
+    testing::Values(
+        std::make_tuple("origin", "", TrRouting::ParameterException::Type::MISSING_ORIGIN),
+        std::make_tuple("destination", "", TrRouting::ParameterException::Type::MISSING_DESTINATION),
+        std::make_tuple("scenario_id", "", TrRouting::ParameterException::Type::MISSING_SCENARIO),
+        std::make_tuple("time_of_trip", "", TrRouting::ParameterException::Type::MISSING_TIME_OF_TRIP),
+        std::make_tuple("time_of_trip", "-3", TrRouting::ParameterException::Type::MISSING_TIME_OF_TRIP),
+        std::make_tuple("scenario_id", EMPTY_SCENARIO_UUID, TrRouting::ParameterException::Type::EMPTY_SCENARIO),
+        std::make_tuple("origin", "45", TrRouting::ParameterException::Type::INVALID_ORIGIN),
+        std::make_tuple("origin", "foo,bar", TrRouting::ParameterException::Type::INVALID_ORIGIN),
+        std::make_tuple("destination", "-73", TrRouting::ParameterException::Type::INVALID_DESTINATION),
+        std::make_tuple("destination", "foo,bar", TrRouting::ParameterException::Type::INVALID_DESTINATION),
+        std::make_tuple("min_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_access_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_egress_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_transfer_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_first_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA)
+    )
+);
+
+TEST_P(InvalidParamTestSuite, TestParams)
+{
+    std::tuple<std::string, std::string, TrRouting::ParameterException::Type> param = GetParam();
+    std::string paramName = std::get<0>(param);
+    std::string paramValue = std::get<1>(param);
+    TrRouting::ParameterException::Type exceptionType = std::get<2>(param);
+
+    std::vector<std::pair<std::string, std::string>> parametersWithValues;
+    if (paramName != "origin")
+    {
+        parametersWithValues.push_back(std::make_pair("origin", "-73.5,45.5544"));
+    }
+    if (paramName != "destination")
+    {
+        parametersWithValues.push_back(std::make_pair("destination", "-73.57786713522127,45.55239801892435"));
+    }
+    if (paramName != "time_of_trip")
+    {
+        parametersWithValues.push_back(std::make_pair("time_of_trip", "10800"));
+    }
+    if (paramName != "scenario_id")
+    {
+        parametersWithValues.push_back(std::make_pair("scenario_id", boost::uuids::to_string(scenarios[0]->uuid)));
+    }
+    if (!paramValue.empty())
+    {
+        parametersWithValues.push_back(std::make_pair(paramName, paramValue));
+    }
+
+    try {
+        TrRouting::RouteParameters queryParams = TrRouting::RouteParameters::createRouteODParameter(parametersWithValues, scenarioIndexesByUuid, scenarios);
+        FAIL() << "Expected TrRouting::ParameterException, no exception was thrown";
+    }
+    catch(TrRouting::ParameterException const & err) {
+        EXPECT_EQ(err.getType(), exceptionType);
+    }
+    catch(...) {
+        FAIL() << "Expected TrRouting::ParameterException, another type was thrown";
+    }
+}
+
+TEST_F(RouteParametersFixtureTests, DefaultParameters)
+{
+    std::vector<std::pair<std::string, std::string>> parametersWithValues;
+    parametersWithValues.push_back(std::make_pair("scenario_id", boost::uuids::to_string(scenarios[0]->uuid)));
+    parametersWithValues.push_back(std::make_pair("origin", "-73.5,45.5544"));
+    parametersWithValues.push_back(std::make_pair("destination", "-73.57786713522127, 45.55239801892435"));
+    parametersWithValues.push_back(std::make_pair("time_of_trip", "10800"));
+
+    TrRouting::RouteParameters queryParams = TrRouting::RouteParameters::createRouteODParameter(parametersWithValues, scenarioIndexesByUuid, scenarios);
+    EXPECT_DOUBLE_EQ(queryParams.getOrigin()->latitude, 45.5544);
+    EXPECT_DOUBLE_EQ(queryParams.getOrigin()->longitude, -73.5);
+    EXPECT_DOUBLE_EQ(queryParams.getDestination()->latitude, 45.55239801892435);
+    EXPECT_DOUBLE_EQ(queryParams.getDestination()->longitude, -73.57786713522127);
+    EXPECT_EQ(queryParams.isWithAlternatives(), false);
+    EXPECT_EQ(queryParams.isForwardCalculation(), true);
+
+    // Values that should be set to defaults
+    EXPECT_EQ(queryParams.getTimeOfTrip(), 10800);
+    EXPECT_EQ(queryParams.getMinWaitingTimeSeconds(), 3 * 60);
+    EXPECT_EQ(queryParams.getMaxTotalTravelTimeSeconds(), TrRouting::MAX_INT);
+    EXPECT_EQ(queryParams.getMaxAccessWalkingTravelTimeSeconds(), 20 * 60);
+    EXPECT_EQ(queryParams.getMaxEgressWalkingTravelTimeSeconds(), 20 * 60);
+    EXPECT_EQ(queryParams.getMaxTransferWalkingTravelTimeSeconds(), 20 * 60);
+    EXPECT_EQ(queryParams.getMaxFirstWaitingTimeSeconds(), 30 * 60);
+}
+
+TEST_F(RouteParametersFixtureTests, SetAllParameters)
+{
+    // Set arbitrary values for parameters, different for each case
+    int minWaitingTime = 60, maxTotalTime = 3600, maxAccess = 600;
+    int maxEgress = 900, maxTransfer = 750, maxFirst = 300;
+
+    std::vector<std::pair<std::string, std::string>> parametersWithValues;
+    parametersWithValues.push_back(std::make_pair("scenario_id", boost::uuids::to_string(scenarios[0]->uuid)));
+    parametersWithValues.push_back(std::make_pair("origin", "-73.5,45.5544"));
+    parametersWithValues.push_back(std::make_pair("destination", "-73.57786713522127, 45.55239801892435"));
+    parametersWithValues.push_back(std::make_pair("time_of_trip", "10800"));
+    parametersWithValues.push_back(std::make_pair("time_type", "1"));
+    parametersWithValues.push_back(std::make_pair("alternatives", "1"));
+    parametersWithValues.push_back(std::make_pair("min_waiting_time", std::to_string(minWaitingTime)));
+    parametersWithValues.push_back(std::make_pair("max_access_travel_time", std::to_string(maxAccess)));
+    parametersWithValues.push_back(std::make_pair("max_egress_travel_time", std::to_string(maxEgress)));
+    parametersWithValues.push_back(std::make_pair("max_transfer_travel_time", std::to_string(maxTransfer)));
+    parametersWithValues.push_back(std::make_pair("max_travel_time", std::to_string(maxTotalTime)));
+    parametersWithValues.push_back(std::make_pair("max_first_waiting_time", std::to_string(maxFirst)));
+
+    TrRouting::RouteParameters queryParams = TrRouting::RouteParameters::createRouteODParameter(parametersWithValues, scenarioIndexesByUuid, scenarios);
+    EXPECT_DOUBLE_EQ(queryParams.getOrigin()->latitude, 45.5544);
+    EXPECT_DOUBLE_EQ(queryParams.getOrigin()->longitude, -73.5);
+    EXPECT_DOUBLE_EQ(queryParams.getDestination()->latitude, 45.55239801892435);
+    EXPECT_DOUBLE_EQ(queryParams.getDestination()->longitude, -73.57786713522127);
+    EXPECT_EQ(queryParams.isWithAlternatives(), true);
+    EXPECT_EQ(queryParams.isForwardCalculation(), false);
+
+    // Values that should be set to defaults
+    EXPECT_EQ(queryParams.getTimeOfTrip(), 10800);
+    EXPECT_EQ(queryParams.getMinWaitingTimeSeconds(), minWaitingTime);
+    EXPECT_EQ(queryParams.getMaxTotalTravelTimeSeconds(), maxTotalTime);
+    EXPECT_EQ(queryParams.getMaxAccessWalkingTravelTimeSeconds(), maxAccess);
+    EXPECT_EQ(queryParams.getMaxEgressWalkingTravelTimeSeconds(), maxEgress);
+    EXPECT_EQ(queryParams.getMaxTransferWalkingTravelTimeSeconds(), maxTransfer);
+    EXPECT_EQ(queryParams.getMaxFirstWaitingTimeSeconds(), maxFirst);
+}


### PR DESCRIPTION
This class contains the parameters passed to a single routing query:
origin/destination, max/min times for waiting, access, egress, transfer,
etc and scenario data.

Add a factory method to create a parameters object from a parameters
vector.

Add unit tests for this factory method.