### PR TITLE
Add status to odTrips response

### DIFF
--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -406,6 +406,7 @@ namespace TrRouting
       json["pathProfiles"] = pathProfilesJson;
 
     }
+    json["status"] = STATUS_SUCCESS;
     return json.dump(2);
 
   }


### PR DESCRIPTION
For coherence with other result types, the od trip routing results
should also have a status field in the main response.