### PR TITLE
Add -f flag when cleaning up capnp files

### DIFF
--- a/include/capnp/Makefile.am
+++ b/include/capnp/Makefile.am
@@ -4,7 +4,7 @@ SUFFIXES = .capnp .capnp.h
 	$(CAPNP_BIN) compile -oc++ $<
 
 clean-local:
-	rm *.capnp.h *.capnp.c++
+	rm -f *.capnp.h *.capnp.c++
 
 # TODO we might need to distribute those headers and change the nodist here
 nodist_include_HEADERS = agencyCollection.capnp.h \


### PR DESCRIPTION
We need to rm -f the capnp file, so that the make clean does not fail if the file
where already erased