### PR TITLE
Cleanup various include

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -2,33 +2,13 @@
 #define TR_CALCULATOR
 
 #include <string>
-#include <ctime>
-#include <utility>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <sstream>
-#include <iterator>
 #include <vector>
-#include <math.h>
-#include <algorithm>
-#include <random>
-#include <chrono>
-#include <boost/algorithm/string.hpp>
-#include <boost/format.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/ptr_container/ptr_vector.hpp>
-#include <boost/range/adaptor/reversed.hpp>
-//#include <boost/compute.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/filesystem.hpp>
+#include <map>
+#include <memory>
+#include <deque>
+#include <tuple>
+
 #include <boost/uuid/uuid.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <limits>
-#include <stdlib.h>
 
 #include "calculation_time.hpp"
 

--- a/connection_scan_algorithm/include/program_options.hpp
+++ b/connection_scan_algorithm/include/program_options.hpp
@@ -2,7 +2,6 @@
 #define TR_PROGRAM_OPTIONS
 
 #include <string>
-#include <vector>
 
 #include <boost/program_options.hpp>
 

--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "calculator.hpp"
 #include "constants.hpp"
 #include "routing_result.hpp"
@@ -5,6 +7,7 @@
 #include "parameters.hpp"
 #include "combinations.hpp"
 #include "routing_result.hpp"
+#include "point.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -1,6 +1,7 @@
 #include "calculator.hpp"
 #include "toolbox.hpp"
 #include "parameters.hpp"
+#include "node.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -1,3 +1,4 @@
+
 #include "calculator.hpp"
 #include "constants.hpp"
 #include "parameters.hpp"
@@ -8,7 +9,7 @@
 #include "path.hpp"
 #include "agency.hpp"
 #include "routing_result.hpp"
-
+#include "toolbox.hpp" //MAX_INT
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -9,6 +9,7 @@
 #include "line.hpp"
 #include "trip.hpp"
 #include "routing_result.hpp"
+#include "od_trip.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -1,3 +1,5 @@
+#include <random>
+
 #include "calculator.hpp"
 #include "toolbox.hpp"
 #include "constants.hpp"

--- a/connection_scan_algorithm/src/optimize_journey.cpp
+++ b/connection_scan_algorithm/src/optimize_journey.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "calculator.hpp"
 #include "trip.hpp"
 #include "parameters.hpp"

--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -1,5 +1,11 @@
+#include <iostream>
+#include <chrono>
+#include <boost/uuid/string_generator.hpp>
+#include <boost/algorithm/string.hpp>
+
 #include "parameters.hpp"
 #include "node.hpp"
+#include "od_trip.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -2,6 +2,8 @@
 #include "parameters.hpp"
 #include "trip.hpp"
 #include "osrm_fetcher.hpp"
+#include "toolbox.hpp" //MAX_INT
+#include "od_trip.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -1,6 +1,9 @@
+#include <boost/uuid/string_generator.hpp>
+
 #include "calculator.hpp"
 #include "toolbox.hpp"
 #include "parameters.hpp"
+#include "node.hpp"
 
 namespace TrRouting
 {

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -1,4 +1,10 @@
+#include <boost/uuid/string_generator.hpp>
+#include <boost/algorithm/string.hpp>
+
 #include "parameters.hpp"
+#include "toolbox.hpp" //MAX_INT
+#include "scenario.hpp"
+#include "point.hpp"
 
 namespace TrRouting
 {

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -2,38 +2,11 @@
 #define TR_CACHE_FETCHER
 
 #include <string>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
-#include <iterator>
 #include <vector>
-#include <math.h>
-#include <fcntl.h>
+#include <map>
 #include <memory>
 #include <boost/uuid/uuid.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/uuid/nil_generator.hpp>
-#include <boost/uuid/string_generator.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
-//#include <boost/algorithm/string.hpp>
-//#include <boost/property_tree/ptree.hpp>
-//#include <boost/property_tree/json_parser.hpp>
-//#include <boost/tokenizer.hpp>
-//#include <boost/filesystem.hpp>
-//#include <boost/lexical_cast.hpp>
-//#include <boost/asio/ip/tcp.hpp>
-//#include <stdlib.h>
-#include <capnp/message.h>
-#include <capnp/serialize-packed.h>
 
-#include "calculation_time.hpp"
-
-//#include "tuple_boost_serialize.hpp"
-#include "toolbox.hpp"
-#include "parameters.hpp"
 #include "agency.hpp"
 #include "line.hpp"
 #include "node.hpp"
@@ -53,6 +26,8 @@
 
 namespace TrRouting
 {
+
+  class Parameters;
   
   class CacheFetcher
   {

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <math.h>
 #include <fcntl.h>
+#include <memory>
 #include <boost/uuid/uuid.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -2,26 +2,10 @@
 #define TR_PARAMETERS
 
 #include <string>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
-#include <iterator>
-#include <chrono>
 #include <vector>
 #include <map>
-#include <math.h>
 #include <optional>
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/string_generator.hpp>
-#include <boost/algorithm/string.hpp>
-
-#include "point.hpp"
-#include "toolbox.hpp"
-#include "od_trip.hpp"
-#include "scenario.hpp"
-#include "node.hpp"
 
 namespace TrRouting
 {
@@ -30,6 +14,10 @@ namespace TrRouting
   class CacheFetcher;
   class GtfsFetcher;
   class CsvFetcher;
+  class Point;
+  class OdTrip;
+  class Scenario;
+  class Node;
 
   class ParameterException : public std::exception
   {

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -7,11 +7,10 @@
 #include <stdlib.h>
 #include "routing_result_visitor.hpp"
 #include "json.hpp"
+#include "point.hpp" //Not using a forward declaration, as we use it more directly, see issue #129
 
 namespace TrRouting
 {
-  class Point;
-
   // TODO These enums are used temporarily, while we need the class hierarchy to be able to determine which type is returned when dynamic cast is necessary
   enum result_type { SINGLE_CALCULATION, ALTERNATIVES, ALL_NODES };
   enum result_step_type { WALKING, BOARDING, UNBOARDING };

--- a/src/agencies_cache_fetcher.cpp
+++ b/src/agencies_cache_fetcher.cpp
@@ -5,7 +5,13 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
+#include <boost/uuid/nil_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
+
+#include <capnp/message.h>
+#include <capnp/serialize-packed.h>
 
 #include "cache_fetcher.hpp"
 #include "agency.hpp"

--- a/src/cache_fetcher.cpp
+++ b/src/cache_fetcher.cpp
@@ -1,4 +1,8 @@
+#include <fstream>
+#include <fcntl.h>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
+#include "parameters.hpp"
 
 namespace TrRouting
 {

--- a/src/data_sources_cache_fetcher.cpp
+++ b/src/data_sources_cache_fetcher.cpp
@@ -5,8 +5,10 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "data_source.hpp"
 #include "capnp/dataSourceCollection.capnp.h"

--- a/src/households_cache_fetcher.cpp
+++ b/src/households_cache_fetcher.cpp
@@ -5,14 +5,15 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "household.hpp"
 #include "point.hpp"
 #include "capnp/householdCollection.capnp.h"
 #include "capnp/household.capnp.h"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -5,12 +5,13 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "line.hpp"
 #include "capnp/lineCollection.capnp.h"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/nodes_cache_fetcher.cpp
+++ b/src/nodes_cache_fetcher.cpp
@@ -6,15 +6,16 @@
 #include <vector>
 #include <numeric>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "node.hpp"
 #include "point.hpp"
 #include "capnp/nodeCollection.capnp.h"
 #include "capnp/node.capnp.h"
 #include "calculation_time.hpp"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/od_trips_cache_fetcher.cpp
+++ b/src/od_trips_cache_fetcher.cpp
@@ -4,13 +4,14 @@
 
 #include <string>
 #include <vector>
-
+#include <fcntl.h>
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "od_trip.hpp"
 #include "point.hpp"
 #include "capnp/odTripCollection.capnp.h"
 #include "capnp/odTrip.capnp.h"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -5,13 +5,14 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "path.hpp"
 #include "capnp/pathCollection.capnp.h"
 #include "json.hpp"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/persons_cache_fetcher.cpp
+++ b/src/persons_cache_fetcher.cpp
@@ -4,13 +4,14 @@
 
 #include <string>
 #include <vector>
-
+#include <fcntl.h>
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "person.hpp"
 #include "point.hpp"
 #include "capnp/personCollection.capnp.h"
 #include "capnp/person.capnp.h"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/places_cache_fetcher.cpp
+++ b/src/places_cache_fetcher.cpp
@@ -4,13 +4,14 @@
 
 #include <string>
 #include <vector>
-
+#include <fcntl.h>
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "place.hpp"
 #include "point.hpp"
 #include "capnp/placeCollection.capnp.h"
 #include "capnp/place.capnp.h"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -5,12 +5,14 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <boost/uuid/nil_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "scenario.hpp"
 #include "capnp/scenarioCollection.capnp.h"
-//#include "toolbox.hpp"
 
 namespace TrRouting
 {

--- a/src/services_cache_fetcher.cpp
+++ b/src/services_cache_fetcher.cpp
@@ -5,8 +5,11 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/nil_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "service.hpp"
 #include "capnp/serviceCollection.capnp.h"

--- a/src/stations_cache_fetcher.cpp
+++ b/src/stations_cache_fetcher.cpp
@@ -5,8 +5,10 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
-
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 #include "cache_fetcher.hpp"
 #include "station.hpp"
 #include "point.hpp"

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -5,7 +5,10 @@
 #include <string>
 #include <vector>
 #include <errno.h>
+#include <fcntl.h>
 #include <kj/exception.h>
+#include <boost/uuid/string_generator.hpp>
+#include <capnp/serialize-packed.h>
 
 #include "cache_fetcher.hpp"
 #include "trip.hpp"

--- a/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <experimental/filesystem>
+#include <boost/uuid/string_generator.hpp>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "routing_result.hpp"
@@ -9,6 +10,7 @@
 #include "toolbox.hpp"
 #include "point.hpp"
 #include "parameters.hpp"
+#include "scenario.hpp"
 
 namespace fs = std::experimental::filesystem;
 

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -19,6 +19,8 @@
 #include "line.hpp"
 #include "path.hpp"
 #include "trip.hpp"
+#include "od_trip.hpp"
+#include "node.hpp"
 
 // TODO:
 // Test transferable mode, it has separate code path

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.hpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.hpp
@@ -6,6 +6,7 @@
 #include "parameters.hpp"
 #include "csa_test_base.hpp"
 #include "scenario.hpp"
+#include "toolbox.hpp" //MAX_INT
 
 // This fixture tests the parameters from the single route parameters values
 class SingleRouteCalculationFixtureTests : public BaseCsaFixtureTests

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -19,6 +19,8 @@
 #include "line.hpp"
 #include "path.hpp"
 #include "trip.hpp"
+#include "od_trip.hpp"
+#include "node.hpp"
 
 /**
  * This file covers tests with transfers and requests for alternatives

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -21,6 +21,7 @@
 #include "place.hpp"
 #include "station.hpp"
 #include "stop.hpp"
+#include "od_trip.hpp"
 
 /**
  *  Create a default data set:

--- a/tests/connection_scan_algorithm/csa_test_base.hpp
+++ b/tests/connection_scan_algorithm/csa_test_base.hpp
@@ -1,6 +1,8 @@
 #ifndef _CSA_TEST_H
 #define _CSA_TEST_H
 
+#include <boost/uuid/string_generator.hpp>
+
 #include "gtest/gtest.h"
 #include "calculator.hpp"
 #include "parameters.hpp"

--- a/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_access_map_test.cpp
@@ -19,6 +19,8 @@
 #include "line.hpp"
 #include "path.hpp"
 #include "trip.hpp"
+#include "od_trip.hpp"
+#include "node.hpp"
 
 /**
  * This file covers accessibility map use cases, where the value of all_nodes is

--- a/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
@@ -19,6 +19,8 @@
 #include "line.hpp"
 #include "path.hpp"
 #include "trip.hpp"
+#include "od_trip.hpp"
+#include "node.hpp"
 
 /**
  * This file covers od trips use cases, where the value of od_trips is set to 1

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -21,6 +21,7 @@
 #include "place.hpp"
 #include "station.hpp"
 #include "stop.hpp"
+#include "od_trip.hpp"
 
 // TODO:
 // Test transferable mode, it has separate code path

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -22,6 +22,7 @@
 #include "place.hpp"
 #include "station.hpp"
 #include "stop.hpp"
+#include "od_trip.hpp"
 
 /**
  * This file covers tests with transfers and requests for alternatives

--- a/tests/connection_scan_algorithm/route_parameters_test.cpp
+++ b/tests/connection_scan_algorithm/route_parameters_test.cpp
@@ -1,11 +1,14 @@
 #include <errno.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/string_generator.hpp>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
 #include "parameters_test.hpp"
 #include "scenario.hpp"
+#include "point.hpp"
+#include "toolbox.hpp" //MAX_INT
 
 const std::string EMPTY_SCENARIO_UUID = "acdcef12-1111-2222-3333-444455558888";
 


### PR DESCRIPTION
Did a bunch of clean up in the most frequent use include files. 
(git grep -h "#include" | sort | uniq -c | sort -n)
     24 #include "calculator.hpp"
     33 #include "cache_fetcher.hpp"
     45 #include "parameters.hpp"

This is saving about 20%-25% build time: 
Before: 
real	3m31,590s
user	3m15,584s
sys	0m15,681s

After:
real	2m41,266s
user	2m29,484s
sys	0m11,691s

Also saving a little bit over 2M in the size of the resulting binary. 

Issue #126 