### PR TITLE
don't include project shortname in custom cache

### DIFF
--- a/src/cache_fetcher.cpp
+++ b/src/cache_fetcher.cpp
@@ -46,15 +46,17 @@ namespace TrRouting
     if (!params.cacheDirectoryPath.empty()) {
       filePath += params.cacheDirectoryPath + "/";
     }
-    if (!params.projectShortname.empty()) {
+    else if (!params.projectShortname.empty()) {
       filePath += params.projectShortname + "/";
     }
     if (customPath.empty())
     {
+      std::cout << "reading " << (filePath + cacheFilePath) << " cache file" << std::endl;
       return filePath + cacheFilePath;
     }
     else
     {
+      std::cout << "reading " << (filePath + customPath + "/" + cacheFilePath) << " cache file" << std::endl;
       return filePath + customPath + "/" + cacheFilePath;
     }
   }

--- a/tests/cache_fetch/cache_fetcher_test.cpp
+++ b/tests/cache_fetch/cache_fetcher_test.cpp
@@ -19,15 +19,15 @@ TEST_F(CacheFetcherFixtureTests, TestGetFilePath)
     filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, VALID_CUSTOM_PATH);
     EXPECT_STREQ(filePath.c_str(), (VALID_CUSTOM_PATH + '/' + CACHE_FILE).c_str());
 
+    // Put all parameters
+    params.projectShortname = PROJECT_NAME;
+    filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
+    EXPECT_STREQ(filePath.c_str(), (PROJECT_NAME + '/' + CACHE_FILE).c_str());
+
     // Omit the project name in params
     params.cacheDirectoryPath = relativeCacheDir;
     filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
     EXPECT_STREQ(filePath.c_str(), (relativeCacheDir + '/' + CACHE_FILE).c_str());
-
-    // Put all parameters
-    params.projectShortname = PROJECT_NAME;
-    filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
-    EXPECT_STREQ(filePath.c_str(), (relativeCacheDir + '/' + PROJECT_NAME + '/' + CACHE_FILE).c_str());
 
     // Omit the cache directory path
     params.cacheDirectoryPath = "";


### PR DESCRIPTION
when providing a custom cache directory path, we should not add the project shortname to the path, because it should be included if needed in the custom path, this fix problem with Transition sending custom paths for simulations