### PR TITLE
Introduce a base class DataFetcher as parent to CacheFetcher

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -11,10 +11,11 @@
 #include <boost/uuid/uuid.hpp>
 
 #include "calculation_time.hpp"
+#include "parameters.hpp"
 
 namespace TrRouting
 {
-  class Parameters;
+
   class RouteParameters;
   class Mode;
   class DataSource;
@@ -33,6 +34,7 @@ namespace TrRouting
   class Trip;
   class RoutingResult;
   class AlternativesResult;
+  class DataFetcher;
 
   // tuple representing a connection: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, lineIndex, blockIndex, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
   using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>;
@@ -65,7 +67,7 @@ namespace TrRouting
 
     std::map<std::string, int> benchmarking;
 
-    Calculator(Parameters& theParams);
+    Calculator(DataFetcher& dataFetcher);
 
     /**
      * Prepare the data for the calculator and validate that there are at least
@@ -190,8 +192,9 @@ namespace TrRouting
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;        // tripIndex: [connectionIndex (sequence in trip): sum of od trips weights using this connection (demand)]
     //std::vector<std::unique_ptr<std::vector<std::unique_ptr<int>>>>   tripIndexesByPathIndex;
 
-    Parameters& params;
+    Parameters params;
     CalculationTime algorithmCalculationTime;
+    DataFetcher &dataFetcher;
 
     OdTrip * odTrip;
 

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -22,8 +22,8 @@
 namespace TrRouting
 {
 
-  Calculator::Calculator(Parameters& theParams) :
-    params(theParams),
+  Calculator::Calculator(DataFetcher& fetcher) :
+    dataFetcher(fetcher),
     odTrip(nullptr),
     algorithmCalculationTime(CalculationTime()),
     departureTimeSeconds(0),

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -1,7 +1,8 @@
 #include "spdlog/spdlog.h"
 #include "calculator.hpp"
 #include "parameters.hpp"
-#include "cache_fetcher.hpp"
+#include "data_fetcher.hpp"
+#include "mode.hpp"
 
 namespace TrRouting
 {
@@ -15,66 +16,66 @@ namespace TrRouting
   {
     params.cacheFetcher->getStops(stops, stopIndexesByUuid, nodeIndexesByUuid, params, customPath);
   }*/
-
+  // TODO now that we have a "generic" data fetcher interface, we should remove the FromCache from these function name
   int Calculator::updateNodesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, customPath);
+    return dataFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, customPath);
   }
 
   int Calculator::updateDataSourcesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getDataSources(dataSources, dataSourceIndexesByUuid, customPath);
+    return dataFetcher.getDataSources(dataSources, dataSourceIndexesByUuid, customPath);
   }
 
   int Calculator::updateHouseholdsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getHouseholds(households, householdIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getHouseholds(households, householdIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
   int Calculator::updatePersonsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getPersons(persons, personIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getPersons(persons, personIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, customPath);
   }
   
   int Calculator::updateOdTripsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getOdTrips(odTrips, odTripIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getOdTrips(odTrips, odTripIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
   int Calculator::updatePlacesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getPlaces(places, placeIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getPlaces(places, placeIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
   int Calculator::updateAgenciesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getAgencies(agencies, agencyIndexesByUuid, customPath);
+    return dataFetcher.getAgencies(agencies, agencyIndexesByUuid, customPath);
   }
 
   int Calculator::updateServicesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getServices(services, serviceIndexesByUuid, customPath);
+    return dataFetcher.getServices(services, serviceIndexesByUuid, customPath);
   }
 
   int Calculator::updateLinesFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, customPath);
+    return dataFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, customPath);
   }
 
   int Calculator::updatePathsFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, customPath);
   }
 
   int Calculator::updateScenariosFromCache(std::string customPath)
   {
-    return params.cacheFetcher->getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, customPath);
+    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, customPath);
   }
 
   int Calculator::updateSchedulesFromCache(std::string customPath)
   {
     std::vector<std::shared_ptr<ConnectionTuple>> connections;
-    int ret =  params.cacheFetcher->getSchedules(
+    int ret =  dataFetcher.getSchedules(
       trips,
       lines,
       paths,
@@ -135,94 +136,80 @@ namespace TrRouting
 
     spdlog::debug("preparing nodes, routes, trips, connections and footpaths...");
     
-    if (params.dataFetcherShortname == "cache")
+    std::tie(modes, modeIndexesByShortname) = dataFetcher.getModes();
+
+    //updateStationsFromCache();
+    //updateStopsFromCache();
+    ret = updateNodesFromCache();
+    // Ignore missing nodes file
+    if (ret < 0 && ret != -ENOENT)
     {
-      std::tie(modes, modeIndexesByShortname) = params.cacheFetcher->getModes();
-
-      //updateStationsFromCache();
-      //updateStopsFromCache();
-      ret = updateNodesFromCache();
-      // Ignore missing nodes file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-
-      ret = updateDataSourcesFromCache();
-      // Ignore missing data sources file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updateHouseholdsFromCache();
-      if (ret < 0)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updatePersonsFromCache();
-      if (ret < 0)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updateOdTripsFromCache();
-      if (ret < 0)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updatePlacesFromCache();
-      if (ret < 0)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-
-      ret = updateAgenciesFromCache();
-      // Ignore missing file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updateServicesFromCache();
-      // Ignore missing file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      
-      ret = updateLinesFromCache();
-      // Ignore missing file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updatePathsFromCache();
-      // Ignore missing file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updateScenariosFromCache();
-      // Ignore missing file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      ret = updateSchedulesFromCache();
-      // Ignore missing file
-      if (ret < 0 && ret != -ENOENT)
-      {
-        return Calculator::DataStatus::DATA_READ_ERROR;
-      }
-      
+      return Calculator::DataStatus::DATA_READ_ERROR;
     }
-    else if (params.dataFetcherShortname == "gtfs")
+    ret = updateDataSourcesFromCache();
+    // Ignore missing data sources file
+    if (ret < 0 && ret != -ENOENT)
     {
-      // not yet implemented
+      return Calculator::DataStatus::DATA_READ_ERROR;
     }
-    else if (params.dataFetcherShortname == "csv")
+    ret = updateHouseholdsFromCache();
+    if (ret < 0)
     {
-      // not yet implemented
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updatePersonsFromCache();
+    if (ret < 0)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updateOdTripsFromCache();
+    if (ret < 0)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updatePlacesFromCache();
+    if (ret < 0)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
     }
     
+    ret = updateAgenciesFromCache();
+    // Ignore missing file
+    if (ret < 0 && ret != -ENOENT)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updateServicesFromCache();
+    // Ignore missing file
+    if (ret < 0 && ret != -ENOENT)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updateLinesFromCache();
+    // Ignore missing file
+    if (ret < 0 && ret != -ENOENT)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updatePathsFromCache();
+    // Ignore missing file
+    if (ret < 0 && ret != -ENOENT)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updateScenariosFromCache();
+    // Ignore missing file
+    if (ret < 0 && ret != -ENOENT)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+    ret = updateSchedulesFromCache();
+    // Ignore missing file
+    if (ret < 0 && ret != -ENOENT)
+    {
+      return Calculator::DataStatus::DATA_READ_ERROR;
+    }
+
     initializeCalculationData();
     spdlog::info("preparing nodes tentative times, trips enter connections and journeys...");
     return validateData(this);

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -1,0 +1,262 @@
+#ifndef TR_DATA_FETCHER
+#define TR_DATA_FETCHER
+
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+#include <boost/uuid/uuid.hpp>
+
+namespace TrRouting
+{
+  class DataSource;
+  class Household;
+  class Person;
+  class OdTrip;
+  class Place;
+  class Agency;
+  class Service;
+  class Station;
+  class Node;
+  class Stop;
+  class Line;
+  class Path;
+  class Scenario;
+  class Trip;
+  class Mode;
+
+  /** Base class for all data access mode (cache, gtfs, db, etc)
+   */
+  class DataFetcher
+  {
+  public:
+      virtual const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes() = 0;
+
+      //TODO the customPath does not make much sense to a generic data access pattern (see issue #160)
+    /**
+     * Read the data sources cache file and fill the data sources vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getDataSources(
+      std::vector<std::unique_ptr<DataSource>>& ts, 
+      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::string customPath = "") = 0;
+
+    /**
+     * Read the households cache file and fill the households vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+     virtual int getHouseholds(
+      std::vector<std::unique_ptr<Household>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::string customPath = "") = 0;
+
+    /**
+     * Read the persons cache file and fill the persons vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getPersons(
+      std::vector<std::unique_ptr<Person>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the odTrips cache file and fill the odTrips vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getOdTrips(
+      std::vector<std::unique_ptr<OdTrip>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the places cache file and fill the places vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getPlaces(
+      std::vector<std::unique_ptr<Place>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the agencies cache file and fill the agencies vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getAgencies(
+      std::vector<std::unique_ptr<Agency>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the services cache file and fill the services vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getServices(
+      std::vector<std::unique_ptr<Service>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the stations cache file and fill the stations vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getStations(
+      std::vector<std::unique_ptr<Station>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the nodes cache file and fill the nodes and stations vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getNodes(
+      std::vector<std::unique_ptr<Node>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, int>& stationIndexesById,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the lines cache file and fill the lines vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getLines(
+      std::vector<std::unique_ptr<Line>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      std::map<std::string, int>& modeIndexesByShortname,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the paths cache file and fill the paths vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getPaths(
+      std::vector<std::unique_ptr<Path>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the scenarios cache file and fill the scenarios vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getScenarios(
+      std::vector<std::unique_ptr<Scenario>>& ts,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::map<std::string, int>& modeIndexesByShortname,
+      std::string customPath = ""
+    ) = 0;
+
+    /**
+     * Read the lines with schedules cache file and fill the trips vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
+    virtual int getSchedules(
+      std::vector<std::unique_ptr<Trip>>& trips,
+      std::vector<std::unique_ptr<Line>>& lines,
+      std::vector<std::unique_ptr<Path>>& paths,
+      std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::map<std::string, int>& modeIndexesByShortname,
+      std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
+      std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
+      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
+      std::string customPath = "") = 0;
+
+  };    
+}
+#endif

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -1,82 +1,55 @@
-#ifndef TR_CACHE_FETCHER
-#define TR_CACHE_FETCHER
+#ifndef TR_DUMMY_DATA_FETCHER
+#define TR_DUMMY_DATA_FETCHER
 
 #include <string>
 #include <vector>
 #include <map>
 #include <memory>
 #include <boost/uuid/uuid.hpp>
-
 #include "data_fetcher.hpp"
-
-#include "agency.hpp"
-#include "line.hpp"
-#include "node.hpp"
-#include "data_source.hpp"
-#include "household.hpp"
-#include "person.hpp"
-#include "od_trip.hpp"
-#include "place.hpp"
-#include "service.hpp"
-#include "scenario.hpp"
-#include "path.hpp"
-#include "block.hpp"
-#include "stop.hpp"
-#include "mode.hpp"
-#include "station.hpp"
-#include "trip.hpp"
 
 namespace TrRouting
 {
+  class DataSource;
+  class Household;
+  class Person;
+  class OdTrip;
+  class Place;
+  class Agency;
+  class Service;
+  class Station;
+  class Node;
+  class Stop;
+  class Line;
+  class Path;
+  class Scenario;
+  class Trip;
+  class Mode;
 
-  class CacheFetcher : public DataFetcher
+  /** Dummy class, which returns empty data. Useful for simple testing
+   */
+  class DummyDataFetcher : public DataFetcher
   {
-  
   public:
+    DummyDataFetcher() {}
+    virtual ~DummyDataFetcher() {}
+    virtual const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes() {
+      std::vector<Mode> ts;
+      std::map<std::string, int> tIndexesByShortname;
+      return std::make_pair(ts, tIndexesByShortname);
+    };
     
-    CacheFetcher(const std::string &cacheDir);
-    virtual ~CacheFetcher();
-    
-    template<class T>
-
-    /**
-     * Save data to a cache file. The cache file path can be obtained using the
-     * getFilePath function
-     */
-    static void saveToCapnpCacheFile(T& data, std::string cacheFilePath);
-    /**
-     * Returns whether a cache file exists. The cache file path can be obtained
-     * using the getFilePath function
-     */
-    static bool capnpCacheFileExists(         std::string cacheFilePath);
-    /**
-     * Get the number of cache files in a directory. The cache file path can be
-     * obtained using the getFilePath function
-     */
-    static int  getCacheFilesCount  (         std::string cacheFilePath);
-    /**
-     * Get the complete file path from the parameters and configuration
-     * 
-     * Returns the complete file path in the cache
-     */
-    std::string getFilePath  (         std::string cacheFilePath, std::string customPath = "");
-    
-    virtual const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes();
-
-    /** Refer to the base class for these functions documentations */
     virtual int getDataSources(
       std::vector<std::unique_ptr<DataSource>>& ts, 
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::string customPath = ""
-    );
+      std::string customPath = "") {return 0;}
 
-    virtual int getHouseholds(
+     virtual int getHouseholds(
       std::vector<std::unique_ptr<Household>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::string customPath = ""
-    );
+      std::string customPath = "") {return 0;}
 
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
@@ -85,7 +58,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
-    );
+                           ) {return 0;}
 
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
@@ -95,7 +68,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& personIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
-    );
+                           ) {return 0;}
 
     virtual int getPlaces(
       std::vector<std::unique_ptr<Place>>& ts,
@@ -103,32 +76,32 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
-    );
+                          ) {return 0;}
 
     virtual int getAgencies(
       std::vector<std::unique_ptr<Agency>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::string customPath = ""
-    );
+                            ) {return 0;}
 
     virtual int getServices(
       std::vector<std::unique_ptr<Service>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::string customPath = ""
-    );
+                            ) {return 0;}
 
     virtual int getStations(
       std::vector<std::unique_ptr<Station>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::string customPath = ""
-    );
+                            ) {return 0;}
 
     virtual int getNodes(
       std::vector<std::unique_ptr<Node>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       std::map<boost::uuids::uuid, int>& stationIndexesById,
       std::string customPath = ""
-    );
+                         ) {return 0;}
 
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
@@ -136,7 +109,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
-    );
+                         ) {return 0;}
 
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
@@ -144,8 +117,17 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
-    );
+                         ) {return 0;}
 
+    /**
+     * Read the scenarios cache file and fill the scenarios vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
     virtual int getScenarios(
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
@@ -155,8 +137,17 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
-    );
+                             ) {return 0;}
 
+    /**
+     * Read the lines with schedules cache file and fill the trips vector.
+     * 
+     * @return 0 in case of success, values below 0 when errors occurred:
+     * -EBADMSG if deserialization did not work
+     * -ENOENT if the file does not exist
+     * -EINVAL For any other data related error
+     * -(error codes from the open system call)
+     */
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
       std::vector<std::unique_ptr<Line>>& lines,
@@ -171,13 +162,8 @@ namespace TrRouting
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
-      std::string customPath = ""
-    );
-        
-  private:
-    std::string cacheDirectoryPath;
-  };
-    
-}
+      std::string customPath = "") {return 0;}
 
-#endif // TR_CACHE_FETCHER
+  };    
+}
+#endif

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -10,8 +10,6 @@
 namespace TrRouting
 {
 
-  class DatabaseFetcher;
-  class CacheFetcher;
   class Point;
   class OdTrip;
   class Scenario;
@@ -142,10 +140,7 @@ namespace TrRouting
 
     public:
 
-      std::string dataFetcherShortname; // cache, csv or gtfs, only cache is implemented for now
       std::string calculationName;
-
-      CacheFetcher* cacheFetcher;
 
       int batchNumber;
       int batchesCount;

--- a/src/cache_fetcher.cpp
+++ b/src/cache_fetcher.cpp
@@ -7,9 +7,10 @@
 
 namespace TrRouting
 {
-   CacheFetcher::CacheFetcher(const std::string &cacheDir)
+  CacheFetcher::CacheFetcher(const std::string &cacheDir)
     : cacheDirectoryPath(cacheDir) {
   }
+  CacheFetcher::~CacheFetcher() {}
 
   template<class T>
   void CacheFetcher::saveToCapnpCacheFile(T& data, std::string cacheFilePath) {

--- a/tests/benchmark_csa/benchmark_CSA_test.cpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.cpp
@@ -21,7 +21,6 @@ using namespace TrRouting;
 const int NB_ITER = 30;
 
 // Global test suite variables, they should not be reset for each test
-Parameters algorithmParams;
 Calculator* calculator;
 std::ofstream benchmarkResultsFile;
 std::ofstream benchmarkDetailedResultsFile;
@@ -62,7 +61,6 @@ public:
   // Initialize calculator and parameters. Open the result files and add headers
   static void SetUpTestSuite()
   {
-    algorithmParams.dataFetcherShortname = "cache";
     OsrmFetcher::osrmWalkingPort = "5000";
     OsrmFetcher::osrmWalkingHost = "localhost"; //"http://localhost";
     OsrmFetcher::osrmCyclingPort = "8000";
@@ -71,10 +69,9 @@ public:
     OsrmFetcher::osrmDrivingHost = "localhost";
 
     CacheFetcher cacheFetcher = TrRouting::CacheFetcher("cache/demo_transition");
-    algorithmParams.cacheFetcher = &cacheFetcher;
     OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
-    calculator = new TrRouting::Calculator(algorithmParams);
+    calculator = new TrRouting::Calculator(cacheFetcher);
 
     if (!updateCalculatorFromCache(calculator)) {
       ASSERT_EQ(true, false);
@@ -110,7 +107,7 @@ public:
   void benchmarkCurrentParams(TrRouting::RouteParameters &routeParams, bool expectResult, int nbIter)
   {
     // TODO Shouldn't have to do this, a query is not a benchmark
-    algorithmParams.setDefaultValues();
+    calculator->params.setDefaultValues();
     calculator->algorithmCalculationTime.start();
     calculator->benchmarking.clear();
 

--- a/tests/cache_fetch/Makefile.am
+++ b/tests/cache_fetch/Makefile.am
@@ -2,7 +2,7 @@
 check_PROGRAMS = gtest
 
 gtest_SOURCES = gtest.cpp \
-    ../../src/cache_fetcher.cpp cache_fetcher_test.cpp \
+    ../../src/cache_fetcher.cpp ../../src/modes_initialization.cpp cache_fetcher_test.cpp \
     ../../src/agencies_cache_fetcher.cpp agencies_cache_fetcher_test.cpp \
     ../../src/nodes_cache_fetcher.cpp nodes_cache_fetcher_test.cpp \
     ../../src/services_cache_fetcher.cpp services_cache_fetcher_test.cpp \

--- a/tests/connection_scan_algorithm/csa_test_base.hpp
+++ b/tests/connection_scan_algorithm/csa_test_base.hpp
@@ -4,8 +4,8 @@
 #include <boost/uuid/string_generator.hpp>
 
 #include "gtest/gtest.h"
+#include "dummy_data_fetcher.hpp"
 #include "calculator.hpp"
-#include "parameters.hpp"
 #include "routing_result.hpp"
 
 
@@ -50,11 +50,10 @@ protected:
     inline static const boost::uuids::uuid trip2EWUuid = uuidGenerator("ea8c90ba-7deb-46af-87c6-8af211e8fab7");
     inline static const boost::uuids::uuid trip1ExtraUuid = uuidGenerator("4aff9220-e72e-4b41-9cbf-0d86565d5128");
 
-    // Parameter object is required to build the calculator.
-    // TODO As code evolves, it won't be necessary anymore
-    TrRouting::Parameters params;
     // Calculator is the entry point to run the algorithm, it is part of the test object since (for now) there is nothing specific for its initialization.
     TrRouting::Calculator calculator;
+    // A DataFetcher is required to initialize the calculator
+    TrRouting::DummyDataFetcher dataFetcher;
 
     // Setup functions. The base class will define a complete default data set,
     // but specific test cases can override these methods and add their own data
@@ -68,7 +67,7 @@ protected:
     void setUpSchedules(std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> &connections);
 
 public:
-    BaseCsaFixtureTests() : params(TrRouting::Parameters()), calculator(TrRouting::Calculator(params)) {}
+    BaseCsaFixtureTests() : dataFetcher(TrRouting::DummyDataFetcher()), calculator(TrRouting::Calculator(dataFetcher)) {}
     void SetUp();
     // Assert the result returned an exception and that the reason matches the expected reason
     void assertNoRouting(const TrRouting::NoRoutingFoundException& exception, TrRouting::NoRoutingReason expectedReason);
@@ -87,4 +86,4 @@ public:
 
 };
 
-#endif // _CACHE_FETCHER_TEST_H
+#endif


### PR DESCRIPTION
Instead of having a if on the data source type in preparation.cpp which calls
different functions, we create the infrastructure to simple parse the type in
the main and instantiate the appropriate Fetcher there and pass it to
the Calculator

This simple some functions and remove need for a few parameters in the Parameters class