### PR TITLE
csa: Drop csv support in od_trips calculation function

### DIFF
--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -18,7 +18,6 @@ namespace TrRouting
     calculationName                        = "trRouting";
     batchNumber                            = 1;
     batchesCount                           = 1;
-    responseFormat                         = "json";
     saveResultToFile                       = false;
     odTripsSampleRatio                     = 1.0;
     dataSourceUuid.reset();
@@ -572,11 +571,6 @@ namespace TrRouting
       else if (parameterWithValueVector[0] == "calculation_name" || parameterWithValueVector[0] == "name")
       {
         calculationName = parameterWithValueVector[1];
-        continue;
-      }
-      else if (parameterWithValueVector[0] == "file_format" || parameterWithValueVector[0] == "format" || parameterWithValueVector[0] == "response_format" || parameterWithValueVector[0] == "response")
-      {
-        responseFormat = parameterWithValueVector[1];
         continue;
       }
       else if (parameterWithValueVector[0] == "batch")

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -316,7 +316,7 @@ int main(int argc, char** argv) {
 
     if (!response.empty())
     {
-      *serverResponse << "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: application/" << calculator.params.responseFormat << "; charset=utf-8\r\nContent-Length: " << response.length() << "\r\n\r\n" << response;
+      *serverResponse << "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: " << response.length() << "\r\n\r\n" << response;
       return;
     }
 
@@ -398,7 +398,7 @@ int main(int argc, char** argv) {
         std::cerr << "writing file" << std::endl;
         std::ofstream file;
         //file.imbue(std::locale("en_US.UTF8"));
-        file.open(calculator.params.calculationName + "." + calculator.params.responseFormat, std::ios_base::trunc);
+        file.open(calculator.params.calculationName + ".json", std::ios_base::trunc);
         file << response;
         file.close();
       }
@@ -428,7 +428,7 @@ int main(int argc, char** argv) {
       response = "{\"status\": \"error\", \"error\": \"Wrong or malformed query\"}";
     }
 
-    *serverResponse << "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: application/" << calculator.params.responseFormat << "; charset=utf-8\r\nContent-Length: " << response.length() << "\r\n\r\n" << response;
+    *serverResponse << "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: " << response.length() << "\r\n\r\n" << response;
 
   };
 

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -160,7 +160,6 @@ namespace TrRouting
       std::string dataFetcherShortname; // cache, csv or gtfs, only cache is implemented for now
       std::string cacheDirectoryPath;
       std::string calculationName;
-      std::string responseFormat;
 
       CacheFetcher* cacheFetcher;
       GtfsFetcher*  gtfsFetcher;


### PR DESCRIPTION
Fixes #110

For now, support of csv is dropped entirely and only the json response
is returned by the odTripsRouting method. If csv support is required
again in the future, it can easily be generated from the routing
results.