### PR TITLE
Move cacheDirectoryPath parameter inside the CacheFetcher class

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -101,21 +101,21 @@ namespace TrRouting
      * -EINVAL For any other data related error
      * -(error codes from the open system call)
      */
-    int                    updateDataSourcesFromCache(Parameters&  params, std::string customPath = "");
-    int                    updateHouseholdsFromCache (Parameters&  params, std::string customPath = "");
-    int                    updatePersonsFromCache    (Parameters&  params, std::string customPath = "");
-    int                    updateOdTripsFromCache    (Parameters&  params, std::string customPath = "");
-    int                    updatePlacesFromCache     (Parameters&  params, std::string customPath = "");
+    int                    updateDataSourcesFromCache(std::string customPath = "");
+    int                    updateHouseholdsFromCache (std::string customPath = "");
+    int                    updatePersonsFromCache    (std::string customPath = "");
+    int                    updateOdTripsFromCache    (std::string customPath = "");
+    int                    updatePlacesFromCache     (std::string customPath = "");
 
-    int                    updateStationsFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateAgenciesFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateServicesFromCache   (Parameters&  params, std::string customPath = "");
-    int                    updateNodesFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updateStopsFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updateLinesFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updatePathsFromCache      (Parameters&  params, std::string customPath = "");
-    int                    updateScenariosFromCache  (Parameters&  params, std::string customPath = "");
-    int                    updateSchedulesFromCache  (Parameters&  params, std::string customPath = "");
+    int                    updateStationsFromCache   (std::string customPath = "");
+    int                    updateAgenciesFromCache   (std::string customPath = "");
+    int                    updateServicesFromCache   (std::string customPath = "");
+    int                    updateNodesFromCache      (std::string customPath = "");
+    int                    updateStopsFromCache      (std::string customPath = "");
+    int                    updateLinesFromCache      (std::string customPath = "");
+    int                    updatePathsFromCache      (std::string customPath = "");
+    int                    updateScenariosFromCache  (std::string customPath = "");
+    int                    updateSchedulesFromCache  (std::string customPath = "");
 
     int                    setConnections(std::vector<std::shared_ptr<ConnectionTuple>> connections);
 

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -16,62 +16,62 @@ namespace TrRouting
     params.cacheFetcher->getStops(stops, stopIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }*/
 
-  int Calculator::updateNodesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateNodesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, customPath);
   }
 
-  int Calculator::updateDataSourcesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateDataSourcesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getDataSources(dataSources, dataSourceIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getDataSources(dataSources, dataSourceIndexesByUuid, customPath);
   }
 
-  int Calculator::updateHouseholdsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateHouseholdsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getHouseholds(households, householdIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getHouseholds(households, householdIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
-  int Calculator::updatePersonsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updatePersonsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getPersons(persons, personIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getPersons(persons, personIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, customPath);
   }
   
-  int Calculator::updateOdTripsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateOdTripsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getOdTrips(odTrips, odTripIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getOdTrips(odTrips, odTripIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
-  int Calculator::updatePlacesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updatePlacesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getPlaces(places, placeIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getPlaces(places, placeIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
-  int Calculator::updateAgenciesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateAgenciesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getAgencies(agencies, agencyIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getAgencies(agencies, agencyIndexesByUuid, customPath);
   }
 
-  int Calculator::updateServicesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateServicesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getServices(services, serviceIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getServices(services, serviceIndexesByUuid, customPath);
   }
 
-  int Calculator::updateLinesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateLinesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, params, customPath);
+    return params.cacheFetcher->getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, customPath);
   }
 
-  int Calculator::updatePathsFromCache(Parameters& params, std::string customPath)
+  int Calculator::updatePathsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, params, customPath);
+    return params.cacheFetcher->getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
-  int Calculator::updateScenariosFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateScenariosFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, params, customPath);
+    return params.cacheFetcher->getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, customPath);
   }
 
-  int Calculator::updateSchedulesFromCache(Parameters& params, std::string customPath)
+  int Calculator::updateSchedulesFromCache(std::string customPath)
   {
     std::vector<std::shared_ptr<ConnectionTuple>> connections;
     int ret =  params.cacheFetcher->getSchedules(
@@ -88,7 +88,6 @@ namespace TrRouting
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
-      params,
       customPath
     );
     if (ret < 0)
@@ -140,74 +139,74 @@ namespace TrRouting
     {
       std::tie(modes, modeIndexesByShortname) = params.cacheFetcher->getModes();
 
-      //updateStationsFromCache(params);
-      //updateStopsFromCache(params);
-      ret = updateNodesFromCache(params);
+      //updateStationsFromCache();
+      //updateStopsFromCache();
+      ret = updateNodesFromCache();
       // Ignore missing nodes file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
 
-      ret = updateDataSourcesFromCache(params);
+      ret = updateDataSourcesFromCache();
       // Ignore missing data sources file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updateHouseholdsFromCache(params);
+      ret = updateHouseholdsFromCache();
       if (ret < 0)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updatePersonsFromCache(params);
+      ret = updatePersonsFromCache();
       if (ret < 0)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updateOdTripsFromCache(params);
+      ret = updateOdTripsFromCache();
       if (ret < 0)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updatePlacesFromCache(params);
+      ret = updatePlacesFromCache();
       if (ret < 0)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
 
-      ret = updateAgenciesFromCache(params);
+      ret = updateAgenciesFromCache();
       // Ignore missing file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updateServicesFromCache(params);
+      ret = updateServicesFromCache();
       // Ignore missing file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
       
-      ret = updateLinesFromCache(params);
+      ret = updateLinesFromCache();
       // Ignore missing file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updatePathsFromCache(params);
+      ret = updatePathsFromCache();
       // Ignore missing file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updateScenariosFromCache(params);
+      ret = updateScenariosFromCache();
       // Ignore missing file
       if (ret < 0 && ret != -ENOENT)
       {
         return Calculator::DataStatus::DATA_READ_ERROR;
       }
-      ret = updateSchedulesFromCache(params);
+      ret = updateSchedulesFromCache();
       // Ignore missing file
       if (ret < 0 && ret != -ENOENT)
       {

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -67,7 +67,6 @@ int main(int argc, char** argv) {
   // setup program options:
   spdlog::info("Starting transit routing on port {} for the data: {}", programOptions.port, programOptions.cachePath);
   
-  algorithmParams.cacheDirectoryPath     = programOptions.cachePath;
   algorithmParams.dataFetcherShortname   = programOptions.dataFetcherShortname;
   OsrmFetcher::osrmWalkingPort        = programOptions.osrmWalkingPort;
   OsrmFetcher::osrmCyclingPort        = programOptions.osrmCyclingPort;
@@ -80,7 +79,7 @@ int main(int argc, char** argv) {
     spdlog::set_level(spdlog::level::debug);
   }
 
-  CacheFetcher cacheFetcher    = CacheFetcher();
+  CacheFetcher cacheFetcher    = CacheFetcher(programOptions.cachePath);
   algorithmParams.cacheFetcher = &cacheFetcher;
 
   Calculator calculator(algorithmParams);
@@ -167,67 +166,68 @@ int main(int argc, char** argv) {
 
     int i {0};
     bool correctCacheName {false};
+    //TODO Merge this and the preparations.cpp code
     for(std::string cacheName : cacheNames)
     {
       if (cacheName == "data_sources" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateDataSourcesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateDataSourcesFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "households" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateHouseholdsFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateHouseholdsFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "persons" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updatePersonsFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updatePersonsFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "od_trips" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateOdTripsFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateOdTripsFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "places" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updatePlacesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updatePlacesFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "agencies" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateAgenciesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateAgenciesFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "services" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateServicesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateServicesFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "nodes" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateNodesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateNodesFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "lines" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateLinesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateLinesFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "paths" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updatePathsFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updatePathsFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "scenarios" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateScenariosFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateScenariosFromCache(customCacheDirectoryPath);
       }
       if (cacheName == "schedules" || cacheName == "all")
       {
         correctCacheName = true;
-        calculator.updateSchedulesFromCache(calculator.params, customCacheDirectoryPath);
+        calculator.updateSchedulesFromCache(customCacheDirectoryPath);
       }
 
       if (correctCacheName)

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -27,14 +27,12 @@
 namespace TrRouting
 {
 
-  class Parameters;
-  
   class CacheFetcher
   {
   
   public:
     
-    CacheFetcher() {}
+    CacheFetcher(const std::string &cacheDir);
     
     template<class T>
 
@@ -58,7 +56,7 @@ namespace TrRouting
      * 
      * Returns the complete file path in the cache
      */
-    static std::string getFilePath  (         std::string cacheFilePath, Parameters& params, std::string customPath = "");
+    std::string getFilePath  (         std::string cacheFilePath, std::string customPath = "");
     
     const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes();
     
@@ -74,7 +72,6 @@ namespace TrRouting
     int getDataSources(
       std::vector<std::unique_ptr<DataSource>>& ts, 
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -92,7 +89,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -111,7 +107,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
       std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -131,7 +126,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& personIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -149,7 +143,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -165,7 +158,6 @@ namespace TrRouting
     int getAgencies(
       std::vector<std::unique_ptr<Agency>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -181,7 +173,6 @@ namespace TrRouting
     int getServices(
       std::vector<std::unique_ptr<Service>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -197,7 +188,6 @@ namespace TrRouting
     int getStations(
       std::vector<std::unique_ptr<Station>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -214,7 +204,6 @@ namespace TrRouting
       std::vector<std::unique_ptr<Node>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& stationIndexesById,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -232,7 +221,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       std::map<std::string, int>& modeIndexesByShortname,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -250,7 +238,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -271,7 +258,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::map<std::string, int>& modeIndexesByShortname,
-      Parameters& params,
       std::string customPath = ""
     );
 
@@ -298,12 +284,11 @@ namespace TrRouting
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
-      Parameters& params,
       std::string customPath = ""
     );
         
   private:
-    
+    std::string cacheDirectoryPath;
   };
     
 }

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -143,7 +143,6 @@ namespace TrRouting
     public:
 
       std::string dataFetcherShortname; // cache, csv or gtfs, only cache is implemented for now
-      std::string cacheDirectoryPath;
       std::string calculationName;
 
       CacheFetcher* cacheFetcher;

--- a/src/agencies_cache_fetcher.cpp
+++ b/src/agencies_cache_fetcher.cpp
@@ -24,7 +24,6 @@ namespace TrRouting
   int CacheFetcher::getAgencies(
     std::vector<std::unique_ptr<Agency>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -46,7 +45,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
     
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
 
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)

--- a/src/cache_fetcher.cpp
+++ b/src/cache_fetcher.cpp
@@ -7,7 +7,10 @@
 
 namespace TrRouting
 {
-  
+   CacheFetcher::CacheFetcher(const std::string &cacheDir)
+    : cacheDirectoryPath(cacheDir) {
+  }
+
   template<class T>
   void CacheFetcher::saveToCapnpCacheFile(T& data, std::string cacheFilePath) {
     std::ofstream oCacheFile;
@@ -42,10 +45,10 @@ namespace TrRouting
     return count;
   }
   
-  std::string CacheFetcher::getFilePath(std::string cacheFilePath, Parameters& params, std::string customPath) {
+  std::string CacheFetcher::getFilePath(std::string cacheFilePath, std::string customPath) {
     std::string filePath = "";
-    if (!params.cacheDirectoryPath.empty()) {
-      filePath += params.cacheDirectoryPath + "/";
+    if (!cacheDirectoryPath.empty()) {
+      filePath += cacheDirectoryPath + "/";
     }
     if (customPath.empty())
     {

--- a/src/data_sources_cache_fetcher.cpp
+++ b/src/data_sources_cache_fetcher.cpp
@@ -20,7 +20,6 @@ namespace TrRouting
   int CacheFetcher::getDataSources(
     std::vector<std::unique_ptr<DataSource>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -41,7 +40,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
     
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)

--- a/src/households_cache_fetcher.cpp
+++ b/src/households_cache_fetcher.cpp
@@ -24,7 +24,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -51,14 +50,14 @@ namespace TrRouting
 
       std::string cacheFilePath {"dataSources/" + boost::uuids::to_string(dataSourceUuid) + "/" + cacheFileName};
 
-      int filesCount {CacheFetcher::getCacheFilesCount(CacheFetcher::getFilePath(cacheFilePath + ".capnpbin.count", params, customPath))};
+      int filesCount {CacheFetcher::getCacheFilesCount(getFilePath(cacheFilePath + ".capnpbin.count", customPath))};
 
       spdlog::info("files count households: {} path: {}", filesCount, cacheFilePath);
 
       for (int i = 0; i < filesCount; i++)
       {
         std::string filePath {cacheFilePath + ".capnpbin" + (filesCount > 1 ? "." + std::to_string(i) : "")};
-        std::string cacheFilePath = CacheFetcher::getFilePath(filePath, params, customPath);
+        std::string cacheFilePath = getFilePath(filePath, customPath);
 
         int fd = open(cacheFilePath.c_str(), O_RDWR);
         if (fd < 0)

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -22,7 +22,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     std::map<std::string, int>& modeIndexesByShortname,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -43,7 +42,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
       
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)

--- a/src/nodes_cache_fetcher.cpp
+++ b/src/nodes_cache_fetcher.cpp
@@ -25,7 +25,6 @@ namespace TrRouting
     std::vector<std::unique_ptr<Node>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& stationIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -48,7 +47,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
 
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)
@@ -130,7 +129,7 @@ namespace TrRouting
       Node * t = ts[i].get();
 
       nodeCacheFileName = "nodes/node_" + boost::uuids::to_string(t->uuid);
-      nodeCacheFileNamePath = CacheFetcher::getFilePath(nodeCacheFileName, params, customPath) + ".capnpbin";
+      nodeCacheFileNamePath = getFilePath(nodeCacheFileName, customPath) + ".capnpbin";
 
       int fd = open(nodeCacheFileNamePath.c_str(), O_RDWR);
       if (fd < 0)

--- a/src/od_trips_cache_fetcher.cpp
+++ b/src/od_trips_cache_fetcher.cpp
@@ -24,7 +24,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
     std::map<boost::uuids::uuid, int>& personIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -47,14 +46,14 @@ namespace TrRouting
 
       std::string cacheFilePath {"dataSources/" + boost::uuids::to_string(dataSourceUuid) + "/" + cacheFileName};
 
-      int filesCount {CacheFetcher::getCacheFilesCount(CacheFetcher::getFilePath(cacheFilePath + ".capnpbin.count", params, customPath))};
+      int filesCount {CacheFetcher::getCacheFilesCount(getFilePath(cacheFilePath + ".capnpbin.count", customPath))};
 
       spdlog::info("files count odTrips: {} path: {}", filesCount, cacheFilePath);
 
       for (int i = 0; i < filesCount; i++)
       {
         std::string filePath {cacheFilePath + ".capnpbin" + (filesCount > 1 ? "." + std::to_string(i) : "")};
-        std::string cacheFilePath = CacheFetcher::getFilePath(filePath, params, customPath);
+        std::string cacheFilePath = getFilePath(filePath, customPath);
 
         int fd = open(cacheFilePath.c_str(), O_RDWR);
         if (fd < 0)

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -23,7 +23,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -44,7 +43,7 @@ namespace TrRouting
     
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)
     {

--- a/src/persons_cache_fetcher.cpp
+++ b/src/persons_cache_fetcher.cpp
@@ -23,7 +23,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   { 
@@ -49,14 +48,14 @@ namespace TrRouting
 
       std::string cacheFilePath {"dataSources/" + boost::uuids::to_string(dataSourceUuid) + "/" + cacheFileName};
 
-      int filesCount {CacheFetcher::getCacheFilesCount(CacheFetcher::getFilePath(cacheFilePath + ".capnpbin.count", params, customPath))};
+      int filesCount {CacheFetcher::getCacheFilesCount(getFilePath(cacheFilePath + ".capnpbin.count", customPath))};
 
       spdlog::info("files count persons: {} path: {}", filesCount, cacheFilePath);
 
       for (int i = 0; i < filesCount; i++)
       {
         std::string filePath {cacheFilePath + ".capnpbin" + (filesCount > 1 ? "." + std::to_string(i) : "")};
-        std::string cacheFilePath = CacheFetcher::getFilePath(filePath, params, customPath);
+        std::string cacheFilePath = getFilePath(filePath, customPath);
 
         int fd = open(cacheFilePath.c_str(), O_RDWR);
         if (fd < 0)

--- a/src/places_cache_fetcher.cpp
+++ b/src/places_cache_fetcher.cpp
@@ -22,7 +22,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -45,14 +44,14 @@ namespace TrRouting
 
       std::string cacheFilePath {"dataSources/" + boost::uuids::to_string(dataSourceUuid) + "/" + cacheFileName};
 
-      int filesCount {CacheFetcher::getCacheFilesCount(CacheFetcher::getFilePath(cacheFilePath + ".capnpbin.count", params, customPath))};
+      int filesCount {CacheFetcher::getCacheFilesCount(getFilePath(cacheFilePath + ".capnpbin.count", customPath))};
 
       spdlog::info("files count places: {} path: {}", filesCount, cacheFilePath);
 
       for (int i = 0; i < filesCount; i++)
       {
         std::string filePath {cacheFilePath + ".capnpbin" + (filesCount > 1 ? "." + std::to_string(i) : "")};
-        std::string cacheFilePath = CacheFetcher::getFilePath(filePath, params, customPath);
+        std::string cacheFilePath = getFilePath(filePath, customPath);
 
         int fd = open(cacheFilePath.c_str(), O_RDWR);
         if (fd < 0)

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -26,7 +26,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::map<std::string, int>& modeIndexesByShortname,
-    Parameters& params,
     std::string customPath
   ) {
 
@@ -47,7 +46,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
     
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
 
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)

--- a/src/services_cache_fetcher.cpp
+++ b/src/services_cache_fetcher.cpp
@@ -21,7 +21,6 @@ namespace TrRouting
   int CacheFetcher::getServices(
     std::vector<std::unique_ptr<Service>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
     std::string customPath
   )
   {
@@ -43,7 +42,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
    
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
 
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)

--- a/src/stations_cache_fetcher.cpp
+++ b/src/stations_cache_fetcher.cpp
@@ -21,7 +21,6 @@ namespace TrRouting
   int CacheFetcher::getStations(
     std::vector<std::unique_ptr<Station>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    Parameters& params,
     std::string customPath
   ) 
   {
@@ -42,7 +41,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
     
-    std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+    std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
     int fd = open(cacheFilePath.c_str(), O_RDWR);
     if (fd < 0)
     {

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -35,7 +35,6 @@ namespace TrRouting
     std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
     std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
     std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
-    Parameters& params,
     std::string customPath
   )
   {
@@ -71,7 +70,7 @@ namespace TrRouting
     for (auto & line : lines)
     {
       cacheFileName = "lines/line_" + boost::uuids::to_string(line->uuid);
-      std::string cacheFilePath = CacheFetcher::getFilePath(cacheFileName, params, customPath) + ".capnpbin";
+      std::string cacheFilePath = getFilePath(cacheFileName, customPath) + ".capnpbin";
       int fd = open(cacheFilePath.c_str(), O_RDWR);
       if (fd < 0)
       {

--- a/tests/benchmark_csa/benchmark_CSA_test.cpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.cpp
@@ -62,7 +62,6 @@ public:
   // Initialize calculator and parameters. Open the result files and add headers
   static void SetUpTestSuite()
   {
-    algorithmParams.cacheDirectoryPath = "cache/demo_transition";
     algorithmParams.dataFetcherShortname = "cache";
     OsrmFetcher::osrmWalkingPort = "5000";
     OsrmFetcher::osrmWalkingHost = "localhost"; //"http://localhost";
@@ -71,7 +70,7 @@ public:
     OsrmFetcher::osrmDrivingPort = "7000";
     OsrmFetcher::osrmDrivingHost = "localhost";
 
-    CacheFetcher cacheFetcher = TrRouting::CacheFetcher();
+    CacheFetcher cacheFetcher = TrRouting::CacheFetcher("cache/demo_transition");
     algorithmParams.cacheFetcher = &cacheFetcher;
     OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 

--- a/tests/cache_fetch/agencies_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/agencies_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "agency.hpp"
@@ -21,34 +20,34 @@ public:
     { 
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/agencies.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/agencies.capnpbin");
     }
 
     void TearDown( ) override
     { 
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/agencies.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/agencies.capnpbin");
     }
 };
 
 TEST_F(AgencyCacheFetcherFixtureTests, TestGetAgenciesInvalid)
 {
-    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, agencies.size());
 }
 
 TEST_F(AgencyCacheFetcherFixtureTests, TestGetAgenciesValid)
 {
-    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, agencies.size());
 }
 
 TEST_F(AgencyCacheFetcherFixtureTests, TestGetAgenciesFileNotExists)
 {
-    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, agencies.size());
 }

--- a/tests/cache_fetch/cache_fetcher_test.cpp
+++ b/tests/cache_fetch/cache_fetcher_test.cpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 
@@ -12,22 +11,19 @@ protected:
 TEST_F(CacheFetcherFixtureTests, TestGetFilePath)
 {
     // Test with default params values
-    std::string filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
+    TrRouting::CacheFetcher aCacheFetcher("");
+    std::string filePath = aCacheFetcher.getFilePath(CACHE_FILE, "");
     EXPECT_STREQ(filePath.c_str(), CACHE_FILE.c_str());
 
     // Test with default params and custom path
-    filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, VALID_CUSTOM_PATH);
+    filePath = aCacheFetcher.getFilePath(CACHE_FILE, VALID_CUSTOM_PATH);
     EXPECT_STREQ(filePath.c_str(), (VALID_CUSTOM_PATH + '/' + CACHE_FILE).c_str());
 
     // Omit the project name in params
-    params.cacheDirectoryPath = relativeCacheDir;
-    filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
+    TrRouting::CacheFetcher relCacheFetcher(relativeCacheDir);
+    filePath = relCacheFetcher.getFilePath(CACHE_FILE, "");
     EXPECT_STREQ(filePath.c_str(), (relativeCacheDir + '/' + CACHE_FILE).c_str());
 
-    // Omit the cache directory path
-    params.cacheDirectoryPath = "";
-    filePath = TrRouting::CacheFetcher::getFilePath(CACHE_FILE, params, "");
-    EXPECT_STREQ(filePath.c_str(), (CACHE_FILE).c_str());
 }
 
 TEST_F(CacheFetcherFixtureTests, TestFileExists)

--- a/tests/cache_fetch/cache_fetcher_test.hpp
+++ b/tests/cache_fetch/cache_fetcher_test.hpp
@@ -2,29 +2,27 @@
 #define _CACHE_FETCHER_TEST_H
 
 #include "gtest/gtest.h"
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 
 class ConstantCacheFetcherFixtureTests : public ::testing::Test 
 {
 protected:
-    TrRouting::Parameters params;
     std::string cacheFile = "cacheFile.capnpbin";
     const std::string INVALID_CUSTOM_PATH = "invalidCacheFiles";
     const std::string VALID_CUSTOM_PATH = "validCacheFiles";
     const std::string BASE_CUSTOM_PATH = "";
-    const std::string PROJECT_NAME = "testCache";
+    const std::string BASE_CACHE_DIRECTORY_NAME = "testCache";
 };
 
 class BaseCacheFetcherFixtureTests : public ConstantCacheFetcherFixtureTests 
 {
 protected:
-    TrRouting::CacheFetcher cacheFetcher = TrRouting::CacheFetcher();
+    TrRouting::CacheFetcher cacheFetcher = TrRouting::CacheFetcher(BASE_CACHE_DIRECTORY_NAME);
 
 public:
     void SetUp() 
     {
-        params.cacheDirectoryPath = PROJECT_NAME;
+
     }
 };
 

--- a/tests/cache_fetch/data_sources_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/data_sources_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "data_source.hpp"
@@ -21,27 +20,27 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/dataSources.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/dataSources.capnpbin");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/dataSources.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/dataSources.capnpbin");
     }
 };
 
 TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesInvalid)
 {
-    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
 
 TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesValid)
 {
-    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     // TODO Test with actual data
     ASSERT_EQ(0, objects.size());
@@ -49,7 +48,7 @@ TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesValid)
 
 TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesFileNotExists)
 {
-    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/households_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/households_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "household.hpp"
@@ -21,7 +20,7 @@ protected:
 
 TEST_F(HouseholdCacheFetcherFixtureTests, TestGetHouseholdsValid)
 {
-    int retVal = cacheFetcher.getHouseholds(objects, objectIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getHouseholds(objects, objectIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/lines_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/lines_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "line.hpp"
@@ -23,34 +22,34 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/lines.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines.capnpbin");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/lines.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines.capnpbin");
     }
 };
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesInvalid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesValid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesFileNotExists)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/nodes_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/nodes_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "node.hpp"
@@ -23,23 +22,23 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin");
         // Create a nodes directory and create invalid files with same names as valid ones
-        fs::create_directory(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes");
+        fs::create_directory(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file and nodes directory
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin");
-        fs::remove_all(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin");
+        fs::remove_all(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes");
     }
 };
 
 TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesInvalidNodesFile)
 {
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, nodes.size());
 }
@@ -47,8 +46,8 @@ TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesInvalidNodesFile)
 TEST_F(NodeCacheFetcherFixtureTests, TestGetUnexistingSingleNodeFile)
 {
     // Copy the file from the valid nodes, but have nodes be unexisting
-    fs::copy_file(PROJECT_NAME + "/" + VALID_CUSTOM_PATH + "/nodes.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin", fs::copy_options::overwrite_existing);
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + VALID_CUSTOM_PATH + "/nodes.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin", fs::copy_options::overwrite_existing);
+    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, INVALID_CUSTOM_PATH);
     // TODO: Is this right?
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(11, nodes.size());
@@ -57,26 +56,26 @@ TEST_F(NodeCacheFetcherFixtureTests, TestGetUnexistingSingleNodeFile)
 TEST_F(NodeCacheFetcherFixtureTests, TestGetSingleInvalidNodeFile)
 {
     // Copy the file from the valid nodes, but have invalid node files
-    fs::copy_file(PROJECT_NAME + "/" + VALID_CUSTOM_PATH + "/nodes.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin", fs::copy_options::overwrite_existing);
-    for(auto& p: fs::directory_iterator(PROJECT_NAME + "/" + VALID_CUSTOM_PATH + "/nodes"))
+    fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + VALID_CUSTOM_PATH + "/nodes.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin", fs::copy_options::overwrite_existing);
+    for(auto& p: fs::directory_iterator(BASE_CACHE_DIRECTORY_NAME + "/" + VALID_CUSTOM_PATH + "/nodes"))
     {
         // Copy the invalid file for each node name
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes/" + p.path().filename().c_str());
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes/" + p.path().filename().c_str());
     }
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
 }
 
 TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesValid)
 {
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(11, nodes.size());
 }
 
 TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesFileNotExists)
 {
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, nodes.size());
 }

--- a/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "od_trip.hpp"
@@ -22,7 +21,7 @@ protected:
 
 TEST_F(OdTripCacheFetcherFixtureTests, TestGetOdTripsValid)
 {
-    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "path.hpp"
@@ -23,20 +22,20 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/paths.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/paths.capnpbin");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/paths.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/paths.capnpbin");
     }
 };
 
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsInvalid)
 {
-    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -44,14 +43,14 @@ TEST_F(PathCacheFetcherFixtureTests, TestGetPathsInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsValid)
 {
-    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(4, objects.size());
 }
 
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsFileNotExists)
 {
-    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/persons_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/persons_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "person.hpp"
@@ -22,7 +21,7 @@ protected:
 
 TEST_F(PersonCacheFetcherFixtureTests, TestGetPersonsValid)
 {
-    int retVal = cacheFetcher.getPersons(objects, objectIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPersons(objects, objectIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/places_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/places_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "place.hpp"
@@ -20,7 +19,7 @@ protected:
 
 TEST_F(PlaceCacheFetcherFixtureTests, TestGetPlacesValid)
 {
-    int retVal = cacheFetcher.getPlaces(objects, objectIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPlaces(objects, objectIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "scenario.hpp"
@@ -26,20 +25,20 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/scenarios.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/scenarios.capnpbin");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/scenarios.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/scenarios.capnpbin");
     }
 };
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -47,14 +46,14 @@ TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosValid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosFileNotExists)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "trip.hpp"
@@ -37,18 +36,18 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Read valid data for agencies, lines and paths
-        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, params, VALID_CUSTOM_PATH);
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, params, VALID_CUSTOM_PATH);
-        cacheFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, params, VALID_CUSTOM_PATH);
+        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+        cacheFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
         // Create the invalid lines directory
-        fs::create_directory(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
+        fs::create_directory(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid lines directory
-        fs::remove_all(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
+        fs::remove_all(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
     }
 };
 
@@ -56,7 +55,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
 {
     // Copy the invalid file for the first line 
     std::string node0Uuid = boost::uuids::to_string(lines[0].get()->uuid);
-    fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/lines/line_ " + node0Uuid.c_str() + ".capnpbin");
+    fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines/line_ " + node0Uuid.c_str() + ".capnpbin");
     int retVal = cacheFetcher.getSchedules(
       trips,
       lines,
@@ -71,7 +70,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
-      params,
       INVALID_CUSTOM_PATH
     );
     // TODO: Since a file was invalid, should this return -EBADMSG?
@@ -95,7 +93,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
-      params,
       INVALID_CUSTOM_PATH
     );
     ASSERT_EQ(0, retVal);
@@ -118,7 +115,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
-      params,
       VALID_CUSTOM_PATH
     );
     ASSERT_EQ(0, retVal);

--- a/tests/cache_fetch/services_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/services_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "service.hpp"
@@ -21,34 +20,34 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/services.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/services.capnpbin");
     }
 
     void TearDown( ) override
     {
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/services.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/services.capnpbin");
     }
 };
 
 TEST_F(ServiceCacheFetcherFixtureTests, TestGetServicesInvalid)
 {
-    int retVal = cacheFetcher.getServices(objects, objectIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getServices(objects, objectIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
 
 TEST_F(ServiceCacheFetcherFixtureTests, TestGetServicesValid)
 {
-    int retVal = cacheFetcher.getServices(objects, objectIndexesByUuid, params, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getServices(objects, objectIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(ServiceCacheFetcherFixtureTests, TestGetServicesFileNotExists)
 {
-    int retVal = cacheFetcher.getServices(objects, objectIndexesByUuid, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getServices(objects, objectIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/stations_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/stations_cache_fetcher_test.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 
 #include "gtest/gtest.h" // we will add the path to C preprocessor later
-#include "parameters.hpp"
 #include "cache_fetcher.hpp"
 #include "cache_fetcher_test.hpp"
 #include "station.hpp"
@@ -21,27 +20,27 @@ public:
     { 
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
-        fs::copy_file(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/stations.capnpbin");
+        fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/stations.capnpbin");
     }
 
     void TearDown( ) override
     { 
         BaseCacheFetcherFixtureTests::TearDown();
         // Remove the invalid file
-        fs::remove(PROJECT_NAME + "/" + INVALID_CUSTOM_PATH + "/stations.capnpbin");
+        fs::remove(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/stations.capnpbin");
     }
 };
 
 TEST_F(StationCacheFetcherFixtureTests, TestGetStationsInvalid)
 {
-    int retVal = cacheFetcher.getStations(stations, agencyIndexesByUuid, params, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getStations(stations, agencyIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, stations.size());
 }
 
 TEST_F(StationCacheFetcherFixtureTests, TestGetStationsFileNotExists)
 {
-    int retVal = cacheFetcher.getStations(stations, agencyIndexesByUuid, params, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getStations(stations, agencyIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, stations.size());
 }


### PR DESCRIPTION
Instead of passing around this information in the Paramaters object, we make it
part of the CacheFetcher object directly. For this, we need to remove the static
qualifier on getFilePath.

Lot of modifications, but the vast majority is to remove the params parameter in
many function call that we don't need anymore