### PR TITLE
Add const to DataFetcher functions

### DIFF
--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -73,35 +73,35 @@ namespace TrRouting
     virtual int getHouseholds(
       std::vector<std::unique_ptr<Household>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );
 
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );
 
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );
 
     virtual int getPlaces(
       std::vector<std::unique_ptr<Place>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );
 
@@ -126,48 +126,48 @@ namespace TrRouting
     virtual int getNodes(
       std::vector<std::unique_ptr<Node>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& stationIndexesById,
+      const std::map<boost::uuids::uuid, int>& stationIndexesById,
       std::string customPath = ""
     );
 
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
     );
 
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );
 
     virtual int getScenarios(
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
     );
 
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
-      std::vector<std::unique_ptr<Line>>& lines,
+      const std::vector<std::unique_ptr<Line>>& lines,
       std::vector<std::unique_ptr<Path>>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -59,8 +59,8 @@ namespace TrRouting
      virtual int getHouseholds(
       std::vector<std::unique_ptr<Household>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = "") = 0;
 
     /**
@@ -75,9 +75,9 @@ namespace TrRouting
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     ) = 0;
 
@@ -93,10 +93,10 @@ namespace TrRouting
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     ) = 0;
 
@@ -112,8 +112,8 @@ namespace TrRouting
     virtual int getPlaces(
       std::vector<std::unique_ptr<Place>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     ) = 0;
 
@@ -174,7 +174,7 @@ namespace TrRouting
     virtual int getNodes(
       std::vector<std::unique_ptr<Node>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& stationIndexesById,
+      const std::map<boost::uuids::uuid, int>& stationIndexesById,
       std::string customPath = ""
     ) = 0;
 
@@ -190,8 +190,8 @@ namespace TrRouting
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
     ) = 0;
 
@@ -207,8 +207,8 @@ namespace TrRouting
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     ) = 0;
 
@@ -224,11 +224,11 @@ namespace TrRouting
     virtual int getScenarios(
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
     ) = 0;
 
@@ -243,15 +243,15 @@ namespace TrRouting
      */
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
-      std::vector<std::unique_ptr<Line>>& lines,
+      const std::vector<std::unique_ptr<Line>>& lines,
       std::vector<std::unique_ptr<Path>>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -47,34 +47,34 @@ namespace TrRouting
      virtual int getHouseholds(
       std::vector<std::unique_ptr<Household>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = "") {return 0;}
 
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
                            ) {return 0;}
 
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
                            ) {return 0;}
 
     virtual int getPlaces(
       std::vector<std::unique_ptr<Place>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
                           ) {return 0;}
 
@@ -99,23 +99,23 @@ namespace TrRouting
     virtual int getNodes(
       std::vector<std::unique_ptr<Node>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& stationIndexesById,
+      const std::map<boost::uuids::uuid, int>& stationIndexesById,
       std::string customPath = ""
                          ) {return 0;}
 
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
                          ) {return 0;}
 
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
                          ) {return 0;}
 
@@ -131,11 +131,11 @@ namespace TrRouting
     virtual int getScenarios(
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::string customPath = ""
                              ) {return 0;}
 
@@ -150,15 +150,15 @@ namespace TrRouting
      */
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
-      std::vector<std::unique_ptr<Line>>& lines,
+      const std::vector<std::unique_ptr<Line>>& lines,
       std::vector<std::unique_ptr<Path>>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 

--- a/src/households_cache_fetcher.cpp
+++ b/src/households_cache_fetcher.cpp
@@ -22,8 +22,8 @@ namespace TrRouting
   int CacheFetcher::getHouseholds(
     std::vector<std::unique_ptr<Household>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::string customPath
   )
   {
@@ -44,7 +44,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    for(std::map<boost::uuids::uuid, int>::iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
+    for(std::map<boost::uuids::uuid, int>::const_iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
     {
       boost::uuids::uuid dataSourceUuid = iter->first;
 
@@ -91,7 +91,7 @@ namespace TrRouting
             t->carNumber       = capnpT.getCarNumber();
             t->incomeLevel     = capnpT.getIncomeLevel();
             t->internalId      = capnpT.getInternalId();
-            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid[uuidGenerator(dataSourceUuid)] : -1;
+            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid.at(uuidGenerator(dataSourceUuid)) : -1;
 
             switch (capnpT.getIncomeLevelGroup()) {
               case household::Household::IncomeLevelGroup::NONE      : t->incomeLevelGroup = "none";     break;
@@ -124,7 +124,7 @@ namespace TrRouting
             for (int i = 0; i < homeNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getHomeNodesUuids()[i]};
-              homeNodesIdx               [i] = nodeIndexesByUuid[uuidGenerator(nodeUuid)];
+              homeNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
               homeNodesTravelTimesSeconds[i] = capnpT.getHomeNodesTravelTimes()[i];
               homeNodesDistancesMeters   [i] = capnpT.getHomeNodesDistances()[i];
             }

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -20,8 +20,8 @@ namespace TrRouting
   int CacheFetcher::getLines(
     std::vector<std::unique_ptr<Line>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-    std::map<std::string, int>& modeIndexesByShortname,
+    const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+    const std::map<std::string, int>& modeIndexesByShortname,
     std::string customPath
   )
   {
@@ -74,8 +74,8 @@ namespace TrRouting
         t->shortname              = capnpT.getShortname();
         t->longname               = capnpT.getLongname();
         t->internalId             = capnpT.getInternalId();
-        t->agencyIdx              = agencyIndexesByUuid[uuidGenerator(agencyUuid)];
-        t->modeIdx                = modeIndexesByShortname[capnpT.getMode()];
+        t->agencyIdx              = agencyIndexesByUuid.at(uuidGenerator(agencyUuid));
+        t->modeIdx                = modeIndexesByShortname.at(capnpT.getMode());
         t->allowSameLineTransfers = capnpT.getAllowSameLineTransfers();
         
         tIndexesByUuid[t->uuid] = ts.size();
@@ -86,6 +86,11 @@ namespace TrRouting
     {
       spdlog::error("Error opening cache file {}: {}", tStr, e.getDescription().cStr());
       ret = -EBADMSG;
+    }
+    catch (const std::exception& e)
+    {
+      spdlog::error("Unknown error occurred {} {}", tStr, e.what());
+      ret = -EINVAL;
     }
     catch (...)
     {

--- a/src/nodes_cache_fetcher.cpp
+++ b/src/nodes_cache_fetcher.cpp
@@ -24,7 +24,7 @@ namespace TrRouting
   int CacheFetcher::getNodes(
     std::vector<std::unique_ptr<Node>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& stationIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& stationIndexesByUuid,
     std::string customPath
   )
   {
@@ -84,7 +84,7 @@ namespace TrRouting
 
         if (stationUuid.length() > 0 && stationIndexesByUuid.count(uuidGenerator(stationUuid)) != 0)
         {
-          t->stationIdx = stationIndexesByUuid[uuidGenerator(stationUuid)];
+          t->stationIdx = stationIndexesByUuid.at(uuidGenerator(stationUuid));
         }
         else
         {

--- a/src/od_trips_cache_fetcher.cpp
+++ b/src/od_trips_cache_fetcher.cpp
@@ -20,10 +20,10 @@ namespace TrRouting
   int CacheFetcher::getOdTrips(
     std::vector<std::unique_ptr<OdTrip>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::string customPath
   )
   {
@@ -40,7 +40,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    for(std::map<boost::uuids::uuid, int>::iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
+    for(std::map<boost::uuids::uuid, int>::const_iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
     {
       boost::uuids::uuid dataSourceUuid = iter->first;
 
@@ -105,9 +105,9 @@ namespace TrRouting
             t->origin                 = std::move(origin);
             t->destination            = std::move(destination);
 
-            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid[uuidGenerator(dataSourceUuid)] : -1;
-            t->householdIdx    = householdUuid.length()  > 0 ? householdIndexesByUuid[uuidGenerator(householdUuid)]   : -1;
-            t->personIdx       = personUuid.length()     > 0 ? personIndexesByUuid[uuidGenerator(personUuid)]         : -1;
+            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid.at(uuidGenerator(dataSourceUuid)) : -1;
+            t->householdIdx    = householdUuid.length()  > 0 ? householdIndexesByUuid.at(uuidGenerator(householdUuid))   : -1;
+            t->personIdx       = personUuid.length()     > 0 ? personIndexesByUuid.at(uuidGenerator(personUuid))         : -1;
 
             switch (capnpT.getMode()) {
               case odTrip::OdTrip::Mode::NONE             : t->mode = "none";            break;
@@ -184,7 +184,7 @@ namespace TrRouting
             for (int i = 0; i < originNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getOriginNodesUuids()[i]};
-              originNodesIdx               [i] = nodeIndexesByUuid[uuidGenerator(nodeUuid)];
+              originNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
               originNodesTravelTimesSeconds[i] = capnpT.getOriginNodesTravelTimes()[i];
               originNodesDistancesMeters   [i] = capnpT.getOriginNodesDistances()[i];
             }
@@ -199,7 +199,7 @@ namespace TrRouting
             for (int i = 0; i < destinationNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getDestinationNodesUuids()[i]};
-              destinationNodesIdx               [i] = nodeIndexesByUuid[uuidGenerator(nodeUuid)];
+              destinationNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
               destinationNodesTravelTimesSeconds[i] = capnpT.getDestinationNodesTravelTimes()[i];
               destinationNodesDistancesMeters   [i] = capnpT.getDestinationNodesDistances()[i];
             }

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -21,8 +21,8 @@ namespace TrRouting
   int CacheFetcher::getPaths(
     std::vector<std::unique_ptr<Path>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::string customPath
   )
   {
@@ -78,12 +78,12 @@ namespace TrRouting
         t->uuid                   = uuidGenerator(uuid);
         t->direction              = capnpT.getDirection();
         t->internalId             = capnpT.getInternalId();
-        t->lineIdx                = lineIndexesByUuid[uuidGenerator(lineUuid)];
+        t->lineIdx                = lineIndexesByUuid.at(uuidGenerator(lineUuid));
         t->tripsIdx               = tripsIdx;
         for (std::string nodeUuidStr : capnpT.getNodesUuids())
         {
           nodeUuid = uuidGenerator(nodeUuidStr);
-          nodesIdx.push_back(nodeIndexesByUuid[nodeUuid]);
+          nodesIdx.push_back(nodeIndexesByUuid.at(nodeUuid));
         }
         t->nodesIdx = nodesIdx;
 
@@ -112,6 +112,11 @@ namespace TrRouting
     {
       spdlog::error("Error opening cache file {}: {}", tStr, e.getDescription().cStr());
       ret = -EBADMSG;
+    }
+    catch (const std::exception& e)
+    {
+      spdlog::error("Unknown error occurred {} {}", tStr, e.what());
+      ret = -EINVAL;
     }
     catch (...)
     {

--- a/src/persons_cache_fetcher.cpp
+++ b/src/persons_cache_fetcher.cpp
@@ -20,9 +20,9 @@ namespace TrRouting
   int CacheFetcher::getPersons(
     std::vector<std::unique_ptr<Person>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& householdIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::string customPath
   )
   { 
@@ -42,7 +42,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    for(std::map<boost::uuids::uuid, int>::iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
+    for(std::map<boost::uuids::uuid, int>::const_iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
     {
       boost::uuids::uuid dataSourceUuid = iter->first;
 
@@ -94,8 +94,8 @@ namespace TrRouting
             t->drivingLicenseOwner   = capnpT.getDrivingLicenseOwner();
             t->transitPassOwner      = capnpT.getTransitPassOwner();
 
-            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid[uuidGenerator(dataSourceUuid)] : -1;
-            t->householdIdx    = householdUuid.length()  > 0 ? householdIndexesByUuid[uuidGenerator(householdUuid)]   : -1;
+            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid.at(uuidGenerator(dataSourceUuid)) : -1;
+            t->householdIdx    = householdUuid.length()  > 0 ? householdIndexesByUuid.at(uuidGenerator(householdUuid))   : -1;
 
             switch (capnpT.getAgeGroup()) {
               case person::Person::AgeGroup::NONE     : t->ageGroup = "none";     break;
@@ -157,7 +157,7 @@ namespace TrRouting
             for (int i = 0; i < usualWorkPlaceNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getUsualWorkPlaceNodesUuids()[i]};
-              usualWorkPlaceNodesIdx               [i] = nodeIndexesByUuid[uuidGenerator(nodeUuid)];
+              usualWorkPlaceNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
               usualWorkPlaceNodesTravelTimesSeconds[i] = capnpT.getUsualWorkPlaceNodesTravelTimes()[i];
               usualWorkPlaceNodesDistancesMeters   [i] = capnpT.getUsualWorkPlaceNodesDistances()[i];
             }
@@ -178,7 +178,7 @@ namespace TrRouting
             for (int i = 0; i < usualSchoolPlaceNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getUsualSchoolPlaceNodesUuids()[i]};
-              usualSchoolPlaceNodesIdx               [i] = nodeIndexesByUuid[uuidGenerator(nodeUuid)];
+              usualSchoolPlaceNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
               usualSchoolPlaceNodesTravelTimesSeconds[i] = capnpT.getUsualSchoolPlaceNodesTravelTimes()[i];
               usualSchoolPlaceNodesDistancesMeters   [i] = capnpT.getUsualSchoolPlaceNodesDistances()[i];
             }

--- a/src/places_cache_fetcher.cpp
+++ b/src/places_cache_fetcher.cpp
@@ -20,8 +20,8 @@ namespace TrRouting
   int CacheFetcher::getPlaces(
     std::vector<std::unique_ptr<Place>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::string customPath
   )
   {
@@ -38,7 +38,7 @@ namespace TrRouting
 
     spdlog::info("Fetching {} from cache... {}", tStr, customPath);
 
-    for(std::map<boost::uuids::uuid, int>::iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
+    for(std::map<boost::uuids::uuid, int>::const_iterator iter = dataSourceIndexesByUuid.begin(); iter != dataSourceIndexesByUuid.end(); ++iter)
     {
       boost::uuids::uuid dataSourceUuid = iter->first;
 
@@ -85,7 +85,7 @@ namespace TrRouting
             t->shortname       = capnpT.getShortname();
             t->name            = capnpT.getName();
             t->internalId      = capnpT.getInternalId();
-            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid[uuidGenerator(dataSourceUuid)] : -1;
+            t->dataSourceIdx   = dataSourceUuid.length() > 0 ? dataSourceIndexesByUuid.at(uuidGenerator(dataSourceUuid)) : -1;
 
             point->latitude  = ((double)capnpT.getLatitude())  / 1000000.0;
             point->longitude = ((double)capnpT.getLongitude()) / 1000000.0;
@@ -98,7 +98,7 @@ namespace TrRouting
             for (int i = 0; i < nodesCount; i++)
             {
               std::string nodeUuid {capnpT.getNodesUuids()[i]};
-              nodesIdx               [i] = nodeIndexesByUuid[uuidGenerator(nodeUuid)];
+              nodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
               nodesTravelTimesSeconds[i] = capnpT.getNodesTravelTimes()[i];
               nodesDistancesMeters   [i] = capnpT.getNodesDistances()[i];
             }

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -21,11 +21,11 @@ namespace TrRouting
   int CacheFetcher::getScenarios(
     std::vector<std::unique_ptr<Scenario>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    std::map<std::string, int>& modeIndexesByShortname,
+    const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<std::string, int>& modeIndexesByShortname,
     std::string customPath
   ) {
 
@@ -97,7 +97,7 @@ namespace TrRouting
           serviceUuid = uuidGenerator(serviceUuidStr);
           if (serviceIndexesByUuid.count(serviceUuid) != 0)
           {
-            servicesIdx.push_back(serviceIndexesByUuid[serviceUuid]);
+            servicesIdx.push_back(serviceIndexesByUuid.at(serviceUuid));
           }
         }
         t->servicesIdx = servicesIdx;
@@ -106,7 +106,7 @@ namespace TrRouting
           lineUuid = uuidGenerator(lineUuidStr);
           if (lineIndexesByUuid.count(lineUuid) != 0)
           {
-            onlyLinesIdx.push_back(lineIndexesByUuid[lineUuid]);
+            onlyLinesIdx.push_back(lineIndexesByUuid.at(lineUuid));
           }
         }
         t->onlyLinesIdx = onlyLinesIdx;
@@ -115,7 +115,7 @@ namespace TrRouting
           agencyUuid = uuidGenerator(agencyUuidStr);
           if (agencyIndexesByUuid.count(agencyUuid) != 0)
           {
-            onlyAgenciesIdx.push_back(agencyIndexesByUuid[agencyUuid]);
+            onlyAgenciesIdx.push_back(agencyIndexesByUuid.at(agencyUuid));
           }
         }
         t->onlyAgenciesIdx = onlyAgenciesIdx;
@@ -124,7 +124,7 @@ namespace TrRouting
           nodeUuid = uuidGenerator(nodeUuidStr);
           if (nodeIndexesByUuid.count(nodeUuid) != 0)
           {
-            onlyNodesIdx.push_back(nodeIndexesByUuid[nodeUuid]);
+            onlyNodesIdx.push_back(nodeIndexesByUuid.at(nodeUuid));
           }
         }
         t->onlyNodesIdx = onlyNodesIdx;
@@ -132,7 +132,7 @@ namespace TrRouting
         {
           if (modeIndexesByShortname.count(modeShortnameStr) != 0)
           {
-            onlyModesIdx.push_back(modeIndexesByShortname[modeShortnameStr]);
+            onlyModesIdx.push_back(modeIndexesByShortname.at(modeShortnameStr));
           }
         }
         t->onlyModesIdx = onlyModesIdx;
@@ -142,7 +142,7 @@ namespace TrRouting
           lineUuid = uuidGenerator(lineUuidStr);
           if (lineIndexesByUuid.count(lineUuid) != 0)
           {
-            exceptLinesIdx.push_back(lineIndexesByUuid[lineUuid]);
+            exceptLinesIdx.push_back(lineIndexesByUuid.at(lineUuid));
           }
         }
         t->exceptLinesIdx = exceptLinesIdx;
@@ -151,7 +151,7 @@ namespace TrRouting
           agencyUuid = uuidGenerator(agencyUuidStr);
           if (agencyIndexesByUuid.count(agencyUuid) != 0)
           {
-            exceptAgenciesIdx.push_back(agencyIndexesByUuid[agencyUuid]);
+            exceptAgenciesIdx.push_back(agencyIndexesByUuid.at(agencyUuid));
           }
         }
         t->exceptAgenciesIdx = exceptAgenciesIdx;
@@ -160,7 +160,7 @@ namespace TrRouting
           nodeUuid = uuidGenerator(nodeUuidStr);
           if (nodeIndexesByUuid.count(nodeUuid) != 0)
           {
-            exceptNodesIdx.push_back(nodeIndexesByUuid[nodeUuid]);
+            exceptNodesIdx.push_back(nodeIndexesByUuid.at(nodeUuid));
           }
         }
         t->exceptNodesIdx = exceptNodesIdx;
@@ -168,7 +168,7 @@ namespace TrRouting
         {
           if (modeIndexesByShortname.count(modeShortnameStr) != 0)
           {
-            exceptModesIdx.push_back(modeIndexesByShortname[modeShortnameStr]);
+            exceptModesIdx.push_back(modeIndexesByShortname.at(modeShortnameStr));
           }
         }
         t->exceptModesIdx = exceptModesIdx;

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -23,15 +23,15 @@ namespace TrRouting
   
   int CacheFetcher::getSchedules(
     std::vector<std::unique_ptr<Trip>>& trips,
-    std::vector<std::unique_ptr<Line>>& lines,
+    const std::vector<std::unique_ptr<Line>>& lines,
     std::vector<std::unique_ptr<Path>>& paths,
     std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-    std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    std::map<std::string, int>& modeIndexesByShortname,
+    const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<std::string, int>& modeIndexesByShortname,
     std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
     std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
     std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 
@@ -51,7 +51,7 @@ namespace TrRouting
     connections.clear();
     connections.shrink_to_fit();
 
-    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname["transferable"] : -1};
+    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname.at("transferable") : -1};
 
     //std::vector<Block> blocks;
     //std::map<boost::uuids::uuid, int> blockIndexesByUuid;
@@ -89,7 +89,7 @@ namespace TrRouting
         {
           serviceUuidStr = schedule.getServiceUuid();
           serviceUuid    = uuidGenerator(serviceUuidStr);
-          serviceIdx     = serviceIndexesByUuid[serviceUuid];
+          serviceIdx     = serviceIndexesByUuid.at(serviceUuid);
 
           const auto periods {schedule.getPeriods()};
           for (const auto & period : periods)
@@ -101,15 +101,15 @@ namespace TrRouting
               pathUuidStr  = capnpTrip.getPathUuid();
               tripUuid     = uuidGenerator(tripUuidStr);
               pathUuid     = uuidGenerator(pathUuidStr);
-              path         = paths[pathIndexesByUuid[pathUuid]].get();
+              path         = paths[pathIndexesByUuid.at(pathUuid)].get();
               pathNodesIdx = path->nodesIdx;
               
               std::unique_ptr<Trip> trip = std::make_unique<Trip>();
 
               trip->uuid                   = tripUuid;
               trip->agencyIdx              = line->agencyIdx;
-              trip->lineIdx                = lineIndexesByUuid[line->uuid];
-              trip->pathIdx                = pathIndexesByUuid[pathUuid];
+              trip->lineIdx                = lineIndexesByUuid.at(line->uuid);
+              trip->pathIdx                = pathIndexesByUuid.at(pathUuid);
               trip->modeIdx                = line->modeIdx;
               trip->serviceIdx             = serviceIdx;
               trip->totalCapacity          = capnpTrip.getTotalCapacity();

--- a/tests/cache_fetch/lines_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/lines_cache_fetcher_test.cpp
@@ -23,6 +23,16 @@ public:
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines.capnpbin");
+
+        // Load valid data 
+        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
+        int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+
+        std::vector<std::unique_ptr<TrRouting::Line>> lines;
+
+        std::vector<TrRouting::Mode>                        modes;
+        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
+        
     }
 
     void TearDown( ) override

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -23,6 +23,24 @@ public:
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/paths.capnpbin");
+
+        // Load valid data 
+        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
+        std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
+        int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+
+        std::vector<std::unique_ptr<TrRouting::Line>> lines;
+
+        std::vector<TrRouting::Mode>                        modes;
+        std::map<std::string, int> modeIndexesByShortname;
+        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+
+        // Empty Station
+        std::map<boost::uuids::uuid, int>        stationIndexesByUuid;
+
+        std::vector<std::unique_ptr<TrRouting::Node>> nodes;
+        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
     }
 
     void TearDown( ) override

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -26,6 +26,28 @@ public:
         BaseCacheFetcherFixtureTests::SetUp();
         // Copy the invalid file
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/scenarios.capnpbin");
+
+        // Load valid data 
+        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
+        cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+
+        std::vector<std::unique_ptr<TrRouting::Line>> lines;
+
+        std::vector<TrRouting::Mode>                        modes;
+        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+
+        std::vector<std::unique_ptr<TrRouting::Station>>     stations;
+        std::map<boost::uuids::uuid, int>        stationIndexesByUuid;
+
+        cacheFetcher.getStations(stations, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+
+        std::vector<std::unique_ptr<TrRouting::Node>> nodes;
+        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
+
+        std::vector<std::unique_ptr<TrRouting::Service>> services;
+        cacheFetcher.getServices(services, serviceIndexesByUuid, VALID_CUSTOM_PATH);
+
     }
 
     void TearDown( ) override

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -36,6 +36,13 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Read valid data for agencies, lines and paths
+        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
+        cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+        std::vector<TrRouting::Mode>                        modes;
+        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
+        std::vector<std::unique_ptr<TrRouting::Service>> services;
+        cacheFetcher.getServices(services, serviceIndexesByUuid, VALID_CUSTOM_PATH);
+
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
         cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
         cacheFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);


### PR DESCRIPTION
Several of the parameters passed to the various function were on fact read only
Add const qualifier to highlight and enforce this fact.

Several accessor had to be changed from [] to at(). With that, since at() validate that the data is
there, several tests need to be changed to actually load the dependent data.