### PR TITLE
Remove the save to file feature

### DIFF
--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -28,10 +28,8 @@ namespace TrRouting
 
     onlyDataSourceIdx = -1;
 
-    calculationName                        = "trRouting";
     batchNumber                            = 1;
     batchesCount                           = 1;
-    saveResultToFile                       = false;
     odTripsSampleRatio                     = 1.0;
     dataSourceUuid.reset();
     odTripUuid.reset();
@@ -578,11 +576,6 @@ namespace TrRouting
         continue;
       }
 
-      else if (parameterWithValueVector[0] == "calculation_name" || parameterWithValueVector[0] == "name")
-      {
-        calculationName = parameterWithValueVector[1];
-        continue;
-      }
       else if (parameterWithValueVector[0] == "batch")
       {
         batchNumber = std::stoi(parameterWithValueVector[1]);
@@ -591,11 +584,6 @@ namespace TrRouting
       else if (parameterWithValueVector[0] == "num_batches")
       {
         batchesCount = std::stoi(parameterWithValueVector[1]);
-        continue;
-      }
-      else if (parameterWithValueVector[0] == "save_to_file" || parameterWithValueVector[0] == "save_file")
-      {
-        if (parameterWithValueVector[1] == "true" || parameterWithValueVector[1] == "1") { saveResultToFile = true; }
         continue;
       }
     }

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -16,7 +16,6 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include "toolbox.hpp"
 #include "cache_fetcher.hpp"
 #include "calculation_time.hpp"
 #include "parameters.hpp"
@@ -368,16 +367,6 @@ int main(int argc, char** argv) {
 
         if (routingResult.get() != nullptr) {
           response = ResultToV1Response::resultToJsonString(*routingResult.get(), routeParams).dump(2);
-        }
-
-        if (calculator.params.saveResultToFile)
-        {
-          spdlog::info("writing file");
-          std::ofstream file;
-          //file.imbue(std::locale("en_US.UTF8"));
-          file.open(calculator.params.calculationName + ".json", std::ios_base::trunc);
-          file << response;
-          file.close();
         }
 
         spdlog::debug("-- total -- {} microseconds", calculator.algorithmCalculationTime.getDurationMicrosecondsNoStop());

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -141,8 +141,6 @@ namespace TrRouting
 
     public:
 
-      std::string calculationName;
-
       int batchNumber;
       int batchesCount;
       int odTripsSampleSize;
@@ -180,7 +178,6 @@ namespace TrRouting
       int originNodeIdx;
       int destinationNodeIdx;
       bool calculateAllOdTrips;
-      bool saveResultToFile;
       std::optional<boost::uuids::uuid> dataSourceUuid;
       std::optional<boost::uuids::uuid> odTripUuid;
       std::optional<boost::uuids::uuid> startingNodeUuid;

--- a/include/toolbox.hpp
+++ b/include/toolbox.hpp
@@ -2,11 +2,6 @@
 #define TR_TOOLBOX
 
 #include <string>
-#include <iomanip>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
-#include <iterator>
 #include <vector>
 #include <math.h>
 


### PR DESCRIPTION
It was possible to ask the route API call to save the result to a file.
It does not really make sense for a remote client to trigger a local action like this.
It's simple for the client to juste save the result to a file. It was transmitted on the socket anyway.

Since we don't need fstream anymore, a little bit of include cleanup was called for