### PR TITLE
Clean up std::filesystem usage

### DIFF
--- a/tests/benchmark_csa/Makefile.am
+++ b/tests/benchmark_csa/Makefile.am
@@ -23,9 +23,9 @@ gtest_SOURCES = gtest.cpp \
 
 gtest_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 
-gtest_LDFLAGS = -no-pie -pthread -std=c++17 -lstdc++fs
+gtest_LDFLAGS = -no-pie -pthread
 
-gtest_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread -std=c++17 -lstdc++fs
+gtest_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread
 
 if RUN_BENCHMARK
 TESTS = gtest

--- a/tests/cache_fetch/Makefile.am
+++ b/tests/cache_fetch/Makefile.am
@@ -20,9 +20,9 @@ gtest_SOURCES = gtest.cpp \
 
 gtest_LDADD = $(top_srcdir)/tests/libgtest.la
 
-gtest_LDFLAGS = -pthread -std=c++17 -lstdc++fs
+gtest_LDFLAGS = -pthread
 
-gtest_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread -std=c++17 -lstdc++fs
+gtest_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread 
 
 TESTS = gtest
 

--- a/tests/cache_fetch/agencies_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/agencies_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "agency.hpp"
 #include "capnp/agencyCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class AgencyCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/data_sources_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/data_sources_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "data_source.hpp"
 #include "capnp/dataSourceCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class DataSourceCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/households_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/households_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "household.hpp"
 #include "capnp/household.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class HouseholdCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/lines_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/lines_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "line.hpp"
 #include "capnp/lineCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class LineCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/nodes_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/nodes_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -9,7 +9,7 @@
 #include "capnp/nodeCollection.capnp.h"
 #include "capnp/node.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class NodeCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -7,7 +7,7 @@
 #include "cache_fetcher_test.hpp"
 #include "od_trip.hpp"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class OdTripCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "path.hpp"
 #include "capnp/pathCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class PathCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/persons_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/persons_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "person.hpp"
 #include "capnp/person.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class PersonCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/places_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/places_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -7,7 +7,7 @@
 #include "cache_fetcher_test.hpp"
 #include "place.hpp"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class PlaceCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "scenario.hpp"
 #include "capnp/scenarioCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class ScenarioCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -11,7 +11,7 @@
 #include "block.hpp"
 #include "capnp/line.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class ScheduleCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/services_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/services_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "service.hpp"
 #include "capnp/serviceCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class ServiceCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/cache_fetch/stations_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/stations_cache_fetcher_test.cpp
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
 #include "parameters.hpp"
@@ -8,7 +8,7 @@
 #include "station.hpp"
 #include "capnp/stationCollection.capnp.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class StationCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {

--- a/tests/connection_scan_algorithm/Makefile.am
+++ b/tests/connection_scan_algorithm/Makefile.am
@@ -16,8 +16,8 @@ csa_test_SOURCES = gtest.cpp \
 
 csa_test_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 
-csa_test_LDFLAGS = -no-pie -pthread -std=c++17 -lstdc++fs
+csa_test_LDFLAGS = -no-pie -pthread
 
-csa_test_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread -std=c++17 -lstdc++fs
+csa_test_CPPFLAGS = -I$(top_srcdir)/googletest/googletest/include -I$(top_srcdir)/googletest/googletest -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/include -pthread
 
 TESTS = csa_test

--- a/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
@@ -1,5 +1,4 @@
 #include <errno.h>
-#include <experimental/filesystem>
 #include <boost/uuid/string_generator.hpp>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
@@ -11,8 +10,6 @@
 #include "point.hpp"
 #include "parameters.hpp"
 #include "scenario.hpp"
-
-namespace fs = std::experimental::filesystem;
 
 class ResultToV1FixtureTest : public ::testing::Test
 {


### PR DESCRIPTION
Use std library instead of the experimental one
and 
clean unncessary link flags. 
#147 