### PR TITLE
Remove modeIndexesByShortname by using direct reference to Mode object

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -137,10 +137,10 @@ namespace TrRouting
     // TODO As part of issue https://github.com/chairemobilite/trRouting/issues/95, this will be removed
     void initializeCalculationData();
 
-
-    std::vector<Mode>                        modes;
-    std::map<std::string, int>               modeIndexesByShortname;
-
+    std::map<std::string, Mode>              modes;
+    // Prefer using getModes to access the mode object, so that we have read-only version
+    // TODO eventually, this will be moved to a const data container
+    const std::map<std::string, Mode> & getModes() {return modes;}
 
     std::vector<std::unique_ptr<DataSource>> dataSources;
     std::map<boost::uuids::uuid, int>        dataSourceIndexesByUuid;

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -27,8 +27,6 @@ namespace TrRouting
     int              reachableNodesCount  {0};
     bool             foundLine            {false};
 
-    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname["transferable"] : -1};
-
     std::vector<int> resultingNodes;
     if (params.returnAllNodesResult)
     {
@@ -54,7 +52,6 @@ namespace TrRouting
       ConnectionTuple * journeyStepExitConnection;
       std::vector<boost::uuids::uuid>                   lineUuids;
       std::vector<int>                                  linesIdx;
-      std::vector<std::string>                          modeShortnames;
       std::vector<boost::uuids::uuid>                   agencyUuids;
       std::vector<boost::uuids::uuid>                   unboardingNodeUuids;
       std::vector<boost::uuids::uuid>                   boardingNodeUuids;
@@ -67,7 +64,6 @@ namespace TrRouting
       Node *   journeyStepNodeArrival;
       Trip *   journeyStepTrip;
       Line *   journeyStepLine;
-      Mode     journeyStepMode;
       Path *   journeyStepPath;
       Agency * journeyStepAgency;
 
@@ -94,7 +90,6 @@ namespace TrRouting
         unboardingNodeUuids.clear();
         tripUuids.clear();
         tripsIdx.clear();
-        modeShortnames.clear();
         inVehicleTravelTimesSeconds.clear();
 
         totalInVehicleTime       =  0; transferArrivalTime    = -1; firstDepartureTime     = -1;
@@ -148,7 +143,6 @@ namespace TrRouting
             journeyStepAgency          = agencies[journeyStepTrip->agencyIdx].get();
             journeyStepLine            = lines[journeyStepTrip->lineIdx].get();
             journeyStepPath            = paths[journeyStepTrip->pathIdx].get();
-            journeyStepMode            = modes[journeyStepLine->modeIdx];
             transferTime               = std::get<journeyStepIndexes::TRANSFER_TRAVEL_TIME>(journeyStep);
             distance                   = std::get<journeyStepIndexes::TRANSFER_DISTANCE>(journeyStep);
             inVehicleDistance          = 0;
@@ -168,13 +162,12 @@ namespace TrRouting
 
             totalInVehicleTime         += inVehicleTime;
             totalWaitingTime           += waitingTime;
-            if (transferableModeIdx != journeyStepLine->modeIdx)
+            if (Mode::TRANSFERABLE != journeyStepLine->mode.shortname)
             {
               numberOfTransfers += 1;
             }
             lineUuids.push_back(journeyStepLine->uuid);
             linesIdx.push_back(journeyStepTrip->lineIdx);
-            modeShortnames.push_back(journeyStepMode.shortname);
             inVehicleTravelTimesSeconds.push_back(inVehicleTime);
             agencyUuids.push_back(journeyStepAgency->uuid);
             boardingNodeUuids.push_back(journeyStepNodeDeparture->uuid);
@@ -190,7 +183,7 @@ namespace TrRouting
                 inVehicleDistance += journeyStepPath->segmentsDistanceMeters[seqI];
               }
               totalDistance += inVehicleDistance;
-              if (transferableModeIdx == journeyStepLine->modeIdx)
+              if (Mode::TRANSFERABLE == journeyStepLine->mode.shortname)
               {
                 totalWalkingDistance     += inVehicleDistance;
                 totalWalkingTime         += inVehicleTime;
@@ -230,8 +223,8 @@ namespace TrRouting
                 journeyStepLine->shortname,
                 journeyStepLine->longname,
                 journeyStepPath->uuid,
-                journeyStepMode.name,
-                journeyStepMode.shortname,
+                journeyStepLine->mode.name,
+                journeyStepLine->mode.shortname,
                 journeyStepTrip->uuid,
                 boardingSequence,
                 boardingSequence,
@@ -251,8 +244,8 @@ namespace TrRouting
                 journeyStepLine->shortname,
                 journeyStepLine->longname,
                 journeyStepPath->uuid,
-                journeyStepMode.name,
-                journeyStepMode.shortname,
+                journeyStepLine->mode.name,
+                journeyStepLine->mode.shortname,
                 journeyStepTrip->uuid,
                 unboardingSequence,
                 unboardingSequence + 1,

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -59,7 +59,7 @@ namespace TrRouting
 
   int Calculator::updateLinesFromCache(std::string customPath)
   {
-    return dataFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, customPath);
+    return dataFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, getModes(), customPath);
   }
 
   int Calculator::updatePathsFromCache(std::string customPath)
@@ -69,7 +69,7 @@ namespace TrRouting
 
   int Calculator::updateScenariosFromCache(std::string customPath)
   {
-    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, customPath);
+    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, getModes(), customPath);
   }
 
   int Calculator::updateSchedulesFromCache(std::string customPath)
@@ -85,7 +85,6 @@ namespace TrRouting
       pathIndexesByUuid,
       agencyIndexesByUuid,
       nodeIndexesByUuid,
-      modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
@@ -136,7 +135,7 @@ namespace TrRouting
 
     spdlog::debug("preparing nodes, routes, trips, connections and footpaths...");
     
-    std::tie(modes, modeIndexesByShortname) = dataFetcher.getModes();
+    modes = dataFetcher.getModes();
 
     //updateStationsFromCache();
     //updateStopsFromCache();

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -6,6 +6,7 @@
 #include "toolbox.hpp" //MAX_INT
 #include "od_trip.hpp"
 #include "routing_result.hpp"
+#include "mode.hpp"
 
 namespace TrRouting
 {
@@ -263,9 +264,9 @@ namespace TrRouting
           }
         }
 
-        if (tripsEnabled[i] == 1 && parameters.getOnlyModesIdx()->size() > 0)
+        if (tripsEnabled[i] == 1 && parameters.getOnlyModes().size() > 0)
         {
-          if (std::find(parameters.getOnlyModesIdx()->begin(), parameters.getOnlyModesIdx()->end(), trip->modeIdx) == parameters.getOnlyModesIdx()->end())
+          if (std::find(parameters.getOnlyModes().begin(), parameters.getOnlyModes().end(), trip->mode) == parameters.getOnlyModes().end())
           {
             tripsEnabled[i] = -1;
           }
@@ -274,10 +275,11 @@ namespace TrRouting
         if (tripsEnabled[i] == 1 && parameters.getOnlyNodesIdx()->size() > 0)
         {
           // FIXME: This is not right, it should look for a node, not the mode
-          if (std::find(parameters.getOnlyNodesIdx()->begin(), parameters.getOnlyNodesIdx()->end(), trip->modeIdx) == parameters.getOnlyNodesIdx()->end())
+          // FIXME2: Commented out, since mode is now typed, it won't match
+          /*if (std::find(parameters.getOnlyNodesIdx()->begin(), parameters.getOnlyNodesIdx()->end(), trip->modeIdx) == parameters.getOnlyNodesIdx()->end())
           {
             tripsEnabled[i] = -1;
-          }
+          }(*/
         }
 
         if (tripsEnabled[i] == 1 && parameters.getOnlyAgenciesIdx()->size() > 0)
@@ -307,15 +309,17 @@ namespace TrRouting
         if (tripsEnabled[i] == 1 && parameters.getExceptNodesIdx()->size() > 0)
         {
           // FIXME: This is not right, it should look for a node, not the mode
+          // FIXME2: Commented out, since mode is now typed, it won't match
+          /*
           if (std::find(parameters.getExceptNodesIdx()->begin(), parameters.getExceptNodesIdx()->end(), trip->modeIdx) != parameters.getExceptNodesIdx()->end())
           {
             tripsEnabled[i] = -1;
-          }
+            }*/
         }
 
-        if (tripsEnabled[i] == 1 && parameters.getExceptModesIdx()->size() > 0)
+        if (tripsEnabled[i] == 1 && parameters.getExceptModes().size() > 0)
         {
-          if (std::find(parameters.getExceptModesIdx()->begin(), parameters.getExceptModesIdx()->end(), trip->modeIdx) != parameters.getExceptModesIdx()->end())
+          if (std::find(parameters.getExceptModes().begin(), parameters.getExceptModes().end(), trip->mode) != parameters.getExceptModes().end())
           {
             tripsEnabled[i] = -1;
           }

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -24,8 +24,6 @@ namespace TrRouting
     int              reachableNodesCount  {0};
     bool             foundRoute           {false};
 
-    int transferableModeIdx {modeIndexesByShortname.find("transferable") != modeIndexesByShortname.end() ? modeIndexesByShortname["transferable"] : -1};
-
     std::vector<int> resultingNodes;
     if (params.returnAllNodesResult)
     {
@@ -51,7 +49,6 @@ namespace TrRouting
       ConnectionTuple * journeyStepExitConnection;
       std::vector<boost::uuids::uuid>                   lineUuids;
       std::vector<int>                                  linesIdx;
-      std::vector<std::string>                          modeShortnames;
       std::vector<boost::uuids::uuid>                   agencyUuids;
       std::vector<boost::uuids::uuid>                   unboardingNodeUuids;
       std::vector<boost::uuids::uuid>                   boardingNodeUuids;
@@ -64,7 +61,6 @@ namespace TrRouting
       Node *   journeyStepNodeArrival;
       Trip *   journeyStepTrip;
       Line *   journeyStepLine;
-      Mode     journeyStepMode;
       Path *   journeyStepPath;
       Agency * journeyStepAgency;
 
@@ -91,7 +87,6 @@ namespace TrRouting
         unboardingNodeUuids.clear();
         tripUuids.clear();
         tripsIdx.clear();
-        modeShortnames.clear();
         inVehicleTravelTimesSeconds.clear();
 
         totalInVehicleTime          =  0; transferArrivalTime    = -1; firstDepartureTime   = -1;
@@ -180,7 +175,6 @@ namespace TrRouting
             journeyStepAgency           = agencies[journeyStepTrip->agencyIdx].get();
             journeyStepLine             = lines[journeyStepTrip->lineIdx].get();
             journeyStepPath             = paths[journeyStepTrip->pathIdx].get();
-            journeyStepMode             = modes[journeyStepLine->modeIdx];
             transferTime                = std::get<journeyStepIndexes::TRANSFER_TRAVEL_TIME>(journeyStep);
             distance                    = std::get<journeyStepIndexes::TRANSFER_DISTANCE>(journeyStep);
             inVehicleDistance           = 0;
@@ -200,13 +194,12 @@ namespace TrRouting
 
             totalInVehicleTime         += inVehicleTime;
             totalWaitingTime           += waitingTime;
-            if (transferableModeIdx != journeyStepLine->modeIdx)
+            if (Mode::TRANSFERABLE != journeyStepLine->mode.shortname)
             {
               numberOfTransfers += 1;
             }
             lineUuids.push_back(journeyStepLine->uuid);
             linesIdx.push_back(journeyStepTrip->lineIdx);
-            modeShortnames.push_back(journeyStepMode.shortname);
             inVehicleTravelTimesSeconds.push_back(inVehicleTime);
             agencyUuids.push_back(journeyStepAgency->uuid);
             boardingNodeUuids.push_back(journeyStepNodeDeparture->uuid);
@@ -222,7 +215,7 @@ namespace TrRouting
                 inVehicleDistance += journeyStepPath->segmentsDistanceMeters[seqI];
               }
               totalDistance += inVehicleDistance;
-              if (transferableModeIdx == journeyStepLine->modeIdx)
+              if (Mode::TRANSFERABLE == journeyStepLine->mode.shortname)
               {
                 totalWalkingDistance     += inVehicleDistance;
                 totalWalkingTime         += inVehicleTime;
@@ -261,8 +254,8 @@ namespace TrRouting
                 journeyStepLine->shortname,
                 journeyStepLine->longname,
                 journeyStepPath->uuid,
-                journeyStepMode.name,
-                journeyStepMode.shortname,
+                journeyStepLine->mode.name,
+                journeyStepLine->mode.shortname,
                 journeyStepTrip->uuid,
                 boardingSequence,
                 boardingSequence,
@@ -282,8 +275,8 @@ namespace TrRouting
                 journeyStepLine->shortname,
                 journeyStepLine->longname,
                 journeyStepPath->uuid,
-                journeyStepMode.name,
-                journeyStepMode.shortname,
+                journeyStepLine->mode.name,
+                journeyStepLine->mode.shortname,
                 journeyStepTrip->uuid,
                 unboardingSequence,
                 unboardingSequence + 1,

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -45,11 +45,11 @@ namespace TrRouting
     onlyLinesIdx = scenario.onlyLinesIdx;
     onlyAgenciesIdx = scenario.onlyAgenciesIdx;
     onlyNodesIdx = scenario.onlyNodesIdx;
-    onlyModesIdx = scenario.onlyModesIdx;
+    onlyModes = scenario.onlyModes;
     exceptLinesIdx = scenario.exceptLinesIdx;
     exceptAgenciesIdx = scenario.exceptAgenciesIdx;
     exceptNodesIdx = scenario.exceptNodesIdx;
-    exceptModesIdx = scenario.exceptModesIdx;
+    exceptModes = scenario.exceptModes;
   }
 
   RouteParameters::RouteParameters(const RouteParameters& routeParams):
@@ -70,11 +70,11 @@ namespace TrRouting
     onlyLinesIdx(routeParams.onlyLinesIdx),
     onlyAgenciesIdx(routeParams.onlyAgenciesIdx),
     onlyNodesIdx(routeParams.onlyNodesIdx),
-    onlyModesIdx(routeParams.onlyModesIdx),
+    onlyModes(routeParams.onlyModes),
     exceptLinesIdx(routeParams.exceptLinesIdx),
     exceptAgenciesIdx(routeParams.exceptAgenciesIdx),
     exceptNodesIdx(routeParams.exceptNodesIdx),
-    exceptModesIdx(routeParams.exceptModesIdx)
+    exceptModes(routeParams.exceptModes)
   {
   }
 

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -61,7 +61,7 @@ namespace TrRouting
      */
     std::string getFilePath  (         std::string cacheFilePath, std::string customPath = "");
     
-    virtual const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes();
+    virtual const std::map<std::string, Mode> getModes();
 
     /** Refer to the base class for these functions documentations */
     virtual int getDataSources(
@@ -134,7 +134,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     );
 
@@ -153,7 +153,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     );
 
@@ -167,7 +167,6 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -30,7 +30,7 @@ namespace TrRouting
   class DataFetcher
   {
   public:
-      virtual const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes() = 0;
+      virtual const std::map<std::string, Mode> getModes() = 0;
 
       //TODO the customPath does not make much sense to a generic data access pattern (see issue #160)
     /**
@@ -191,7 +191,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     ) = 0;
 
@@ -228,7 +228,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     ) = 0;
 
@@ -251,7 +251,6 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -33,10 +33,9 @@ namespace TrRouting
   public:
     DummyDataFetcher() {}
     virtual ~DummyDataFetcher() {}
-    virtual const std::pair<std::vector<Mode>, std::map<std::string, int>> getModes() {
-      std::vector<Mode> ts;
-      std::map<std::string, int> tIndexesByShortname;
-      return std::make_pair(ts, tIndexesByShortname);
+    virtual const  std::map<std::string, Mode> getModes() {
+      std::map<std::string, Mode> modes;
+      return modes;
     };
     
     virtual int getDataSources(
@@ -107,7 +106,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<std::string, Mode>& modes,
       std::string customPath = ""
                          ) {return 0;}
 
@@ -135,7 +134,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
+      const std::map<std::string, Mode>& modes,
       std::string customPath = ""
                              ) {return 0;}
 
@@ -158,7 +157,6 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      const std::map<std::string, int>& modeIndexesByShortname,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>>& connections, 

--- a/include/line.hpp
+++ b/include/line.hpp
@@ -7,14 +7,30 @@
 
 namespace TrRouting
 {
+
+  class Mode;
   
   struct Line {
   
   public:
-   
+    Line(const boost::uuids::uuid &auuid,
+         int aagencyIdx,
+         const Mode &amode,
+         const std::string &ashortname,
+         const std::string &alongname,
+         const std::string &ainternalId,
+         short aallowSameLineTransfers):
+      uuid(auuid),
+      agencyIdx(aagencyIdx),
+      mode(amode),
+      shortname(ashortname),
+      longname(alongname),
+      internalId(ainternalId),
+      allowSameLineTransfers(aallowSameLineTransfers) {}
+
     boost::uuids::uuid uuid;
     int agencyIdx;
-    int modeIdx;
+    const Mode &mode;
     std::string shortname;
     std::string longname;
     std::string internalId;

--- a/include/mode.hpp
+++ b/include/mode.hpp
@@ -9,7 +9,16 @@ namespace TrRouting
   struct Mode {
   
   public:
-   
+    inline static const std::string TRANSFERABLE {"transferable"}; 
+
+    Mode(const std::string &ashortname,
+         const std::string &aname,
+         int agtfsId,
+         int aextendedGtfsId) : shortname(ashortname),
+                                name(aname),
+                                gtfsId(agtfsId),
+                                extendedGtfsId(aextendedGtfsId) {}
+
     std::string shortname;
     std::string name;
     int gtfsId;
@@ -19,8 +28,15 @@ namespace TrRouting
       return "Mode\n  shortname " + shortname + "\n  name " + name + "\n  gtfsId " + std::to_string(gtfsId) + "\n  extendedGtfsId " + std::to_string(extendedGtfsId);
     }
 
+    // Equal operator. We only compare the shortname, since they should be unique.
+    inline bool operator==(const Mode& other ) const { return shortname == other.shortname; }
   };
 
+  // To use std::find with a vector<reference_wrapper<const Mode>>
+  inline bool operator==(const std::reference_wrapper<const TrRouting::Mode>& lhs, const Mode& rhs)
+  {
+    return lhs.get().shortname == rhs.shortname;
+  }
 }
 
 #endif // TR_MODE

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -14,6 +14,7 @@ namespace TrRouting
   class OdTrip;
   class Scenario;
   class Node;
+  class Mode;
 
   class ParameterException : public std::exception
   {
@@ -70,8 +71,8 @@ namespace TrRouting
       // FIXME: Temporarily moved to public until calculation specific parameters exist. This is used directly by alternatives routing.
       // see https://github.com/chairemobilite/trRouting/issues/95
       // std::vector<int> exceptLinesIdx;
-      std::vector<int> onlyModesIdx;
-      std::vector<int> exceptModesIdx;
+      std::vector<std::reference_wrapper<const Mode>> onlyModes;
+      std::vector<std::reference_wrapper<const Mode>> exceptModes;
       std::vector<int> onlyAgenciesIdx;
       std::vector<int> exceptAgenciesIdx;
       std::vector<int> onlyNodesIdx;
@@ -124,8 +125,8 @@ namespace TrRouting
       std::vector<int>* getExceptServicesIdx() { return &exceptServicesIdx; }
       std::vector<int>* getOnlyLinesIdx() { return &onlyLinesIdx; }
       std::vector<int>* getExceptLinesIdx() { return &exceptLinesIdx; }
-      std::vector<int>* getOnlyModesIdx() { return &onlyModesIdx; }
-      std::vector<int>* getExceptModesIdx() { return &exceptModesIdx; }
+      const std::vector<std::reference_wrapper<const Mode>>& getOnlyModes() { return onlyModes; }
+      const std::vector<std::reference_wrapper<const Mode>>& getExceptModes() { return exceptModes; }
       std::vector<int>* getOnlyAgenciesIdx() { return &onlyAgenciesIdx; }
       std::vector<int>* getExceptAgenciesIdx() { return &exceptAgenciesIdx; }
       std::vector<int>* getOnlyNodesIdx() { return &onlyNodesIdx; }

--- a/include/scenario.hpp
+++ b/include/scenario.hpp
@@ -7,6 +7,7 @@
 
 namespace TrRouting
 {
+  class Mode;
   
   struct Scenario {
   
@@ -16,11 +17,11 @@ namespace TrRouting
     std::string name;
     boost::uuids::uuid simulationUuid;
     std::vector<int> servicesIdx;
-    std::vector<int> onlyModesIdx;
+    std::vector<std::reference_wrapper<const Mode>> onlyModes;
     std::vector<int> onlyLinesIdx;
     std::vector<int> onlyAgenciesIdx;
     std::vector<int> onlyNodesIdx;
-    std::vector<int> exceptModesIdx;
+    std::vector<std::reference_wrapper<const Mode>> exceptModes;
     std::vector<int> exceptLinesIdx;
     std::vector<int> exceptAgenciesIdx;
     std::vector<int> exceptNodesIdx;

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -6,21 +6,41 @@
 
 namespace TrRouting
 {
+  class Mode;
   
   struct Trip {
   
   public:
+    Trip( boost::uuids::uuid auuid,
+          int aagencyIdx,
+          int alineIdx,
+          int apathIdx,
+          const Mode &amode,
+          int aserviceIdx,
+          int ablockIdx,
+          short aallowSameLineTransfers,
+          int atotalCapacity = -1,
+          int aseatedCapacity = -1): uuid(auuid),
+                                         agencyIdx(aagencyIdx),
+                                         lineIdx(alineIdx),
+                                         pathIdx(apathIdx),
+                                         mode(amode),
+                                         serviceIdx(aserviceIdx),
+                                         blockIdx(ablockIdx),
+                                         totalCapacity(atotalCapacity),
+                                         seatedCapacity(aseatedCapacity),
+                                         allowSameLineTransfers(aallowSameLineTransfers) {}
    
     boost::uuids::uuid uuid;
     int agencyIdx;
     int lineIdx;
     int pathIdx;
-    int modeIdx;
+    const Mode &mode;
     int serviceIdx;
     int blockIdx;
-    int totalCapacity;
-    int seatedCapacity;
     short allowSameLineTransfers;
+    int totalCapacity; //Unused
+    int seatedCapacity; //Unused
     std::vector<int> forwardConnectionsIdx;
     std::vector<int> reverseConnectionsIdx;
 

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -21,7 +21,7 @@ namespace TrRouting
     std::vector<std::unique_ptr<Line>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
-    const std::map<std::string, int>& modeIndexesByShortname,
+    const std::map<std::string, Mode>& modes, 
     std::string customPath
   )
   {
@@ -68,16 +68,15 @@ namespace TrRouting
         std::string uuid       {capnpT.getUuid()};
         std::string agencyUuid {capnpT.getAgencyUuid()};
         
-        std::unique_ptr<T> t = std::make_unique<T>();
+        std::unique_ptr<T> t = std::make_unique<T>(
+                                                   uuidGenerator(uuid),
+                                                   agencyIndexesByUuid.at(uuidGenerator(agencyUuid)),
+                                                   modes.at(capnpT.getMode()),
+                                                   capnpT.getShortname(),
+                                                   capnpT.getLongname(),
+                                                   capnpT.getInternalId(),
+                                                   capnpT.getAllowSameLineTransfers());
 
-        t->uuid                   = uuidGenerator(uuid);
-        t->shortname              = capnpT.getShortname();
-        t->longname               = capnpT.getLongname();
-        t->internalId             = capnpT.getInternalId();
-        t->agencyIdx              = agencyIndexesByUuid.at(uuidGenerator(agencyUuid));
-        t->modeIdx                = modeIndexesByShortname.at(capnpT.getMode());
-        t->allowSameLineTransfers = capnpT.getAllowSameLineTransfers();
-        
         tIndexesByUuid[t->uuid] = ts.size();
         ts.push_back(std::move(t));
       }

--- a/src/modes_initialization.cpp
+++ b/src/modes_initialization.cpp
@@ -12,77 +12,31 @@
 namespace TrRouting
 {
 
-  const std::pair<std::vector<Mode>, std::map<std::string, int>> CacheFetcher::getModes()
+  const std::map<std::string, Mode> CacheFetcher::getModes()
   {
 
-    using T = Mode;
-
-    std::vector<T> ts;
-    std::map<std::string, int> tIndexesByShortname;
+    std::map<std::string, Mode> modes;
 
     spdlog::info("Initializing modes...");
 
-    T t1 = {"bus", "Bus", 3, 700};
-    ts.push_back(t1);
-    tIndexesByShortname[t1.shortname] = ts.size() - 1;
+    modes.emplace("bus", Mode("bus", "Bus", 3, 700));
+    modes.emplace("rail", Mode("rail", "Rail", 2, 100));
+    modes.emplace("highSpeedRail", Mode("highSpeedRail", "High speed rail", 2, 101));
+    modes.emplace("metro", Mode("metro", "Subway/Metro", 1, 400));
+    modes.emplace("monorail", Mode("monorail", "Monorail", 1, 405));
+    modes.emplace("tram", Mode("tram", "Tram/LRT", 0, 900));
+    modes.emplace("tramTrain", Mode("tramTrain", "Tram Train", 0, 900));
+    modes.emplace("water", Mode("water", "Ferry/Boat", 4, 1000));
+    modes.emplace("gondola", Mode("gondola", "Gondola/Aerial tram", 6, 1300));
+    modes.emplace("funicular", Mode("funicular", "Funicular", 7, 1400));
+    modes.emplace("taxi", Mode("taxi", "Taxi/Cab/Minivan", 3, 1500));
+    modes.emplace("cableCar", Mode("cableCar", "Cable car", 5, 1701));
+    modes.emplace("horse", Mode("horse", "Horse carriage", 3, 1702));
+    modes.emplace("other", Mode("other", "Other", 3, 1700));
+    // TODO investigate if "transferable" should really be a mode or a flag of another object
+    modes.emplace(Mode::TRANSFERABLE, Mode(Mode::TRANSFERABLE, "Transferable", -1, -1));
 
-    T t2 = {"rail", "Rail", 2, 100};
-    ts.push_back(t2);
-    tIndexesByShortname[t2.shortname] = ts.size() - 1;
-
-    T t3 = {"highSpeedRail", "High speed rail", 2, 101};
-    ts.push_back(t3);
-    tIndexesByShortname[t3.shortname] = ts.size() - 1;
-
-    T t4 = {"metro", "Subway/Metro", 1, 400};
-    ts.push_back(t4);
-    tIndexesByShortname[t4.shortname] = ts.size() - 1;
-
-    T t5 = {"monorail", "Monorail", 1, 405};
-    ts.push_back(t5);
-    tIndexesByShortname[t5.shortname] = ts.size() - 1;
-
-    T t6 = {"tram", "Tram/LRT", 0, 900};
-    ts.push_back(t6);
-    tIndexesByShortname[t6.shortname] = ts.size() - 1;
-
-    T t7 = {"tramTrain", "Tram Train", 0, 900};
-    ts.push_back(t7);
-    tIndexesByShortname[t7.shortname] = ts.size() - 1;
-
-    T t8 = {"water", "Ferry/Boat", 4, 1000};
-    ts.push_back(t8);
-    tIndexesByShortname[t8.shortname] = ts.size() - 1;
-
-    T t9 = {"gondola", "Gondola/Aerial tram", 6, 1300};
-    ts.push_back(t9);
-    tIndexesByShortname[t9.shortname] = ts.size() - 1;
-
-    T t10 = {"funicular", "Funicular", 7, 1400};
-    ts.push_back(t10);
-    tIndexesByShortname[t10.shortname] = ts.size() - 1;
-
-    T t11 = {"taxi", "Taxi/Cab/Minivan", 3, 1500};
-    ts.push_back(t11);
-    tIndexesByShortname[t11.shortname] = ts.size() - 1;
-
-    T t12 = {"cableCar", "Cable car", 5, 1701};
-    ts.push_back(t12);
-    tIndexesByShortname[t12.shortname] = ts.size() - 1;
-    
-    T t13 = {"horse", "Horse carriage", 3, 1702};
-    ts.push_back(t13);
-    tIndexesByShortname[t13.shortname] = ts.size() - 1;
-
-    T t14 = {"other", "Other", 3, 1700};
-    ts.push_back(t14);
-    tIndexesByShortname[t14.shortname] = ts.size() - 1;
-
-    T t15 = {"transferable", "Transferable", -1, -1};
-    ts.push_back(t15);
-    tIndexesByShortname[t15.shortname] = ts.size() - 1;
-    
-    return std::make_pair(ts, tIndexesByShortname);
+    return modes;
   }
 
 }

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -25,7 +25,7 @@ namespace TrRouting
     const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-    const std::map<std::string, int>& modeIndexesByShortname,
+    const std::map<std::string, Mode>& modes,
     std::string customPath
   ) {
 
@@ -76,11 +76,11 @@ namespace TrRouting
         std::vector<int> onlyLinesIdx;
         std::vector<int> onlyAgenciesIdx;
         std::vector<int> onlyNodesIdx;
-        std::vector<int> onlyModesIdx;
+        std::vector<std::reference_wrapper<const Mode>> onlyModes;
         std::vector<int> exceptLinesIdx;
         std::vector<int> exceptAgenciesIdx;
         std::vector<int> exceptNodesIdx;
-        std::vector<int> exceptModesIdx;
+        std::vector<std::reference_wrapper<const Mode>> exceptModes;
         boost::uuids::uuid serviceUuid;
         boost::uuids::uuid lineUuid;
         boost::uuids::uuid agencyUuid;
@@ -130,12 +130,12 @@ namespace TrRouting
         t->onlyNodesIdx = onlyNodesIdx;
         for (std::string modeShortnameStr : capnpT.getOnlyModesShortnames())
         {
-          if (modeIndexesByShortname.count(modeShortnameStr) != 0)
+          if (modes.count(modeShortnameStr) != 0)
           {
-            onlyModesIdx.push_back(modeIndexesByShortname.at(modeShortnameStr));
+            onlyModes.push_back(modes.at(modeShortnameStr));
           }
         }
-        t->onlyModesIdx = onlyModesIdx;
+        t->onlyModes = onlyModes;
 
         for (std::string lineUuidStr : capnpT.getExceptLinesUuids())
         {
@@ -166,12 +166,12 @@ namespace TrRouting
         t->exceptNodesIdx = exceptNodesIdx;
         for (std::string modeShortnameStr : capnpT.getExceptModesShortnames())
         {
-          if (modeIndexesByShortname.count(modeShortnameStr) != 0)
+          if (modes.count(modeShortnameStr) != 0)
           {
-            exceptModesIdx.push_back(modeIndexesByShortname.at(modeShortnameStr));
+            exceptModes.push_back(modes.at(modeShortnameStr));
           }
         }
-        t->exceptModesIdx = exceptModesIdx;
+        t->exceptModes = exceptModes;
 
         tIndexesByUuid[t->uuid] = ts.size();
         ts.push_back(std::move(t));

--- a/tests/cache_fetch/lines_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/lines_cache_fetcher_test.cpp
@@ -15,7 +15,7 @@ protected:
     std::vector<std::unique_ptr<TrRouting::Line>> objects;
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
     std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
-    std::map<std::string, int> modeIndexesByShortname;
+    std::map<std::string, TrRouting::Mode> modes;
 
 public:
     void SetUp( ) override
@@ -30,8 +30,7 @@ public:
 
         std::vector<std::unique_ptr<TrRouting::Line>> lines;
 
-        std::vector<TrRouting::Mode>                        modes;
-        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
+        modes = cacheFetcher.getModes();
         
     }
 
@@ -45,21 +44,21 @@ public:
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesInvalid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesValid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesFileNotExists)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -31,10 +31,8 @@ public:
 
         std::vector<std::unique_ptr<TrRouting::Line>> lines;
 
-        std::vector<TrRouting::Mode>                        modes;
-        std::map<std::string, int> modeIndexesByShortname;
-        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+        auto modes = cacheFetcher.getModes();
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
 
         // Empty Station
         std::map<boost::uuids::uuid, int>        stationIndexesByUuid;

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -18,7 +18,7 @@ protected:
     std::map<boost::uuids::uuid, int> lineIndexesByUuid;
     std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
-    std::map<std::string, int> modeIndexesByShortname;
+    std::map<std::string, TrRouting::Mode> modes;
 
 public:
     void SetUp( ) override
@@ -33,9 +33,8 @@ public:
 
         std::vector<std::unique_ptr<TrRouting::Line>> lines;
 
-        std::vector<TrRouting::Mode>                        modes;
-        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+        modes = cacheFetcher.getModes();
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Station>>     stations;
         std::map<boost::uuids::uuid, int>        stationIndexesByUuid;
@@ -60,7 +59,7 @@ public:
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -68,14 +67,14 @@ TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosValid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosFileNotExists)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modeIndexesByShortname, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -26,7 +26,6 @@ protected:
     std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
     std::map<boost::uuids::uuid, int> stationIndexesByUuid;
-    std::map<std::string, int> modeIndexesByShortname;
     std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;
     std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,int,short,short>>> connections;
@@ -38,13 +37,12 @@ public:
         // Read valid data for agencies, lines and paths
         std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
         cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
-        std::vector<TrRouting::Mode>                        modes;
-        std::tie(modes, modeIndexesByShortname) = cacheFetcher.getModes();
+        auto modes = cacheFetcher.getModes();
         std::vector<std::unique_ptr<TrRouting::Service>> services;
         cacheFetcher.getServices(services, serviceIndexesByUuid, VALID_CUSTOM_PATH);
 
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modeIndexesByShortname, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
         cacheFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
         // Create the invalid lines directory
         fs::create_directory(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
@@ -73,7 +71,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       pathIndexesByUuid,
       agencyIndexesByUuid,
       nodeIndexesByUuid,
-      modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
@@ -96,7 +93,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       pathIndexesByUuid,
       agencyIndexesByUuid,
       nodeIndexesByUuid,
-      modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
@@ -118,7 +114,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       pathIndexesByUuid,
       agencyIndexesByUuid,
       nodeIndexesByUuid,
-      modeIndexesByShortname,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -22,7 +22,6 @@
 #include "station.hpp"
 #include "stop.hpp"
 #include "od_trip.hpp"
-
 /**
  *  Create a default data set:
  * - one agency
@@ -195,34 +194,20 @@ void BaseCsaFixtureTests::setUpLines()
 {
     std::vector<std::unique_ptr<TrRouting::Line>>& array = calculator.lines;
     std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.lineIndexesByUuid;
+    auto & busMode = calculator.getModes().at("bus");
 
-    std::unique_ptr<TrRouting::Line> lineSN = std::make_unique<TrRouting::Line>();
-    lineSN->uuid = lineSNUuid;
-    lineSN->agencyIdx = 0;
-    lineSN->modeIdx = 0;
-    lineSN->shortname = "01";
-    lineSN->longname = "South/North";
-    lineSN->allowSameLineTransfers = 0;
+    std::unique_ptr<TrRouting::Line> lineSN = std::make_unique<TrRouting::Line>(lineSNUuid, 0, busMode, "01", "South/North", "", 0);
+
     arrayIndexesByUuid[lineSN->uuid] = array.size();
     array.push_back(std::move(lineSN));
 
-    std::unique_ptr<TrRouting::Line> lineEW = std::make_unique<TrRouting::Line>();
-    lineEW->uuid = lineEWUuid;
-    lineEW->agencyIdx = 0;
-    lineEW->modeIdx = 0;
-    lineEW->shortname = "02";
-    lineEW->longname = "East/West";
-    lineEW->allowSameLineTransfers = 0;
+    std::unique_ptr<TrRouting::Line> lineEW = std::make_unique<TrRouting::Line>(lineEWUuid, 0, busMode, "02", "East/West", "", 0);
+
     arrayIndexesByUuid[lineEW->uuid] = array.size();
     array.push_back(std::move(lineEW));
 
-    std::unique_ptr<TrRouting::Line> lineExtra = std::make_unique<TrRouting::Line>();
-    lineExtra->uuid = lineExtraUuid;
-    lineExtra->agencyIdx = 0;
-    lineExtra->modeIdx = 0;
-    lineExtra->shortname = "03";
-    lineExtra->longname = "Extra";
-    lineExtra->allowSameLineTransfers = 0;
+    std::unique_ptr<TrRouting::Line> lineExtra = std::make_unique<TrRouting::Line>(lineExtraUuid, 0, busMode, "03", "Extra", "", 0);
+
     arrayIndexesByUuid[lineExtra->uuid] = array.size();
     array.push_back(std::move(lineExtra));
 }
@@ -352,17 +337,17 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
     int tripIdx;
     std::vector<std::unique_ptr<TrRouting::Trip>>& array = calculator.trips;
     std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.tripIndexesByUuid;
+    auto & busMode = calculator.getModes().at("bus");
 
     // South/North trip 1 at 10
-    std::unique_ptr<TrRouting::Trip> snTrip1 = std::make_unique<TrRouting::Trip>();
-    snTrip1->uuid = trip1SNUuid;
-    snTrip1->agencyIdx = calculator.agencyIndexesByUuid[agencyUuid];
-    snTrip1->lineIdx = calculator.lineIndexesByUuid[lineSNUuid];
-    snTrip1->pathIdx = calculator.pathIndexesByUuid[pathSNUuid];
-    snTrip1->modeIdx = 0;
-    snTrip1->serviceIdx = calculator.serviceIndexesByUuid[serviceUuid];
-    snTrip1->blockIdx = -1;
-
+    std::unique_ptr<TrRouting::Trip> snTrip1 = std::make_unique<TrRouting::Trip>(trip1SNUuid,
+                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.lineIndexesByUuid[lineSNUuid],
+                                                                                 calculator.pathIndexesByUuid[pathSNUuid],
+                                                                                 busMode,
+                                                                                 calculator.serviceIndexesByUuid[serviceUuid],
+                                                                                 -1,
+                                                                                 0);
     tripIdx = array.size();
     arrayIndexesByUuid[snTrip1->uuid] = tripIdx;
 
@@ -373,15 +358,14 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
     array.push_back(std::move(snTrip1));
 
     // South/North trip 2 at 11
-    std::unique_ptr<TrRouting::Trip> snTrip2 = std::make_unique<TrRouting::Trip>();
-    snTrip2->uuid = trip2SNUuid;
-    snTrip2->agencyIdx = calculator.agencyIndexesByUuid[agencyUuid];
-    snTrip2->lineIdx = calculator.lineIndexesByUuid[lineSNUuid];
-    snTrip2->pathIdx = calculator.pathIndexesByUuid[pathSNUuid];
-    snTrip2->modeIdx = 0;
-    snTrip2->serviceIdx = calculator.serviceIndexesByUuid[serviceUuid];
-    snTrip2->blockIdx = -1;
-
+    std::unique_ptr<TrRouting::Trip> snTrip2 = std::make_unique<TrRouting::Trip>(trip2SNUuid,
+                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.lineIndexesByUuid[lineSNUuid],
+                                                                                 calculator.pathIndexesByUuid[pathSNUuid],
+                                                                                 busMode,
+                                                                                 calculator.serviceIndexesByUuid[serviceUuid],
+                                                                                 -1,
+                                                                                 0);
     tripIdx = array.size();
     arrayIndexesByUuid[snTrip2->uuid] = tripIdx;
 
@@ -392,15 +376,14 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
     array.push_back(std::move(snTrip2));
 
     // East/West trip 1 at 9
-    std::unique_ptr<TrRouting::Trip> ewTrip1 = std::make_unique<TrRouting::Trip>();
-    ewTrip1->uuid = trip1EWUuid;
-    ewTrip1->agencyIdx = calculator.agencyIndexesByUuid[agencyUuid];
-    ewTrip1->lineIdx = calculator.lineIndexesByUuid[lineEWUuid];
-    ewTrip1->pathIdx = calculator.pathIndexesByUuid[pathEWUuid];
-    ewTrip1->modeIdx = 0;
-    ewTrip1->serviceIdx = calculator.serviceIndexesByUuid[serviceUuid];
-    ewTrip1->blockIdx = -1;
-
+    std::unique_ptr<TrRouting::Trip> ewTrip1 = std::make_unique<TrRouting::Trip>(trip1EWUuid,
+                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.lineIndexesByUuid[lineEWUuid],
+                                                                                 calculator.pathIndexesByUuid[pathEWUuid],
+                                                                                 busMode,
+                                                                                 calculator.serviceIndexesByUuid[serviceUuid],
+                                                                                 -1,
+                                                                                 0);
     tripIdx = array.size();
     arrayIndexesByUuid[ewTrip1->uuid] = tripIdx;
 
@@ -411,15 +394,14 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
     array.push_back(std::move(ewTrip1));
 
     // East/West trip 2 at 10:02
-    std::unique_ptr<TrRouting::Trip> ewTrip2 = std::make_unique<TrRouting::Trip>();
-    ewTrip2->uuid = trip2EWUuid;
-    ewTrip2->agencyIdx = calculator.agencyIndexesByUuid[agencyUuid];
-    ewTrip2->lineIdx = calculator.lineIndexesByUuid[lineEWUuid];
-    ewTrip2->pathIdx = calculator.pathIndexesByUuid[pathEWUuid];
-    ewTrip2->modeIdx = 0;
-    ewTrip2->serviceIdx = calculator.serviceIndexesByUuid[serviceUuid];
-    ewTrip2->blockIdx = -1;
-
+    std::unique_ptr<TrRouting::Trip> ewTrip2 = std::make_unique<TrRouting::Trip>(trip2EWUuid,
+                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.lineIndexesByUuid[lineEWUuid],
+                                                                                 calculator.pathIndexesByUuid[pathEWUuid],
+                                                                                 busMode,
+                                                                                 calculator.serviceIndexesByUuid[serviceUuid],
+                                                                                 -1,
+                                                                                 0);
     tripIdx = array.size();
     arrayIndexesByUuid[ewTrip2->uuid] = tripIdx;
 
@@ -430,15 +412,14 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
     array.push_back(std::move(ewTrip2));
 
     // Extra trip at 10h20
-    std::unique_ptr<TrRouting::Trip> extraTrip1 = std::make_unique<TrRouting::Trip>();
-    extraTrip1->uuid = trip1ExtraUuid;
-    extraTrip1->agencyIdx = calculator.agencyIndexesByUuid[agencyUuid];
-    extraTrip1->lineIdx = calculator.lineIndexesByUuid[lineExtraUuid];
-    extraTrip1->pathIdx = calculator.pathIndexesByUuid[pathExtraUuid];
-    extraTrip1->modeIdx = 0;
-    extraTrip1->serviceIdx = calculator.serviceIndexesByUuid[serviceUuid];
-    extraTrip1->blockIdx = -1;
-
+    std::unique_ptr<TrRouting::Trip> extraTrip1 = std::make_unique<TrRouting::Trip>(trip1ExtraUuid,
+                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.lineIndexesByUuid[lineExtraUuid],
+                                                                                 calculator.pathIndexesByUuid[pathExtraUuid],
+                                                                                 busMode,
+                                                                                 calculator.serviceIndexesByUuid[serviceUuid],
+                                                                                 -1,
+                                                                                 0);
     tripIdx = array.size();
     arrayIndexesByUuid[extraTrip1->uuid] = tripIdx;
 
@@ -452,9 +433,7 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
 
 void BaseCsaFixtureTests::setUpModes()
 {
-    TrRouting::Mode mode = {"bus", "Bus", 3, 700};
-    calculator.modeIndexesByShortname[mode.shortname] = 0;
-    calculator.modes.push_back(mode);
+    calculator.modes.emplace("bus", TrRouting::Mode("bus", "Bus", 3, 700));
 }
 
 void BaseCsaFixtureTests::assertNoRouting(const TrRouting::NoRoutingFoundException& exception, TrRouting::NoRoutingReason expectedReason)


### PR DESCRIPTION
Instead of a vector of mode, we simple use a map of UUID:Mode object.
When a index to a mode was used, we simply store a direct reference to the
refered Mode object.

Since we store a reference, we need to construct some of the objects directly.

(Tested with Transition)