### PR TITLE
Replace boost::optional with std::optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ LT_INIT
 # AX_ macros copied from the autoconf-archive
 
 # TODO Do we need the strict mode or not here ?
-AX_CXX_COMPILE_STDCXX_14(noext)
+AX_CXX_COMPILE_STDCXX(17,noext)
 
 AX_BOOST_BASE
 AX_BOOST_FILESYSTEM

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -23,7 +23,6 @@
 #include <boost/range/adaptor/reversed.hpp>
 //#include <boost/compute.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/optional.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/lexical_cast.hpp>

--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -8,10 +8,10 @@ namespace TrRouting
     if (debugDisplay)
     {
       std::cout << "parameters: "            << std::endl;
-      std::cout << " hasScenarioUuid: "      << (scenarioUuid.is_initialized()   ? "true" : "false") << std::endl;
+      std::cout << " hasScenarioUuid: "      << (scenarioUuid.has_value()   ? "true" : "false") << std::endl;
       std::cout << " hasServices: "          << (onlyServicesIdx.size() >  0     ? "true" : "false") << std::endl;
-      std::cout << " hasDataSourceUuid: "    << (dataSourceUuid.is_initialized() ? "true" : "false") << std::endl;
-      std::cout << " hasOdTripUuid: "        << (odTripUuid.is_initialized()     ? "true" : "false") << std::endl;
+      std::cout << " hasDataSourceUuid: "    << (dataSourceUuid.has_value() ? "true" : "false") << std::endl;
+      std::cout << " hasOdTripUuid: "        << (odTripUuid.has_value()     ? "true" : "false") << std::endl;
       std::cout << " calculateAllOdTrips: "  << calculateAllOdTrips  << std::endl;
       std::cout << " calculateProfiles: "    << calculateProfiles    << std::endl;
       std::cout << " hasOrigin: "            << hasOrigin            << std::endl;
@@ -21,11 +21,11 @@ namespace TrRouting
       std::cout << " arrivalTimeSeconds: "   << arrivalTimeSeconds   << std::endl;
       std::cout << " returnAllNodesResult: " << returnAllNodesResult << std::endl;
     }
-    if (!scenarioUuid.is_initialized() || onlyServicesIdx.size() == 0) // scenario and only services is mandatory
+    if (!scenarioUuid.has_value() || onlyServicesIdx.size() == 0) // scenario and only services is mandatory
     {
       return false;
     }
-    if (calculateAllOdTrips || odTripUuid.is_initialized())
+    if (calculateAllOdTrips || odTripUuid.has_value())
     {
       return true;
     }
@@ -76,11 +76,11 @@ namespace TrRouting
     responseFormat                         = "json";
     saveResultToFile                       = false;
     odTripsSampleRatio                     = 1.0;
-    scenarioUuid                           = boost::none;
-    dataSourceUuid                         = boost::none;
-    odTripUuid                             = boost::none;
-    startingNodeUuid                       = boost::none;
-    endingNodeUuid                         = boost::none;
+    scenarioUuid.reset();
+    dataSourceUuid.reset();
+    odTripUuid.reset();
+    startingNodeUuid.reset();
+    endingNodeUuid.reset();
     origin                                 = Point();
     destination                            = Point();
     hasOrigin                              = false;
@@ -143,8 +143,8 @@ namespace TrRouting
     boost::uuids::string_generator uuidGenerator;
 
     Scenario *         scenario;
-    scenarioUuid   = boost::none;
-    dataSourceUuid = boost::none;
+    scenarioUuid.reset();
+    dataSourceUuid.reset();
     boost::uuids::uuid originNodeUuid;
     boost::uuids::uuid destinationNodeUuid;
 

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -90,7 +90,7 @@ namespace TrRouting
     boost::uuids::string_generator uuidGenerator;
 
     Scenario * scenario = nullptr;
-    boost::optional<boost::uuids::uuid> scenarioUuid = boost::none;
+    std::optional<boost::uuids::uuid> scenarioUuid;
     boost::uuids::uuid originNodeUuid;
     boost::uuids::uuid destinationNodeUuid;
 
@@ -102,8 +102,8 @@ namespace TrRouting
     int maxEgressWalkingTravelTimeSeconds = DEFAULT_MAX_EGRESS_TRAVEL_TIME;
     int maxTransferWalkingTravelTimeSeconds = DEFAULT_MAX_TRANSFER_TRAVEL_TIME;
     int maxFirstWaitingTimeSeconds = DEFAULT_FIRST_WAITING_TIME; // Ignore all connections at access nodes if waiting time would be more than this value.
-    boost::optional<Point> origin = boost::none;
-    boost::optional<Point> destination = boost::none;
+    std::optional<Point> origin;
+    std::optional<Point> destination;
     bool alternatives = false;
     bool forwardCalculation = true;
 
@@ -263,8 +263,8 @@ namespace TrRouting
       throw ParameterException(ParameterException::Type::MISSING_TIME_OF_TRIP);
     }
 
-    return RouteParameters(std::make_unique<TrRouting::Point>(origin.get().latitude, origin.get().longitude),
-      std::make_unique<TrRouting::Point>(destination.get().latitude, destination.get().longitude),
+    return RouteParameters(std::make_unique<TrRouting::Point>(origin->latitude, origin->longitude),
+      std::make_unique<TrRouting::Point>(destination->latitude, destination->longitude),
       *scenario,
       timeOfTrip,
       minWaitingTimeSeconds,

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -11,7 +11,6 @@
 #include <iterator>
 #include <curses.h>
 
-#include <boost/optional.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -363,9 +362,9 @@ int main(int argc, char** argv) {
         calculator.destination = &calculator.params.destination;
         calculator.odTrip      = nullptr;
 
-        if (calculator.params.odTripUuid.is_initialized() && calculator.odTripIndexesByUuid.count(calculator.params.odTripUuid.get()))
+        if (calculator.params.odTripUuid.has_value() && calculator.odTripIndexesByUuid.count(calculator.params.odTripUuid.value()))
         {
-          calculator.odTrip = calculator.odTrips[calculator.odTripIndexesByUuid[calculator.params.odTripUuid.get()]].get();
+          calculator.odTrip = calculator.odTrips[calculator.odTripIndexesByUuid[calculator.params.odTripUuid.value()]].get();
           foundOdTrip = true;
           std::cout << "od trip uuid " << calculator.odTrip->uuid << std::endl;
           std::cout << "dts " << calculator.odTrip->departureTimeSeconds << std::endl;

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/optional.hpp>
 
 #include "point.hpp"
 

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 #include <map>
 #include <math.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/string_generator.hpp>
 #include <boost/algorithm/string.hpp>
@@ -209,11 +209,11 @@ namespace TrRouting
       int destinationNodeIdx;
       bool calculateAllOdTrips;
       bool saveResultToFile;
-      boost::optional<boost::uuids::uuid> scenarioUuid;
-      boost::optional<boost::uuids::uuid> dataSourceUuid;
-      boost::optional<boost::uuids::uuid> odTripUuid;
-      boost::optional<boost::uuids::uuid> startingNodeUuid;
-      boost::optional<boost::uuids::uuid> endingNodeUuid;
+      std::optional<boost::uuids::uuid> scenarioUuid;
+      std::optional<boost::uuids::uuid> dataSourceUuid;
+      std::optional<boost::uuids::uuid> odTripUuid;
+      std::optional<boost::uuids::uuid> startingNodeUuid;
+      std::optional<boost::uuids::uuid> endingNodeUuid;
 
       std::string osrmWalkingPort;
       std::string osrmCyclingPort;

--- a/include/station.hpp
+++ b/include/station.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 #include <string>
 #include <boost/uuid/uuid.hpp>
-#include <boost/optional.hpp>
 
 #include "point.hpp"
 


### PR DESCRIPTION
We were using functions in boost::optional that were only available in recent version of boost,
breaking builds in older distribution. std::optional is available in CXX17 and provided in gcc since
version 5.

This add build requirement on CXX17 and replace all occurance of boost::optional with the std C++ one.

All unit test still pass

Close #111