### PR TITLE
Use forward declaration in .h instead of includes in calculator.hpp

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -30,32 +30,7 @@
 #include <limits>
 #include <stdlib.h>
 
-#include "json.hpp"
-#include "toolbox.hpp"
-#include "node.hpp"
-#include "line.hpp"
-#include "trip.hpp"
-#include "point.hpp"
-#include "mode.hpp"
-#include "path.hpp"
-#include "stop.hpp"
-#include "data_source.hpp"
-#include "household.hpp"
-#include "person.hpp"
-#include "od_trip.hpp"
-#include "place.hpp"
-#include "scenario.hpp"
-#include "service.hpp"
-#include "station.hpp"
-#include "block.hpp"
-#include "parameters.hpp"
-#include "routing_result.hpp"
-#include "osrm_fetcher.hpp"
 #include "calculation_time.hpp"
-#include "cache_fetcher.hpp"
-#include "gtfs_fetcher.hpp"
-#include "csv_fetcher.hpp"
-#include "combinations.hpp"
 
 extern std::string consoleRed;
 extern std::string consoleGreen;
@@ -66,6 +41,26 @@ extern std::string consoleResetColor;
 
 namespace TrRouting
 {
+  class Parameters;
+  class RouteParameters;
+  class Mode;
+  class DataSource;
+  class Household;
+  class Person;
+  class OdTrip;
+  class Place;
+  class Agency;
+  class Service;
+  class Station;
+  class Node;
+  class Stop;
+  class Line;
+  class Path;
+  class Scenario;
+  class Trip;
+  class RoutingResult;
+  class AlternativesResult;
+
   // tuple representing a connection: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, lineIndex, blockIndex, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
   using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>;
 

--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -1,6 +1,10 @@
 #include "calculator.hpp"
 #include "constants.hpp"
 #include "routing_result.hpp"
+#include "line.hpp"
+#include "parameters.hpp"
+#include "combinations.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -1,4 +1,7 @@
 #include "calculator.hpp"
+#include "toolbox.hpp"
+#include "parameters.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -1,4 +1,6 @@
 #include "calculator.hpp"
+#include "toolbox.hpp"
+#include "parameters.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -1,6 +1,14 @@
 #include "calculator.hpp"
 #include "constants.hpp"
-#include "json.hpp"
+#include "parameters.hpp"
+#include "node.hpp"
+#include "trip.hpp"
+#include "line.hpp"
+#include "mode.hpp"
+#include "path.hpp"
+#include "agency.hpp"
+#include "routing_result.hpp"
+
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -1,4 +1,22 @@
+#include <boost/uuid/uuid.hpp>
+
 #include "calculator.hpp"
+#include "trip.hpp"
+#include "mode.hpp"
+#include "agency.hpp"
+#include "data_source.hpp"
+#include "node.hpp"
+#include "line.hpp"
+#include "path.hpp"
+#include "scenario.hpp"
+#include "stop.hpp"
+#include "service.hpp"
+#include "station.hpp"
+#include "od_trip.hpp"
+#include "place.hpp"
+#include "household.hpp"
+#include "person.hpp"
+
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -1,6 +1,12 @@
 #include "calculator.hpp"
 #include "toolbox.hpp"
 #include "constants.hpp"
+#include "parameters.hpp"
+#include "path.hpp"
+#include "person.hpp"
+#include "line.hpp"
+#include "trip.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/optimize_journey.cpp
+++ b/connection_scan_algorithm/src/optimize_journey.cpp
@@ -1,4 +1,7 @@
 #include "calculator.hpp"
+#include "trip.hpp"
+#include "parameters.hpp"
+#include "node.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -1,4 +1,6 @@
 #include "calculator.hpp"
+#include "parameters.hpp"
+#include "cache_fetcher.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -1,4 +1,7 @@
 #include "calculator.hpp"
+#include "parameters.hpp"
+#include "trip.hpp"
+#include "osrm_fetcher.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -1,4 +1,6 @@
 #include "calculator.hpp"
+#include "toolbox.hpp"
+#include "parameters.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -1,6 +1,13 @@
 #include "calculator.hpp"
 #include "constants.hpp"
-#include "json.hpp"
+#include "parameters.hpp"
+#include "node.hpp"
+#include "trip.hpp"
+#include "line.hpp"
+#include "mode.hpp"
+#include "path.hpp"
+#include "agency.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {
@@ -52,8 +59,6 @@ namespace TrRouting
       std::vector<int>                                  tripsIdx;
       std::vector<int>                                  inVehicleTravelTimesSeconds; // the in vehicle travel time for each segment
       std::vector<std::tuple<int, int, int, int, int>>  legs; // tuple: tripIdx, lineIdx, pathIdx, start connection index, end connection index
-      nlohmann::json stepJson = {};
-      nlohmann::json nodeJson = {};
 
       Node *   journeyStepNodeDeparture;
       Node *   journeyStepNodeArrival;

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -27,6 +27,7 @@
 #include "calculator.hpp"
 #include "program_options.hpp"
 #include "result_to_v1.hpp"
+#include "routing_result.hpp"
 
 using namespace TrRouting;
 

--- a/include/osrm_fetcher.hpp
+++ b/include/osrm_fetcher.hpp
@@ -15,13 +15,12 @@
 #include <utility>
 #include <cstdlib>
 
-#include "point.hpp"
-#include "node.hpp"
-#include "parameters.hpp"
-#include "client_http.hpp"
-
 namespace TrRouting
 {
+  class Point;
+  class Node;
+  class Parameters;
+
   class OsrmFetcher
   {
 

--- a/src/osrm_fetcher.cpp
+++ b/src/osrm_fetcher.cpp
@@ -1,5 +1,9 @@
 #include "osrm_fetcher.hpp"
 #include "json.hpp"
+#include "point.hpp"
+#include "node.hpp"
+#include "parameters.hpp"
+#include "client_http.hpp"
 
 namespace TrRouting
 {

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -7,6 +7,18 @@
 #include "csa_test_base.hpp"
 #include "csa_route_calculation_test.hpp"
 #include "constants.hpp"
+#include "mode.hpp"
+#include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "agency.hpp"
+#include "service.hpp"
+#include "station.hpp"
+#include "stop.hpp"
+#include "line.hpp"
+#include "path.hpp"
+#include "trip.hpp"
 
 // TODO:
 // Test transferable mode, it has separate code path

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -7,6 +7,18 @@
 #include "csa_test_base.hpp"
 #include "csa_route_calculation_test.hpp"
 #include "constants.hpp"
+#include "mode.hpp"
+#include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "agency.hpp"
+#include "service.hpp"
+#include "station.hpp"
+#include "stop.hpp"
+#include "line.hpp"
+#include "path.hpp"
+#include "trip.hpp"
 
 /**
  * This file covers tests with transfers and requests for alternatives

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 #include "calculator.hpp"
 #include "csa_test_base.hpp"
+#include "constants.hpp"
 #include "node.hpp"
 #include "scenario.hpp"
 #include "agency.hpp"
@@ -13,7 +14,13 @@
 #include "path.hpp"
 #include "point.hpp"
 #include "mode.hpp"
-#include "constants.hpp"
+#include "trip.hpp"
+#include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "station.hpp"
+#include "stop.hpp"
 
 /**
  *  Create a default data set:

--- a/tests/connection_scan_algorithm/csa_test_base.hpp
+++ b/tests/connection_scan_algorithm/csa_test_base.hpp
@@ -4,6 +4,8 @@
 #include "gtest/gtest.h"
 #include "calculator.hpp"
 #include "parameters.hpp"
+#include "routing_result.hpp"
+
 
 inline int getTimeInSeconds(int hour, int minutes = 0, int seconds = 0) { return hour * 3600 + minutes * 60 + seconds; }
 const int MIN_WAITING_TIME{180};

--- a/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
@@ -7,6 +7,18 @@
 #include "csa_test_base.hpp"
 #include "csa_v1_simple_calculation_test.hpp"
 #include "constants.hpp"
+#include "mode.hpp"
+#include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "agency.hpp"
+#include "service.hpp"
+#include "station.hpp"
+#include "stop.hpp"
+#include "line.hpp"
+#include "path.hpp"
+#include "trip.hpp"
 
 /**
  * This file covers accessibility map use cases, where the value of all_nodes is

--- a/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
@@ -7,8 +7,18 @@
 #include "csa_test_base.hpp"
 #include "csa_v1_simple_calculation_test.hpp"
 #include "constants.hpp"
-#include "od_trip.hpp"
+#include "mode.hpp"
 #include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "agency.hpp"
+#include "service.hpp"
+#include "station.hpp"
+#include "stop.hpp"
+#include "line.hpp"
+#include "path.hpp"
+#include "trip.hpp"
 
 /**
  * This file covers od trips use cases, where the value of od_trips is set to 1

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -6,6 +6,21 @@
 #include "calculator.hpp"
 #include "csa_test_base.hpp"
 #include "csa_v1_simple_calculation_test.hpp"
+#include "node.hpp"
+#include "scenario.hpp"
+#include "agency.hpp"
+#include "line.hpp"
+#include "service.hpp"
+#include "path.hpp"
+#include "point.hpp"
+#include "mode.hpp"
+#include "trip.hpp"
+#include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "station.hpp"
+#include "stop.hpp"
 
 // TODO:
 // Test transferable mode, it has separate code path

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -7,6 +7,21 @@
 #include "csa_test_base.hpp"
 #include "csa_v1_simple_calculation_test.hpp"
 #include "constants.hpp"
+#include "node.hpp"
+#include "scenario.hpp"
+#include "agency.hpp"
+#include "line.hpp"
+#include "service.hpp"
+#include "path.hpp"
+#include "point.hpp"
+#include "mode.hpp"
+#include "trip.hpp"
+#include "data_source.hpp"
+#include "household.hpp"
+#include "person.hpp"
+#include "place.hpp"
+#include "station.hpp"
+#include "stop.hpp"
 
 /**
  * This file covers tests with transfers and requests for alternatives


### PR DESCRIPTION
It is a good practice to do so, it avoids including unnecessary headers
in compilation units, it should also decrease compilation times,
especially when make small changes.

Headers are included only in the source files that requires them. This
commit does not significantly reduce compilation time, but the size of
the libcsa.a library has decreased from 107M to 92M.

Also remove a few unnecessary json.hpp includes.