### PR TITLE
csa: Add no service at origin and destination no routing reason

### DIFF
--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -2,6 +2,7 @@
 #include "toolbox.hpp"
 #include "parameters.hpp"
 #include "node.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {
@@ -178,7 +179,11 @@ namespace TrRouting
 
     if (params.debugDisplay)
       std::cerr << "-- " << reachableConnectionsCount << " forward connections parsed on " << connectionsCount << std::endl;
-    
+
+    if (!params.returnAllNodesResult && reachableConnectionsCount == 0) {
+      throw NoRoutingFoundException(NoRoutingReason::NO_SERVICE_FROM_ORIGIN);
+    }
+
     int egressNodeArrivalTime {-1};
     int egressExitConnection  {-1};
     int egressTravelTime      {-1};

--- a/connection_scan_algorithm/src/result_to_v1.cpp
+++ b/connection_scan_algorithm/src/result_to_v1.cpp
@@ -11,6 +11,8 @@ namespace TrRouting
   const std::string NO_ROUTING_REASON_DEFAULT = "NO_ROUTING_FOUND";
   const std::string NO_ROUTING_REASON_NO_ACCESS_AT_ORIGIN = "NO_ACCESS_AT_ORIGIN";
   const std::string NO_ROUTING_REASON_NO_ACCESS_AT_DESTINATION = "NO_ACCESS_AT_DESTINATION";
+  const std::string NO_ROUTING_REASON_NO_SERVICE_FROM_ORIGIN = "NO_SERVICE_FROM_ORIGIN";
+  const std::string NO_ROUTING_REASON_NO_SERVICE_TO_DESTINATION = "NO_SERVICE_TO_DESTINATION";
 
   /**
    * @brief Visitor for the result's steps
@@ -221,6 +223,12 @@ namespace TrRouting
         break;
       case NoRoutingReason::NO_ACCESS_AT_DESTINATION:
         reason = NO_ROUTING_REASON_NO_ACCESS_AT_DESTINATION;
+        break;
+      case NoRoutingReason::NO_SERVICE_FROM_ORIGIN:
+        reason = NO_ROUTING_REASON_NO_SERVICE_FROM_ORIGIN;
+        break;
+      case NoRoutingReason::NO_SERVICE_TO_DESTINATION:
+        reason = NO_ROUTING_REASON_NO_SERVICE_TO_DESTINATION;
         break;
       default:
         reason = NO_ROUTING_REASON_DEFAULT;

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -4,6 +4,7 @@
 #include "toolbox.hpp"
 #include "parameters.hpp"
 #include "node.hpp"
+#include "routing_result.hpp"
 
 namespace TrRouting
 {
@@ -200,6 +201,10 @@ namespace TrRouting
     
     if (params.debugDisplay)
       std::cerr << "-- " << reachableConnectionsCount << " reverse connections parsed on " << connectionsCount << std::endl;
+
+    if (!params.returnAllNodesResult && reachableConnectionsCount == 0) {
+      throw NoRoutingFoundException(NoRoutingReason::NO_SERVICE_TO_DESTINATION);
+    }
 
     int accessNodeDepartureTime                    {-1};
     int accessEnterConnection                      {-1};

--- a/docs/API.yml
+++ b/docs/API.yml
@@ -243,6 +243,10 @@ components:
                   - NO_ACCESS_AT_ORIGIN,
                   # No accessible node at destination
                   - NO_ACCESS_AT_DESTINATION
+                  # There is no service from origin with the query parameters
+                  - NO_SERVICE_FROM_ORIGIN,
+                  # There is no service to destination with the query parameters
+                  - NO_SERVICE_TO_DESTINATION
 
     success: # TODO: There's a lot of data returned, document it all, but from the code, not from transition
       allOf:

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -316,7 +316,11 @@ namespace TrRouting
     // No accessible node at origin
     NO_ACCESS_AT_ORIGIN,
     // No accessible node at destination
-    NO_ACCESS_AT_DESTINATION
+    NO_ACCESS_AT_DESTINATION,
+    // There is no service from origin with the query parameters
+    NO_SERVICE_FROM_ORIGIN,
+    // There is no service to destination with the query parameters
+    NO_SERVICE_TO_DESTINATION
   };
 
   /**


### PR DESCRIPTION
In forward and reverse calculation, throw an exception when there are no
reachable connection from origin or destination.

Add those reasons to the API.

Add unit tests for the various cases.