### PR TITLE
Move OSRM related parameters out of the Parameters class

### DIFF
--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -114,7 +114,7 @@ namespace TrRouting
         {
           spdlog::debug("  fetching nodes with osrm with mode {}", params.accessMode);
 
-          accessFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getOrigin(), nodes, params.accessMode, params, parameters.getMaxAccessWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
+          accessFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getOrigin(), nodes, params.accessMode, parameters.getMaxAccessWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
           if (accessFootpaths.size() == 0) {
             accessFootpathOk = false;
           }
@@ -180,7 +180,7 @@ namespace TrRouting
         }
         else
         {
-          egressFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getDestination(), nodes, params.accessMode, params, parameters.getMaxEgressWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
+          egressFootpaths = std::move(OsrmFetcher::getAccessibleNodesFootpathsFromPoint(*parameters.getDestination(), nodes, params.accessMode, parameters.getMaxEgressWalkingTravelTimeSeconds(), params.walkingSpeedMetersPerSecond));
           if (egressFootpaths.size() == 0) {
             egressFootpathOk = false;
           }

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -25,6 +25,7 @@
 #include "program_options.hpp"
 #include "result_to_v1.hpp"
 #include "routing_result.hpp"
+#include "osrm_fetcher.hpp"
 
 using namespace TrRouting;
 
@@ -68,12 +69,12 @@ int main(int argc, char** argv) {
   
   algorithmParams.cacheDirectoryPath     = programOptions.cachePath;
   algorithmParams.dataFetcherShortname   = programOptions.dataFetcherShortname;
-  algorithmParams.osrmWalkingPort        = programOptions.osrmWalkingPort;
-  algorithmParams.osrmCyclingPort        = programOptions.osrmCyclingPort;
-  algorithmParams.osrmDrivingPort        = programOptions.osrmDrivingPort;
-  algorithmParams.osrmWalkingHost        = programOptions.osrmWalkingHost;
-  algorithmParams.osrmCyclingHost        = programOptions.osrmCyclingHost;
-  algorithmParams.osrmDrivingHost        = programOptions.osrmDrivingHost;
+  OsrmFetcher::osrmWalkingPort        = programOptions.osrmWalkingPort;
+  OsrmFetcher::osrmCyclingPort        = programOptions.osrmCyclingPort;
+  OsrmFetcher::osrmDrivingPort        = programOptions.osrmDrivingPort;
+  OsrmFetcher::osrmWalkingHost        = programOptions.osrmWalkingHost;
+  OsrmFetcher::osrmCyclingHost        = programOptions.osrmCyclingHost;
+  OsrmFetcher::osrmDrivingHost        = programOptions.osrmDrivingHost;
 
   if (programOptions.debug) {
     spdlog::set_level(spdlog::level::debug);

--- a/include/osrm_fetcher.hpp
+++ b/include/osrm_fetcher.hpp
@@ -11,25 +11,32 @@ namespace TrRouting
 {
   class Point;
   class Node;
-  class Parameters;
 
   class OsrmFetcher
   {
 
   public:
-    OsrmFetcher() {}
+    //TODO Eventually, this data should be private to an instance, but for now all use case are static
+    static std::string osrmWalkingPort;
+    static std::string osrmCyclingPort;
+    static std::string osrmDrivingPort;
+    static std::string osrmWalkingHost;
+    static std::string osrmCyclingHost;
+    static std::string osrmDrivingHost;
 
-    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
+    //TODO This should be managed outside of the osrm_fetcher, with a dedicated data fetcher
+    static bool birdDistanceAccessibilityEnabled; // true if the accessibility information is obtained using bird distances instead of osrm
+
+    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
 
   protected:
-    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
-    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, Parameters &params, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
+    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
+    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
 
     static std::tuple<float, float> calculateLengthOfOneDegree(const Point &point);
     static float calculateMaxDistanceSquared(int maxWalkingTravelTime, float walkingSpeed);
     static float calculateNodeDistanceSquared(const Point *node, const Point &point, const std::tuple<float, float> &lengthOfOneDegree);
   };
-
 }
 
 #endif // TR_OSRM_FETCHER

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -191,14 +191,6 @@ namespace TrRouting
       std::optional<boost::uuids::uuid> startingNodeUuid;
       std::optional<boost::uuids::uuid> endingNodeUuid;
 
-      std::string osrmWalkingPort;
-      std::string osrmCyclingPort;
-      std::string osrmDrivingPort;
-      std::string osrmWalkingHost;
-      std::string osrmCyclingHost;
-      std::string osrmDrivingHost;
-
-      bool birdDistanceAccessibilityEnabled = false; // true if the accessibility information is obtained using bird distances instead of osrm
       std::string accessMode;
       std::string egressMode;
       bool tryNextModeIfRoutingFails;

--- a/tests/benchmark_csa/benchmark_CSA_test.cpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.cpp
@@ -14,6 +14,7 @@
 #include "scenario.hpp"
 #include "calculator.hpp"
 #include "benchmark_CSA_test.hpp"
+#include "osrm_fetcher.hpp"
 
 using namespace TrRouting;
 
@@ -63,16 +64,16 @@ public:
   {
     algorithmParams.cacheDirectoryPath = "cache/demo_transition";
     algorithmParams.dataFetcherShortname = "cache";
-    algorithmParams.osrmWalkingPort = "5000";
-    algorithmParams.osrmWalkingHost = "localhost"; //"http://localhost";
-    algorithmParams.osrmCyclingPort = "8000";
-    algorithmParams.osrmCyclingHost = "localhost";
-    algorithmParams.osrmDrivingPort = "7000";
-    algorithmParams.osrmDrivingHost = "localhost";
+    OsrmFetcher::osrmWalkingPort = "5000";
+    OsrmFetcher::osrmWalkingHost = "localhost"; //"http://localhost";
+    OsrmFetcher::osrmCyclingPort = "8000";
+    OsrmFetcher::osrmCyclingHost = "localhost";
+    OsrmFetcher::osrmDrivingPort = "7000";
+    OsrmFetcher::osrmDrivingHost = "localhost";
 
     CacheFetcher cacheFetcher = TrRouting::CacheFetcher();
     algorithmParams.cacheFetcher = &cacheFetcher;
-    algorithmParams.birdDistanceAccessibilityEnabled = true;
+    OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     calculator = new TrRouting::Calculator(algorithmParams);
 

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -21,6 +21,7 @@
 #include "trip.hpp"
 #include "od_trip.hpp"
 #include "node.hpp"
+#include "osrm_fetcher.hpp"
 
 // TODO:
 // Test transferable mode, it has separate code path
@@ -547,7 +548,7 @@ std::unique_ptr<TrRouting::RoutingResult> SingleRouteCalculationFixtureTests::ca
 {
     // TODO: This needs to be called to set some default values that are still part of the global parameters
     calculator.params.setDefaultValues();
-    calculator.params.birdDistanceAccessibilityEnabled = true;
+    TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started
     calculator.algorithmCalculationTime.start();

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -21,6 +21,7 @@
 #include "trip.hpp"
 #include "od_trip.hpp"
 #include "node.hpp"
+#include "osrm_fetcher.hpp"
 
 /**
  * This file covers tests with transfers and requests for alternatives
@@ -262,7 +263,7 @@ TrRouting::AlternativesResult SingleTAndACalculationFixtureTests::calculateWithA
 {
     // TODO: This needs to be called to set some default values that are still part of the global parameters
     calculator.params.setDefaultValues();
-    calculator.params.birdDistanceAccessibilityEnabled = true;
+    TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started
     calculator.algorithmCalculationTime.start();

--- a/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
@@ -21,6 +21,7 @@
 #include "trip.hpp"
 #include "od_trip.hpp"
 #include "node.hpp"
+#include "osrm_fetcher.hpp"
 
 /**
  * This file covers od trips use cases, where the value of od_trips is set to 1
@@ -115,7 +116,7 @@ nlohmann::json RouteOdTripsFixtureTests::calculateOdTrips(std::vector<std::strin
         calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSourceIndexesByUuid);
-    calculator.params.birdDistanceAccessibilityEnabled = true;
+    TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started
     calculator.algorithmCalculationTime.start();

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -22,6 +22,7 @@
 #include "station.hpp"
 #include "stop.hpp"
 #include "od_trip.hpp"
+#include "osrm_fetcher.hpp"
 
 // TODO:
 // Test transferable mode, it has separate code path
@@ -385,7 +386,7 @@ std::unique_ptr<TrRouting::RoutingResult> RouteCalculationFixtureTests::calculat
         calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSourceIndexesByUuid);
-    calculator.params.birdDistanceAccessibilityEnabled = true;
+    TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started
     calculator.algorithmCalculationTime.start();

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -23,6 +23,7 @@
 #include "station.hpp"
 #include "stop.hpp"
 #include "od_trip.hpp"
+#include "osrm_fetcher.hpp"
 
 /**
  * This file covers tests with transfers and requests for alternatives
@@ -193,7 +194,7 @@ TrRouting::AlternativesResult TAndACalculationFixtureTests::calculateWithAlterna
         calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSourceIndexesByUuid);
-    calculator.params.birdDistanceAccessibilityEnabled = true;
+    TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started
     calculator.algorithmCalculationTime.start();


### PR DESCRIPTION
The OSRM ports and hosts, and also the birdDistanceAccessibilityEnabled field was only used in
the OsrmFetcher static function. They were only initialized at startup.
We move them inside the OsrmFetcher class as static members, which match their usage pattern.

Eventually, it would be better to have an actual OsrmFetcher (or other routing data fetcher) objects,
but that's for a bigger future refactoring