### PR TITLE
Remove projet shortname from TrRouting

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -64,7 +64,6 @@ namespace TrRouting
     };
 
     std::map<std::string, int> benchmarking;
-    std::string projectShortname;
 
     Calculator(Parameters& theParams);
 

--- a/connection_scan_algorithm/include/program_options.hpp
+++ b/connection_scan_algorithm/include/program_options.hpp
@@ -13,7 +13,6 @@ namespace TrRouting
   public:
     
 
-    std::string projectShortname;
     std::string cachePath;
     int         port;
     bool        debug;

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -23,7 +23,6 @@ namespace TrRouting
 {
 
   Calculator::Calculator(Parameters& theParams) :
-    projectShortname(""),
     params(theParams),
     odTrip(nullptr),
     algorithmCalculationTime(CalculationTime()),

--- a/connection_scan_algorithm/src/program_options.cpp
+++ b/connection_scan_algorithm/src/program_options.cpp
@@ -17,8 +17,6 @@ namespace TrRouting {
     options.add_options()
       ("cachePath",                                         boost::program_options::value<std::string>()->default_value("cache"), "cache path");
     options.add_options()
-      ("project,projectShortname",                          boost::program_options::value<std::string>()->default_value("demo_transition"), "project shortname (shortname of the project to use or data to use)");
-    options.add_options()
       ("osrmPort,osrmWalkPort,osrmWalkingPort",             boost::program_options::value<std::string>()->default_value("5000"), "osrm walking port");
     options.add_options()
       ("osrmCyclingPort",                                   boost::program_options::value<std::string>()->default_value("8000"), "osrm cycling port");
@@ -42,7 +40,6 @@ namespace TrRouting {
     debug                = false;
     dataFetcherShortname = "cache";
     cachePath            = "cache";
-    projectShortname     = "demo_transition";
     osrmWalkingPort      = "5000";
     osrmCyclingPort      = "8000";
     osrmDrivingPort      = "7000";
@@ -69,14 +66,6 @@ namespace TrRouting {
     else if (variablesMap.count("data") == 1)
     {
       dataFetcherShortname = variablesMap["data"].as<std::string>();
-    }
-    if(variablesMap.count("projectShortname") == 1)
-    {
-      projectShortname = variablesMap["projectShortname"].as<std::string>();
-    }
-    else if(variablesMap.count("project") == 1)
-    {
-      projectShortname = variablesMap["project"].as<std::string>();
     }
     if(variablesMap.count("cachePath") == 1)
     {

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -64,9 +64,8 @@ int main(int argc, char** argv) {
   Parameters algorithmParams;
 
   // setup program options:
-  spdlog::info("Starting transit routing on port {} for the project: {}", programOptions.port, programOptions.projectShortname);
+  spdlog::info("Starting transit routing on port {} for the data: {}", programOptions.port, programOptions.cachePath);
   
-  algorithmParams.projectShortname       = programOptions.projectShortname;
   algorithmParams.cacheDirectoryPath     = programOptions.cachePath;
   algorithmParams.dataFetcherShortname   = programOptions.dataFetcherShortname;
   algorithmParams.osrmWalkingPort        = programOptions.osrmWalkingPort;

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -35,9 +35,6 @@ namespace TrRouting
   public:
     
     CacheFetcher() {}
-    CacheFetcher(std::string projectShortname) {
-      
-    }
     
     template<class T>
 

--- a/include/osrm_fetcher.hpp
+++ b/include/osrm_fetcher.hpp
@@ -18,9 +18,6 @@ namespace TrRouting
 
   public:
     OsrmFetcher() {}
-    OsrmFetcher(std::string projectShortname)
-    {
-    }
 
     static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
 

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -142,7 +142,6 @@ namespace TrRouting
 
     public:
 
-      std::string projectShortname;
       std::string dataFetcherShortname; // cache, csv or gtfs, only cache is implemented for now
       std::string cacheDirectoryPath;
       std::string calculationName;

--- a/src/cache_fetcher.cpp
+++ b/src/cache_fetcher.cpp
@@ -47,9 +47,6 @@ namespace TrRouting
     if (!params.cacheDirectoryPath.empty()) {
       filePath += params.cacheDirectoryPath + "/";
     }
-    else if (!params.projectShortname.empty()) {
-      filePath += params.projectShortname + "/";
-    }    
     if (customPath.empty())
     {
       filePath += cacheFilePath;

--- a/tests/cache_fetch/cache_fetcher_test.cpp
+++ b/tests/cache_fetch/cache_fetcher_test.cpp
@@ -19,11 +19,6 @@ TEST_F(CacheFetcherFixtureTests, TestGetFilePath)
     filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, VALID_CUSTOM_PATH);
     EXPECT_STREQ(filePath.c_str(), (VALID_CUSTOM_PATH + '/' + CACHE_FILE).c_str());
 
-    // Put all parameters
-    params.projectShortname = PROJECT_NAME;
-    filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
-    EXPECT_STREQ(filePath.c_str(), (PROJECT_NAME + '/' + CACHE_FILE).c_str());
-
     // Omit the project name in params
     params.cacheDirectoryPath = relativeCacheDir;
     filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
@@ -32,7 +27,7 @@ TEST_F(CacheFetcherFixtureTests, TestGetFilePath)
     // Omit the cache directory path
     params.cacheDirectoryPath = "";
     filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
-    EXPECT_STREQ(filePath.c_str(), (PROJECT_NAME + '/' + CACHE_FILE).c_str());
+    EXPECT_STREQ(filePath.c_str(), (CACHE_FILE).c_str());
 }
 
 TEST_F(CacheFetcherFixtureTests, TestFileExists)

--- a/tests/cache_fetch/cache_fetcher_test.hpp
+++ b/tests/cache_fetch/cache_fetcher_test.hpp
@@ -24,7 +24,7 @@ protected:
 public:
     void SetUp() 
     {
-        params.projectShortname = PROJECT_NAME; 
+        params.cacheDirectoryPath = PROJECT_NAME;
     }
 };
 


### PR DESCRIPTION
The short name was linked to Transition. In reality, TrRouting only need to
know its data location.
    
 Closes: #149

(It's build on top of #155 )
