### PR TITLE
Update the base Dockerfile to use bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim 
+FROM debian:bullseye-slim 
 WORKDIR /source
 # Install dependencies in an intermediate image
 RUN apt-get update && \


### PR DESCRIPTION
Debian Bullseye is now the current stable version.
Also related, the osrm upgrade docker have also (finally!) updated to bullseye