### PR TITLE
Add reasons why there is no routing found

### DIFF
--- a/connection_scan_algorithm/include/result_to_v1.hpp
+++ b/connection_scan_algorithm/include/result_to_v1.hpp
@@ -2,12 +2,12 @@
 #define TR_RESULT_TO_V1_RESPONSE
 
 #include "json.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {
 
   class RouteParameters;
-  class RoutingResult;
 
   /**
    * @brief Convert a result object to a json object for the version 1 trRouting API, as described in docs/API.yml
@@ -15,7 +15,7 @@ namespace TrRouting
   class ResultToV1Response {
   public:
     static nlohmann::json resultToJsonString(RoutingResult& result, RouteParameters& params);
-    static nlohmann::json noRoutingFoundResponse(RouteParameters& params);
+    static nlohmann::json noRoutingFoundResponse(RouteParameters& params, NoRoutingReason noRoutingReason);
   };
 
 }

--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -348,7 +348,7 @@ namespace TrRouting
       return alternatives;
 
     }
-    throw NoRoutingFoundException(NoRoutingFoundException::NO_ROUTING_FOUND);
+    throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
 
   }
 

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -40,7 +40,7 @@ namespace TrRouting
       foundLine = true;
       resultingNodes.push_back(bestEgressNodeIndex);
     } else {
-      throw NoRoutingFoundException(NoRoutingFoundException::NO_ROUTING_FOUND);
+      throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
     }
 
     if (foundLine || params.returnAllNodesResult)

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -117,7 +117,7 @@ namespace TrRouting
 
           accessFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getOrigin(), nodes, params.accessMode, params, parameters.getMaxAccessWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
           if (accessFootpaths.size() == 0) {
-            throw NoRoutingFoundException(NoRoutingFoundException::NO_ACCESS_AT_ORIGIN); 
+            throw NoRoutingFoundException(NoRoutingReason::NO_ACCESS_AT_ORIGIN); 
           }
         }
       }
@@ -187,7 +187,7 @@ namespace TrRouting
         {
           egressFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getDestination(), nodes, params.accessMode, params, parameters.getMaxEgressWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
           if (egressFootpaths.size() == 0) {
-            throw NoRoutingFoundException(NoRoutingFoundException::NO_ACCESS_AT_DESTINATION); 
+            throw NoRoutingFoundException(NoRoutingReason::NO_ACCESS_AT_DESTINATION); 
           }
         }
       }

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -4,6 +4,7 @@
 #include "osrm_fetcher.hpp"
 #include "toolbox.hpp" //MAX_INT
 #include "od_trip.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {
@@ -73,7 +74,7 @@ namespace TrRouting
 
     int j {0};
 
-    if (!params.returnAllNodesResult || departureTimeSeconds >= -1)
+    if (!params.returnAllNodesResult || departureTimeSeconds > -1)
     {
       if (resetAccessPaths)
       {
@@ -115,6 +116,9 @@ namespace TrRouting
             std::cout << "  fetching nodes with osrm with mode " << params.accessMode << std::endl;
 
           accessFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getOrigin(), nodes, params.accessMode, params, parameters.getMaxAccessWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
+          if (accessFootpaths.size() == 0) {
+            throw NoRoutingFoundException(NoRoutingFoundException::NO_ACCESS_AT_ORIGIN); 
+          }
         }
       }
 
@@ -145,7 +149,7 @@ namespace TrRouting
       }
     }
   
-    if (!params.returnAllNodesResult || arrivalTimeSeconds >= -1)
+    if (!params.returnAllNodesResult || arrivalTimeSeconds > -1)
     {
       if (resetAccessPaths)
       {
@@ -182,6 +186,9 @@ namespace TrRouting
         else
         {
           egressFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getDestination(), nodes, params.accessMode, params, parameters.getMaxEgressWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
+          if (egressFootpaths.size() == 0) {
+            throw NoRoutingFoundException(NoRoutingFoundException::NO_ACCESS_AT_DESTINATION); 
+          }
         }
       }
       

--- a/connection_scan_algorithm/src/result_to_v1.cpp
+++ b/connection_scan_algorithm/src/result_to_v1.cpp
@@ -8,6 +8,10 @@
 
 namespace TrRouting
 {
+  const std::string NO_ROUTING_REASON_DEFAULT = "NO_ROUTING_FOUND";
+  const std::string NO_ROUTING_REASON_NO_ACCESS_AT_ORIGIN = "NO_ACCESS_AT_ORIGIN";
+  const std::string NO_ROUTING_REASON_NO_ACCESS_AT_DESTINATION = "NO_ACCESS_AT_DESTINATION";
+
   /**
    * @brief Visitor for the result's steps
    */
@@ -199,7 +203,7 @@ namespace TrRouting
     response = json;
   }
 
- nlohmann::json ResultToV1Response::noRoutingFoundResponse(RouteParameters& params)
+ nlohmann::json ResultToV1Response::noRoutingFoundResponse(RouteParameters& params, NoRoutingReason noRoutingReason)
   {
     nlohmann::json json;
     json["status"]                     = STATUS_NO_ROUTING_FOUND;
@@ -207,6 +211,22 @@ namespace TrRouting
     json["destination"]                = { params.getDestination()->latitude, params.getDestination()->longitude };
     json["departureTime"]              = Toolbox::convertSecondsToFormattedTime(params.getTimeOfTrip());
     json["departureTimeSeconds"]       = params.getTimeOfTrip();
+    std::string reason;
+    switch(noRoutingReason) {
+      case NoRoutingReason::NO_ROUTING_FOUND:
+        reason = NO_ROUTING_REASON_DEFAULT;
+        break;
+      case NoRoutingReason::NO_ACCESS_AT_ORIGIN:
+        reason = NO_ROUTING_REASON_NO_ACCESS_AT_ORIGIN;
+        break;
+      case NoRoutingReason::NO_ACCESS_AT_DESTINATION:
+        reason = NO_ROUTING_REASON_NO_ACCESS_AT_DESTINATION;
+        break;
+      default:
+        reason = NO_ROUTING_REASON_DEFAULT;
+        break;
+    }
+    json["reason"] = reason;
     return json;
   }
 

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -38,7 +38,7 @@ namespace TrRouting
       foundRoute = true;
       resultingNodes.push_back(bestAccessNodeIndex);
     } else {
-      throw NoRoutingFoundException(NoRoutingFoundException::NO_ROUTING_FOUND);
+      throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
     }
 
     if (foundRoute || params.returnAllNodesResult)

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -385,6 +385,8 @@ namespace TrRouting
             departureTime = std::get<connectionIndexes::TIME_DEP>(*reverseConnections[std::get<journeyStepIndexes::FINAL_ENTER_CONNECTION>(reverseAccessJourneysSteps[resultingNodeIndex])].get()) - std::get<connectionIndexes::MIN_WAITING_TIME_SECONDS>(*reverseConnections[std::get<journeyStepIndexes::FINAL_ENTER_CONNECTION>(reverseAccessJourneysSteps[resultingNodeIndex])].get());
             if (arrivalTimeSeconds - departureTime <=  parameters.getMaxTotalTravelTimeSeconds())
             {
+              reachableNodesCount++;
+
               AccessibleNodes node = AccessibleNodes(
                 nodes[resultingNodeIndex].get()->uuid,
                 arrivalTimeSeconds,

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -434,7 +434,7 @@ int main(int argc, char** argv) {
           }
         }
       } catch (NoRoutingFoundException e) {
-          response = ResultToV1Response::noRoutingFoundResponse(routeParams).dump(2);
+          response = ResultToV1Response::noRoutingFoundResponse(routeParams, e.getReason()).dump(2);
       }
 
     }

--- a/docs/API.yml
+++ b/docs/API.yml
@@ -234,6 +234,15 @@ components:
               type: number
               # TODO: Why? it's a no routing response...
               description: Arrival time in seconds
+            reason:
+              type: string
+                enum:
+                  # Generic reason, when not possible to specify more
+                  - NO_ROUTING_FOUND,
+                  # No accessible node at origin
+                  - NO_ACCESS_AT_ORIGIN,
+                  # No accessible node at destination
+                  - NO_ACCESS_AT_DESTINATION
 
     success: # TODO: There's a lot of data returned, document it all, but from the code, not from transition
       allOf:

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -308,6 +308,17 @@ namespace TrRouting
     }
   };
 
+  enum NoRoutingReason
+  {
+    // TODO As the calculator supports more reasons, add more elements to this enum
+    // Generic reason, when not possible to specify more
+    NO_ROUTING_FOUND,
+    // No accessible node at origin
+    NO_ACCESS_AT_ORIGIN,
+    // No accessible node at destination
+    NO_ACCESS_AT_DESTINATION
+  };
+
   /**
    * @brief Exception class thrown when no routing is found
    * 
@@ -315,16 +326,6 @@ namespace TrRouting
   class NoRoutingFoundException : public std::exception
   {
     public:
-      enum NoRoutingReason
-      {
-        // TODO As the calculator supports more reasons, add more elements to this enum
-        // Generic reason, when not possible to specify more
-        NO_ROUTING_FOUND,
-        // No accessible node at origin
-        NO_ACCESS_AT_ORIGIN,
-        // No accessible node at destination
-        NO_ACCESS_AT_DESTINATION
-      };
       NoRoutingFoundException(NoRoutingReason reason_) : std::exception(), reason(reason_) {};
       NoRoutingReason getReason() const { return reason; };
 

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -319,7 +319,11 @@ namespace TrRouting
       {
         // TODO As the calculator supports more reasons, add more elements to this enum
         // Generic reason, when not possible to specify more
-        NO_ROUTING_FOUND
+        NO_ROUTING_FOUND,
+        // No accessible node at origin
+        NO_ACCESS_AT_ORIGIN,
+        // No accessible node at destination
+        NO_ACCESS_AT_DESTINATION
       };
       NoRoutingFoundException(NoRoutingReason reason_) : std::exception(), reason(reason_) {};
       NoRoutingReason getReason() const { return reason; };

--- a/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
@@ -71,9 +71,9 @@ public:
     }
 };
 
-TEST_F(ResultToV1FixtureTest, TestNoRoutingFoundResult)
+TEST_F(ResultToV1FixtureTest, TestNoRoutingFoundResultDefaultReason)
 {
-    nlohmann::json jsonResponse = TrRouting::ResultToV1Response::noRoutingFoundResponse(*testParameters.get());
+    nlohmann::json jsonResponse = TrRouting::ResultToV1Response::noRoutingFoundResponse(*testParameters.get(), TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
 
     TrRouting::Point* origin = testParameters.get()->getOrigin();
     TrRouting::Point* destination = testParameters.get()->getDestination();
@@ -83,6 +83,22 @@ TEST_F(ResultToV1FixtureTest, TestNoRoutingFoundResult)
     ASSERT_EQ(origin->longitude, jsonResponse["origin"][1]);
     ASSERT_EQ(destination->latitude, jsonResponse["destination"][0]);
     ASSERT_EQ(destination->longitude, jsonResponse["destination"][1]);
+    ASSERT_EQ("NO_ROUTING_FOUND", jsonResponse["reason"]);
+}
+
+TEST_F(ResultToV1FixtureTest, TestNoRoutingFoundResultWithReason)
+{
+    nlohmann::json jsonResponse = TrRouting::ResultToV1Response::noRoutingFoundResponse(*testParameters.get(), TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+
+    TrRouting::Point* origin = testParameters.get()->getOrigin();
+    TrRouting::Point* destination = testParameters.get()->getDestination();
+
+    ASSERT_EQ(STATUS_NO_ROUTING_FOUND, jsonResponse["status"]);
+    ASSERT_EQ(origin->latitude, jsonResponse["origin"][0]);
+    ASSERT_EQ(origin->longitude, jsonResponse["origin"][1]);
+    ASSERT_EQ(destination->latitude, jsonResponse["destination"][0]);
+    ASSERT_EQ(destination->longitude, jsonResponse["destination"][1]);
+    ASSERT_EQ("NO_ACCESS_AT_ORIGIN", jsonResponse["reason"]);
 }
 
 TEST_F(ResultToV1FixtureTest, TestSingleCalculationResult)

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -60,7 +60,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoPath)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -88,7 +88,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtOrigin)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -116,7 +116,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtDestination)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -144,7 +144,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseTooEarly)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -314,7 +314,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -346,7 +346,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -381,7 +381,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMaxFirstWaitingTime)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -416,7 +416,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMinWaitingTime)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -451,7 +451,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingTravelTime)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -66,11 +66,39 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoPath)
     }
 }
 
-// Test origin and destination far from network
-TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNode)
+// Test origin far from network
+TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtOrigin)
 {
     TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
         std::make_unique<TrRouting::Point>(45.5349, -73.55478),
+        std::make_unique<TrRouting::Point>(45.54, -73.6146),
+        *scenario,
+        getTimeInSeconds(9, 50),
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MAX_TOTAL_TIME,
+        DEFAULT_MAX_ACCESS_TRAVEL_TIME,
+        DEFAULT_MAX_EGRESS_TRAVEL_TIME,
+        DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
+        DEFAULT_FIRST_WAITING_TIME,
+        false,
+        true
+    );
+
+    try {
+        calculateOd(testParameters);
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
+    } catch (TrRouting::NoRoutingFoundException const & e) {
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+    } catch(...) {
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
+    }
+}
+
+// Test destination far from network
+TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtDestination)
+{
+    TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
+        std::make_unique<TrRouting::Point>(45.5242, -73.5817),
         std::make_unique<TrRouting::Point>(45.5155, -73.56797),
         *scenario,
         getTimeInSeconds(9, 50),
@@ -88,7 +116,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNode)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -286,7 +314,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -318,7 +346,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
         calculateOd(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -222,6 +222,42 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithAlternatives)
     );
 }
 
+// Test a query with alternatives, for a trip with no routing found because too far from network
+TEST_F(SingleTAndACalculationFixtureTests, TripWithNoRoutingAlternatives)
+{
+    int departureTime = getTimeInSeconds(9, 45);
+    int travelTimeInVehicle = 720;
+    // This is where mocking would be interesting. Those were taken from the first run of the test
+    int accessTime = 469;
+    int egressTime = 166;
+    int expectedTransitDepartureTime = getTimeInSeconds(10);
+    int expectedTransferWaitingTime = 300;
+
+    TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
+        std::make_unique<TrRouting::Point>(45.7242, -73.7817),
+        std::make_unique<TrRouting::Point>(45.7541,-73.8186),
+        *scenario,
+        departureTime,
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MAX_TOTAL_TIME,
+        DEFAULT_MAX_ACCESS_TRAVEL_TIME,
+        DEFAULT_MAX_EGRESS_TRAVEL_TIME,
+        DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
+        DEFAULT_FIRST_WAITING_TIME,
+        true,
+        true
+    );
+
+    try {
+        calculateWithAlternatives(testParameters);
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
+    } catch (TrRouting::NoRoutingFoundException const & e) {
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+    } catch(...) {
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
+    }
+}
+
 TrRouting::AlternativesResult SingleTAndACalculationFixtureTests::calculateWithAlternatives(TrRouting::RouteParameters& parameters)
 {
     // TODO: This needs to be called to set some default values that are still part of the global parameters

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -252,7 +252,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithNoRoutingAlternatives)
         calculateWithAlternatives(testParameters);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -457,7 +457,7 @@ void BaseCsaFixtureTests::setUpModes()
     calculator.modes.push_back(mode);
 }
 
-void BaseCsaFixtureTests::assertNoRouting(const TrRouting::NoRoutingFoundException& exception, TrRouting::NoRoutingFoundException::NoRoutingReason expectedReason)
+void BaseCsaFixtureTests::assertNoRouting(const TrRouting::NoRoutingFoundException& exception, TrRouting::NoRoutingReason expectedReason)
 {
     ASSERT_EQ(expectedReason, exception.getReason());
 }

--- a/tests/connection_scan_algorithm/csa_test_base.hpp
+++ b/tests/connection_scan_algorithm/csa_test_base.hpp
@@ -71,7 +71,7 @@ public:
     BaseCsaFixtureTests() : params(TrRouting::Parameters()), calculator(TrRouting::Calculator(params)) {}
     void SetUp();
     // Assert the result returned an exception and that the reason matches the expected reason
-    void assertNoRouting(const TrRouting::NoRoutingFoundException& exception, TrRouting::NoRoutingFoundException::NoRoutingReason expectedReason);
+    void assertNoRouting(const TrRouting::NoRoutingFoundException& exception, TrRouting::NoRoutingReason expectedReason);
     // Asserts the successful result fields, given some easy to provide expected test data
     void assertSuccessResults(TrRouting::RoutingResult& result,
         int origDepartureTime,

--- a/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
@@ -60,6 +60,46 @@ TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQuery)
 
 }
 
+// Test all nodes query from an origin far from the network (origin offsetted)
+TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQueryNoNodeAtOrigin)
+{
+    int departureTime = getTimeInSeconds(9, 45);
+
+    std::vector<std::string> parametersWithValues = initializeParameters();
+    parametersWithValues.push_back("origin=44.5242,-73.5817");
+    parametersWithValues.push_back("departure_time_seconds=" + std::to_string(departureTime));
+
+    try {
+        calculateOd(parametersWithValues);
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
+    } catch (TrRouting::NoRoutingFoundException const & e) {
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+    } catch(...) {
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
+    }
+
+}
+
+// Test all nodes query to a destination far from the network (destination offsetted)
+TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQueryNoNodeAtDestination)
+{
+    int arrivalTime = getTimeInSeconds(9, 45);
+
+    std::vector<std::string> parametersWithValues = initializeParameters();
+    parametersWithValues.push_back("destination=44.5242,-73.5817");
+    parametersWithValues.push_back("arrival_time_seconds=" + std::to_string(arrivalTime));
+
+    try {
+        calculateOd(parametersWithValues);
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
+    } catch (TrRouting::NoRoutingFoundException const & e) {
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
+    } catch(...) {
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
+    }
+
+}
+
 void RouteAccessMapFixtureTests::assertResults(TrRouting::RoutingResult& result,
     int nbReachableNodes)
 {

--- a/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
@@ -45,11 +45,6 @@ public:
 TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQuery)
 {
     int departureTime = getTimeInSeconds(9, 45);
-    int travelTimeInVehicle = 420;
-    // This is where mocking would be interesting. Those were taken from the first run of the test
-    int accessTime = 469;
-    int egressTime = 138;
-    int expectedTransitDepartureTime = getTimeInSeconds(10);
 
     std::vector<std::string> parametersWithValues = initializeParameters();
     parametersWithValues.push_back("origin=45.5242,-73.5817");
@@ -57,6 +52,20 @@ TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQuery)
 
     std::unique_ptr<TrRouting::RoutingResult> result = calculateOd(parametersWithValues);
     assertResults(*result.get(), 5);
+
+}
+
+// Test for an destination near the north2 node
+TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQueryBackward)
+{
+    int arrivalTime = getTimeInSeconds(11, 15);
+
+    std::vector<std::string> parametersWithValues = initializeParameters();
+    parametersWithValues.push_back("destination=45.54,-73.6146");
+    parametersWithValues.push_back("arrival_time_seconds=" + std::to_string(arrivalTime));
+
+    std::unique_ptr<TrRouting::RoutingResult> result = calculateOd(parametersWithValues);
+    assertResults(*result.get(), 6);
 
 }
 

--- a/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
@@ -73,7 +73,7 @@ TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQueryNoNodeAtOrigin)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -93,7 +93,7 @@ TEST_F(RouteAccessMapFixtureTests, SimpleAllNodesQueryNoNodeAtDestination)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -44,7 +44,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoPath)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -62,7 +62,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtOrigin)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -80,7 +80,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtDestination)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -98,7 +98,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseTooEarly)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -223,7 +223,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -246,7 +246,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -272,7 +272,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingMaxFirstWaitingTime)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -298,7 +298,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingMinWaitingTime)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -324,7 +324,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingTravelTime)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -50,11 +50,29 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoPath)
     }
 }
 
-// Test origin and destination far from network
-TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoNode)
+// Test origin far from network
+TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtOrigin)
 {
     std::vector<std::string> parametersWithValues = initializeParameters();
     parametersWithValues.push_back("origin=45.5349,-73.55478");
+    parametersWithValues.push_back("destination=45.54,-73.6146");
+    parametersWithValues.push_back("departure_time_seconds=" + std::to_string(getTimeInSeconds(9, 50)));
+
+    try {
+        calculateOd(parametersWithValues);
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
+    } catch (TrRouting::NoRoutingFoundException const & e) {
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+    } catch(...) {
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
+    }
+}
+
+// Test destination far from network
+TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtDestination)
+{
+    std::vector<std::string> parametersWithValues = initializeParameters();
+    parametersWithValues.push_back("origin=45.5242,-73.5817");
     parametersWithValues.push_back("destination=45.5155,-73.56797");
     parametersWithValues.push_back("departure_time_seconds=" + std::to_string(getTimeInSeconds(9, 50)));
 
@@ -62,7 +80,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingBecauseNoNode)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -205,7 +223,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -228,7 +246,7 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
         calculateOd(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_DESTINATION);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -176,7 +176,7 @@ TEST_F(TAndACalculationFixtureTests, TripWithNoRoutingAlternatives)
         calculateWithAlternatives(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -176,7 +176,7 @@ TEST_F(TAndACalculationFixtureTests, TripWithNoRoutingAlternatives)
         calculateWithAlternatives(parametersWithValues);
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
-        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ROUTING_FOUND);
+        assertNoRouting(e, TrRouting::NoRoutingFoundException::NoRoutingReason::NO_ACCESS_AT_ORIGIN);
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }


### PR DESCRIPTION
This adds the reason to the v1 API for the no_routing_found response.

The supported reasons are no access at origin or no access at destination.