### PR TITLE
Always build benchmark but conditionally run them

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,13 +3,8 @@ libgtest_la_SOURCES = ../googletest/googletest/src/gtest-all.cc
 libgtest_la_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest
 libgtest_la_LDFLAGS = -pthread
 
-if RUN_BENCHMARK
-MAYBE_BENCHMARK = benchmark_csa
-else
-MAYBE_BENCHMARK =
-endif
-
 SUBDIRS = . \
           cache_fetch \
-          connection_scan_algorithm $(MAYBE_BENCHMARK)
+          connection_scan_algorithm \
+          benchmark_csa
 

--- a/tests/benchmark_csa/Makefile.am
+++ b/tests/benchmark_csa/Makefile.am
@@ -27,6 +27,11 @@ gtest_LDFLAGS = -no-pie -pthread -std=c++17 -lstdc++fs
 
 gtest_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread -std=c++17 -lstdc++fs
 
+if RUN_BENCHMARK
 TESTS = gtest
+else
+TESTS =
+endif
+
 
 


### PR DESCRIPTION
So instead of fully gatting out the build of the benchmark with --enable-benchmark in make check,
run only gate out the running of the tests