### PR TITLE
benchmark: Fix path to cache

### DIFF
--- a/tests/benchmark_csa/benchmark_CSA_test.cpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.cpp
@@ -61,8 +61,7 @@ public:
   // Initialize calculator and parameters. Open the result files and add headers
   static void SetUpTestSuite()
   {
-    algorithmParams.projectShortname = "demo_transition";
-    algorithmParams.cacheDirectoryPath = "cache";
+    algorithmParams.cacheDirectoryPath = "cache/demo_transition";
     algorithmParams.dataFetcherShortname = "cache";
     algorithmParams.osrmWalkingPort = "5000";
     algorithmParams.osrmWalkingHost = "localhost"; //"http://localhost";


### PR DESCRIPTION
Fixes #148

The relation between cachePath and project name has changed in commit
0333dc98599b0ec917e35841646ed6fd284d6ec2 so when setting the cache
directory, the projectName is not used. The benchmark just sets the
cache path.