### PR TITLE
Migrate DataSource vector and index map to a single UUID:DataSource map

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -104,10 +104,12 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     int                    updateDataSourcesFromCache(std::string customPath = "");
-    int                    updateHouseholdsFromCache (std::string customPath = "");
+    // TODO #167
+    //int                    updateHouseholdsFromCache (std::string customPath = "");
     int                    updatePersonsFromCache    (std::string customPath = "");
     int                    updateOdTripsFromCache    (std::string customPath = "");
-    int                    updatePlacesFromCache     (std::string customPath = "");
+    // TODO #167
+    //int                    updatePlacesFromCache     (std::string customPath = "");
 
     int                    updateStationsFromCache   (std::string customPath = "");
     int                    updateAgenciesFromCache   (std::string customPath = "");
@@ -142,21 +144,14 @@ namespace TrRouting
     // TODO eventually, this will be moved to a const data container
     const std::map<std::string, Mode> & getModes() {return modes;}
 
-    std::vector<std::unique_ptr<DataSource>> dataSources;
-    std::map<boost::uuids::uuid, int>        dataSourceIndexesByUuid;
-
-    std::vector<std::unique_ptr<Household>>  households;
-    std::map<boost::uuids::uuid, int>        householdIndexesByUuid;
+    std::map<boost::uuids::uuid, DataSource> dataSources;
+    const std::map<boost::uuids::uuid, DataSource> & getDataSources() {return dataSources;}
 
     std::vector<std::unique_ptr<Person>>     persons;
     std::map<boost::uuids::uuid, int>        personIndexesByUuid;
 
     std::vector<std::unique_ptr<OdTrip>>     odTrips;
     std::map<boost::uuids::uuid, int>        odTripIndexesByUuid;
-
-    std::vector<std::unique_ptr<Place>>      places;
-    std::map<boost::uuids::uuid, int>        placeIndexesByUuid;
-
 
     std::vector<std::unique_ptr<Agency>>     agencies;
     std::map<boost::uuids::uuid, int>        agencyIndexesByUuid;

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -247,7 +247,7 @@ namespace TrRouting
       }
 
       // filter wrong data source if only data source is provided:
-      if (params.onlyDataSourceIdx != -1 && odTrip->dataSourceIdx != params.onlyDataSourceIdx)
+      if (params.onlyDataSource && odTrip->dataSource != params.onlyDataSource.value())
       {
         attributesMatches = false;
       }

--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -26,12 +26,11 @@ namespace TrRouting
     egressNodeTravelTimesSeconds.clear();
     egressNodeDistancesMeters.clear();
 
-    onlyDataSourceIdx = -1;
+    onlyDataSource.reset();
 
     batchNumber                            = 1;
     batchesCount                           = 1;
     odTripsSampleRatio                     = 1.0;
-    dataSourceUuid.reset();
     odTripUuid.reset();
     startingNodeUuid.reset();
     endingNodeUuid.reset();
@@ -79,7 +78,7 @@ namespace TrRouting
     std::vector<std::unique_ptr<OdTrip>> &odTrips,
     std::map<boost::uuids::uuid, int> &nodeIndexesByUuid,
     std::vector<std::unique_ptr<Node>> &nodes,
-    std::map<boost::uuids::uuid, int> &dataSourceIndexesByUuid)
+    const std::map<boost::uuids::uuid, DataSource> &dataSources)
   {
 
     setDefaultValues();
@@ -89,7 +88,6 @@ namespace TrRouting
     std::vector<std::pair<std::string, std::string>> newParametersWithValues;
 
     Scenario *         scenario;
-    dataSourceUuid.reset();
     boost::uuids::uuid originNodeUuid;
     boost::uuids::uuid destinationNodeUuid;
 
@@ -237,8 +235,9 @@ namespace TrRouting
 
       else if (parameterWithValueVector[0] == "data_source_uuid")
       {
-        dataSourceUuid    = uuidGenerator(parameterWithValueVector[1]);
-        onlyDataSourceIdx = dataSourceIndexesByUuid[*dataSourceUuid];
+        boost::uuids::uuid dataSourceUuid    = uuidGenerator(parameterWithValueVector[1]);
+        // This will throw an exception if specified data_source_uuid is not valid
+        onlyDataSource = dataSources.at(dataSourceUuid);
         continue;
       }
 

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -24,29 +24,29 @@ namespace TrRouting
 
   int Calculator::updateDataSourcesFromCache(std::string customPath)
   {
-    return dataFetcher.getDataSources(dataSources, dataSourceIndexesByUuid, customPath);
+    return dataFetcher.getDataSources(dataSources, customPath);
   }
-
+  /* TODO #167
   int Calculator::updateHouseholdsFromCache(std::string customPath)
   {
     return dataFetcher.getHouseholds(households, householdIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
   }
-
+  */
   int Calculator::updatePersonsFromCache(std::string customPath)
   {
-    return dataFetcher.getPersons(persons, personIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getPersons(persons, personIndexesByUuid, getDataSources(), customPath);
   }
   
   int Calculator::updateOdTripsFromCache(std::string customPath)
   {
-    return dataFetcher.getOdTrips(odTrips, odTripIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getOdTrips(odTrips, odTripIndexesByUuid, dataSources, personIndexesByUuid, nodeIndexesByUuid, customPath);
   }
-
+  /* TODO #167
   int Calculator::updatePlacesFromCache(std::string customPath)
   {
     return dataFetcher.getPlaces(places, placeIndexesByUuid, dataSourceIndexesByUuid, nodeIndexesByUuid, customPath);
   }
-
+  */ 
   int Calculator::updateAgenciesFromCache(std::string customPath)
   {
     return dataFetcher.getAgencies(agencies, agencyIndexesByUuid, customPath);
@@ -151,11 +151,13 @@ namespace TrRouting
     {
       return Calculator::DataStatus::DATA_READ_ERROR;
     }
+    /* TODO #167
     ret = updateHouseholdsFromCache();
     if (ret < 0)
     {
       return Calculator::DataStatus::DATA_READ_ERROR;
     }
+    */
     ret = updatePersonsFromCache();
     if (ret < 0)
     {
@@ -166,12 +168,13 @@ namespace TrRouting
     {
       return Calculator::DataStatus::DATA_READ_ERROR;
     }
+    /* TODO #167
     ret = updatePlacesFromCache();
     if (ret < 0)
     {
       return Calculator::DataStatus::DATA_READ_ERROR;
     }
-    
+    */
     ret = updateAgenciesFromCache();
     // Ignore missing file
     if (ret < 0 && ret != -ENOENT)

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -176,11 +176,13 @@ int main(int argc, char** argv) {
         correctCacheName = true;
         calculator.updateDataSourcesFromCache(customCacheDirectoryPath);
       }
+      /* TODO #167
       if (cacheName == "households" || cacheName == "all")
       {
         correctCacheName = true;
         calculator.updateHouseholdsFromCache(customCacheDirectoryPath);
       }
+      */
       if (cacheName == "persons" || cacheName == "all")
       {
         correctCacheName = true;
@@ -191,11 +193,13 @@ int main(int argc, char** argv) {
         correctCacheName = true;
         calculator.updateOdTripsFromCache(customCacheDirectoryPath);
       }
+      /* TODO #167
       if (cacheName == "places" || cacheName == "all")
       {
         correctCacheName = true;
         calculator.updatePlacesFromCache(customCacheDirectoryPath);
       }
+      */
       if (cacheName == "agencies" || cacheName == "all")
       {
         correctCacheName = true;
@@ -326,7 +330,7 @@ int main(int argc, char** argv) {
         calculator.odTrips,
         calculator.nodeIndexesByUuid,
         calculator.nodes,
-        calculator.dataSourceIndexesByUuid);
+        calculator.dataSources);
 
       // find OdTrip if provided:
       bool   foundOdTrip{false};

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -65,42 +65,22 @@ namespace TrRouting
 
     /** Refer to the base class for these functions documentations */
     virtual int getDataSources(
-      std::vector<std::unique_ptr<DataSource>>& ts, 
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::string customPath = ""
-    );
-
-    virtual int getHouseholds(
-      std::vector<std::unique_ptr<Household>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::map<boost::uuids::uuid, DataSource>& ts,
       std::string customPath = ""
     );
 
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::map<boost::uuids::uuid, int>& tIndexesById,
+      const std::map<boost::uuids::uuid, DataSource>& dataSources,
       std::string customPath = ""
     );
 
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
+      const std::map<boost::uuids::uuid, DataSource>& dataSources,
       const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::string customPath = ""
-    );
-
-    virtual int getPlaces(
-      std::vector<std::unique_ptr<Place>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -10,10 +10,10 @@
 namespace TrRouting
 {
   class DataSource;
-  class Household;
+  //class Household;  //TODO #167
   class Person;
   class OdTrip;
-  class Place;
+  //class Place;  //TODO #167
   class Agency;
   class Service;
   class Station;
@@ -43,8 +43,7 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getDataSources(
-      std::vector<std::unique_ptr<DataSource>>& ts, 
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, DataSource>& ts, 
       std::string customPath = "") = 0;
 
     /**
@@ -56,12 +55,12 @@ namespace TrRouting
      * -EINVAL For any other data related error
      * -(error codes from the open system call)
      */
-     virtual int getHouseholds(
-      std::vector<std::unique_ptr<Household>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::string customPath = "") = 0;
+    //TODO #167 Place/Household removed while refactoring
+    // virtual int getHouseholds(
+    //  std::vector<std::unique_ptr<Household>>& ts,
+    //  std::map<boost::uuids::uuid, int>& tIndexesById,
+    //  const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    //  std::string customPath = "") = 0;
 
     /**
      * Read the persons cache file and fill the persons vector.
@@ -75,9 +74,7 @@ namespace TrRouting
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, DataSource>& dataSources,
       std::string customPath = ""
     ) = 0;
 
@@ -93,10 +90,9 @@ namespace TrRouting
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, DataSource>& dataSources,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
       std::string customPath = ""
     ) = 0;
 
@@ -109,13 +105,14 @@ namespace TrRouting
      * -EINVAL For any other data related error
      * -(error codes from the open system call)
      */
-    virtual int getPlaces(
-      std::vector<std::unique_ptr<Place>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::string customPath = ""
-    ) = 0;
+    //TODO #167 Place/Household removed while refactoring
+    //virtual int getPlaces(
+    //  std::vector<std::unique_ptr<Place>>& ts,
+    //  std::map<boost::uuids::uuid, int>& tIndexesById,
+    //  const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
+    //  const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    //  std::string customPath = ""
+    //) = 0;
 
     /**
      * Read the agencies cache file and fill the agencies vector.

--- a/include/data_source.hpp
+++ b/include/data_source.hpp
@@ -1,14 +1,14 @@
 #ifndef TR_DATA_SOURCE
 #define TR_DATA_SOURCE
 
-#include <vector>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 namespace TrRouting
 {
   
-  struct DataSource {
+  class DataSource {
   
   public:
    
@@ -20,6 +20,10 @@ namespace TrRouting
     const std::string toString() {
       return "DataSource " + boost::uuids::to_string(uuid) + " name " + name + " type " + type;
     }
+
+    // Equal operator. We only compare the uuid, since they should be unique.
+    inline bool operator==(const DataSource& other ) const { return uuid == other.uuid; }
+    inline bool operator!=(const DataSource& other ) const { return !operator==(other); }
 
   };
 

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -39,43 +39,24 @@ namespace TrRouting
     };
     
     virtual int getDataSources(
-      std::vector<std::unique_ptr<DataSource>>& ts, 
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      std::string customPath = "") {return 0;}
-
-     virtual int getHouseholds(
-      std::vector<std::unique_ptr<Household>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      std::map<boost::uuids::uuid, DataSource>& ts,
       std::string customPath = "") {return 0;}
 
     virtual int getPersons(
       std::vector<std::unique_ptr<Person>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, DataSource>& dataSources,
       std::string customPath = ""
                            ) {return 0;}
 
     virtual int getOdTrips(
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& householdIndexesByUuid, 
-      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, DataSource>& dataSources,
+      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,     
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
                            ) {return 0;}
-
-    virtual int getPlaces(
-      std::vector<std::unique_ptr<Place>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
-      const std::map<boost::uuids::uuid, int>& dataSourceIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
-      std::string customPath = ""
-                          ) {return 0;}
 
     virtual int getAgencies(
       std::vector<std::unique_ptr<Agency>>& ts,

--- a/include/household.hpp
+++ b/include/household.hpp
@@ -15,7 +15,6 @@ namespace TrRouting
   public:
    
     boost::uuids::uuid uuid;
-    int dataSourceIdx;
     unsigned long long id;
     float expansionFactor;
     int size;

--- a/include/od_trip.hpp
+++ b/include/od_trip.hpp
@@ -7,15 +7,60 @@
 
 namespace TrRouting
 {
+  class DataSource;
   
-  struct OdTrip {
+  class OdTrip {
   
   public:
+    OdTrip(boost::uuids::uuid auuid,
+           unsigned long long aid,
+           const std::string &ainternalId,
+           const DataSource &adataSource,
+           int apersonIdx,
+           int adepartureTimeSeconds,
+           int aarrivalTimeSeconds,
+           int awalkingTravelTimeSeconds,
+           int acyclingTravelTimeSeconds,
+           int adrivingTravelTimeSeconds,
+           float aexpansionFactor,
+           const std::string &amode,
+           const std::string &aoriginActivity,
+           const std::string &adestinationActivity,
+           const std::vector<int> &aoriginNodesIdx,
+           const std::vector<int> &aoriginNodesTravelTimesSeconds,
+           const std::vector<int> &aoriginNodesDistancesMeters,
+           const std::vector<int> &adestinationNodesIdx,
+           const std::vector<int> &adestinationNodesTravelTimesSeconds,
+           const std::vector<int> &adestinationNodesDistancesMeters,
+           std::unique_ptr<Point> aorigin,
+           std::unique_ptr<Point> adestination)
+    : uuid(auuid),
+      id(aid),
+      internalId(ainternalId),
+      dataSource(adataSource),
+      personIdx(apersonIdx),
+      departureTimeSeconds(adepartureTimeSeconds),
+      arrivalTimeSeconds(aarrivalTimeSeconds),
+      walkingTravelTimeSeconds(awalkingTravelTimeSeconds),
+      cyclingTravelTimeSeconds(acyclingTravelTimeSeconds),
+      drivingTravelTimeSeconds(adrivingTravelTimeSeconds),
+      expansionFactor(aexpansionFactor),
+      mode(amode),
+      originActivity(aoriginActivity),
+      destinationActivity(adestinationActivity),
+      originNodesIdx(aoriginNodesIdx),
+      originNodesTravelTimesSeconds(aoriginNodesTravelTimesSeconds),
+      originNodesDistancesMeters(aoriginNodesDistancesMeters),
+      destinationNodesIdx(adestinationNodesIdx),
+      destinationNodesTravelTimesSeconds(adestinationNodesTravelTimesSeconds),
+      destinationNodesDistancesMeters(adestinationNodesDistancesMeters),
+      origin(std::move(aorigin)),
+      destination(std::move(adestination)) {}
 
     boost::uuids::uuid uuid;
     unsigned long long id;
-    int dataSourceIdx;
-    int householdIdx;
+    const DataSource & dataSource;
+    //int householdIdx; //TODO #167
     int personIdx;
     int departureTimeSeconds;
     int arrivalTimeSeconds;
@@ -23,10 +68,12 @@ namespace TrRouting
     int cyclingTravelTimeSeconds;
     int drivingTravelTimeSeconds;
     float expansionFactor;
+    //TODO Why is it a string and not an actual mode object?
     std::string mode;
     std::string originActivity;
     std::string destinationActivity;
     std::string internalId;
+    //TODO Combine those 3 into an object
     std::vector<int> originNodesIdx;
     std::vector<int> originNodesTravelTimesSeconds;
     std::vector<int> originNodesDistancesMeters;

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <optional>
 #include <boost/uuid/uuid.hpp>
+#include "data_source.hpp"
 
 namespace TrRouting
 {
@@ -15,6 +16,7 @@ namespace TrRouting
   class Scenario;
   class Node;
   class Mode;
+  class DataSource;
 
   class ParameterException : public std::exception
   {
@@ -149,7 +151,8 @@ namespace TrRouting
       int routingDateYear;   // not implemented, use onlyServicesIdx or exceptServicesIdx for now
       int routingDateMonth;  // not implemented, use onlyServicesIdx or exceptServicesIdx for now
       int routingDateDay;    // not implemented, use onlyServicesIdx or exceptServicesIdx for now
-      int onlyDataSourceIdx;
+      //TODO Make it a reference or not??
+      std::optional<DataSource> onlyDataSource;
       std::vector<int> accessNodesIdx;
       std::vector<int> accessNodeTravelTimesSeconds;
       std::vector<int> accessNodeDistancesMeters;
@@ -178,7 +181,6 @@ namespace TrRouting
       int originNodeIdx;
       int destinationNodeIdx;
       bool calculateAllOdTrips;
-      std::optional<boost::uuids::uuid> dataSourceUuid;
       std::optional<boost::uuids::uuid> odTripUuid;
       std::optional<boost::uuids::uuid> startingNodeUuid;
       std::optional<boost::uuids::uuid> endingNodeUuid;
@@ -214,7 +216,7 @@ namespace TrRouting
         std::vector<std::unique_ptr<OdTrip>> &odTrips,
         std::map<boost::uuids::uuid, int> &nodeIndexesByUuid,
         std::vector<std::unique_ptr<Node>> &nodes,
-        std::map<boost::uuids::uuid, int> &dataSourceIndexesByUuid);
+                             const std::map<boost::uuids::uuid, DataSource> &dataSources);
 
   };
 

--- a/include/person.hpp
+++ b/include/person.hpp
@@ -10,14 +10,35 @@
 namespace TrRouting
 {
   
-  struct Person {
+  class Person {
   
   public:
+    Person( boost::uuids::uuid auuid,
+            unsigned long long aid,
+            const DataSource &adataSource,
+            float aexpansionFactor,
+            int aage,
+            short adrivingLicenseOwner,
+            short atransitPassOwner,
+            std::string aageGroup,
+            std::string agender,
+            std::string aoccupation,
+            std::string ainternalId) : uuid(auuid),
+                                       id(aid),
+                                       dataSource(adataSource),
+                                       expansionFactor(aexpansionFactor),
+                                       age(aage),
+                                       drivingLicenseOwner(adrivingLicenseOwner),
+                                       transitPassOwner(atransitPassOwner),
+                                       ageGroup(aageGroup),
+                                       gender(agender),
+                                       occupation(aoccupation),
+                                       internalId(ainternalId) {}
    
     boost::uuids::uuid uuid;
-    int dataSourceIdx;
-    int householdIdx;
+    //int householdIdx; //TODO #167
     unsigned long long id;
+    const DataSource &dataSource;
     float expansionFactor;
     int age;
     short drivingLicenseOwner;
@@ -26,6 +47,7 @@ namespace TrRouting
     std::string gender;
     std::string occupation;
     std::string internalId;
+    /*TODO #167 Restore those fields when necessary
     std::unique_ptr<Point> usualWorkPlace;
     std::unique_ptr<Point> usualSchoolPlace;
     std::vector<int> usualWorkPlaceNodesIdx;
@@ -40,7 +62,7 @@ namespace TrRouting
     int usualSchoolPlaceWalkingTravelTimeSeconds;
     int usualSchoolPlaceCyclingTravelTimeSeconds;
     int usualSchoolPlaceDrivingTravelTimeSeconds;
-
+    */
     const std::string toString() {
       return "Person " + boost::uuids::to_string(uuid) + " age " + std::to_string(age);
     }

--- a/include/place.hpp
+++ b/include/place.hpp
@@ -15,7 +15,6 @@ namespace TrRouting
   public:
    
     boost::uuids::uuid uuid;
-    int dataSourceIdx;
     unsigned long long id;
     std::string shortname;
     std::string name;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,6 @@ trRouting_SOURCES = agencies_cache_fetcher.cpp \
 		    cache_fetcher.cpp \
 calculation_time.cpp \
 data_sources_cache_fetcher.cpp \
-households_cache_fetcher.cpp \
 lines_cache_fetcher.cpp \
 modes_initialization.cpp \
 nodes_cache_fetcher.cpp \
@@ -15,12 +14,13 @@ od_trips_cache_fetcher.cpp \
 osrm_fetcher.cpp \
 paths_cache_fetcher.cpp \
 persons_cache_fetcher.cpp \
-places_cache_fetcher.cpp \
 scenarios_cache_fetcher.cpp \
 services_cache_fetcher.cpp \
 stations_cache_fetcher.cpp \
 stops_cache_fetcher.cpp \
 trips_and_connections_cache_fetcher.cpp
-
+#TODO #167 Place/Household removed while refactoring
+#places_cache_fetcher.cpp \
+#households_cache_fetcher.cpp 
 
 trRouting_LDADD = ../connection_scan_algorithm/src/libcsa.la

--- a/src/data_sources_cache_fetcher.cpp
+++ b/src/data_sources_cache_fetcher.cpp
@@ -18,8 +18,7 @@ namespace TrRouting
 {
 
   int CacheFetcher::getDataSources(
-    std::vector<std::unique_ptr<DataSource>>& ts,
-    std::map<boost::uuids::uuid, int>& tIndexesByUuid,
+    std::map<boost::uuids::uuid, DataSource>& ts,
     std::string customPath
   )
   {
@@ -30,7 +29,6 @@ namespace TrRouting
     int ret = 0;
 
     ts.clear();
-    tIndexesByUuid.clear();
 
     std::string tStr  = "dataSources";
     std::string TStr  = "DataSources";
@@ -67,28 +65,28 @@ namespace TrRouting
         std::vector<int> servicesIdx;
         boost::uuids::uuid serviceUuid;
         
-        std::unique_ptr<T> t = std::make_unique<T>();
+        T t;
 
-        t->uuid = uuidGenerator(uuid);
-        t->name = capnpT.getName();
+        t.uuid = uuidGenerator(uuid);
+        t.name = capnpT.getName();
 
         switch (capnpT.getType()) {
-          case dataSource::DataSource::Type::NONE                     : t->type = "none";                    break;
-          case dataSource::DataSource::Type::OTHER                    : t->type = "other";                   break;
-          case dataSource::DataSource::Type::GTFS                     : t->type = "gtfs";                    break;
-          case dataSource::DataSource::Type::OD_TRIPS                 : t->type = "odTrips";                 break;
-          case dataSource::DataSource::Type::TRANSIT_SMART_CARD_DATA  : t->type = "transitSmartCardData";    break;
-          case dataSource::DataSource::Type::TRANSIT_OPERATIONAL_DATA : t->type = "transitOperationalData";  break;
-          case dataSource::DataSource::Type::TAXI_TRANSACTIONS        : t->type = "taxiTransactions";        break;
-          case dataSource::DataSource::Type::CAR_SHARING_TRANSACTIONS : t->type = "carSharingTransactions";  break;
-          case dataSource::DataSource::Type::BIKE_SHARING_TRANSACTIONS: t->type = "bikeSharingTransactions"; break;
-          case dataSource::DataSource::Type::GPS_TRACES               : t->type = "gpsTraces";               break;
-          case dataSource::DataSource::Type::STREET_SEGMENT_SPEEDS    : t->type = "streetSegmentSpeeds";     break;
-          case dataSource::DataSource::Type::UNKNOWN                  : t->type = "unknown";                 break;
+          case dataSource::DataSource::Type::NONE                     : t.type = "none";                    break;
+          case dataSource::DataSource::Type::OTHER                    : t.type = "other";                   break;
+          case dataSource::DataSource::Type::GTFS                     : t.type = "gtfs";                    break;
+          case dataSource::DataSource::Type::OD_TRIPS                 : t.type = "odTrips";                 break;
+          case dataSource::DataSource::Type::TRANSIT_SMART_CARD_DATA  : t.type = "transitSmartCardData";    break;
+          case dataSource::DataSource::Type::TRANSIT_OPERATIONAL_DATA : t.type = "transitOperationalData";  break;
+          case dataSource::DataSource::Type::TAXI_TRANSACTIONS        : t.type = "taxiTransactions";        break;
+          case dataSource::DataSource::Type::CAR_SHARING_TRANSACTIONS : t.type = "carSharingTransactions";  break;
+          case dataSource::DataSource::Type::BIKE_SHARING_TRANSACTIONS: t.type = "bikeSharingTransactions"; break;
+          case dataSource::DataSource::Type::GPS_TRACES               : t.type = "gpsTraces";               break;
+          case dataSource::DataSource::Type::STREET_SEGMENT_SPEEDS    : t.type = "streetSegmentSpeeds";     break;
+          case dataSource::DataSource::Type::UNKNOWN                  : t.type = "unknown";                 break;
         }
 
-        tIndexesByUuid[t->uuid] = ts.size();
-        ts.push_back(std::move(t));
+        //tIndexesByUuid[t.uuid] = ts.size();
+        ts[t.uuid] = t;
       }
     } 
     catch (const kj::Exception& e) 

--- a/tests/benchmark_csa/Makefile.am
+++ b/tests/benchmark_csa/Makefile.am
@@ -13,13 +13,14 @@ gtest_SOURCES = gtest.cpp \
     ../../src/paths_cache_fetcher.cpp \
     ../../src/calculation_time.cpp \
     ../../src/trips_and_connections_cache_fetcher.cpp \
-    ../../src/households_cache_fetcher.cpp \
     ../../src/persons_cache_fetcher.cpp \
     ../../src/modes_initialization.cpp \
     ../../src/od_trips_cache_fetcher.cpp \
-    ../../src/osrm_fetcher.cpp \
-    ../../src/places_cache_fetcher.cpp
+    ../../src/osrm_fetcher.cpp
 
+#TODO #167 Place/Household removed while refactoring
+#../../src/households_cache_fetcher.cpp \
+#../../src/places_cache_fetcher.cpp
 
 gtest_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 

--- a/tests/cache_fetch/Makefile.am
+++ b/tests/cache_fetch/Makefile.am
@@ -13,10 +13,11 @@ gtest_SOURCES = gtest.cpp \
     ../../src/paths_cache_fetcher.cpp paths_cache_fetcher_test.cpp \
     ../../src/calculation_time.cpp \
     ../../src/trips_and_connections_cache_fetcher.cpp schedules_cache_fetcher_test.cpp \
-    ../../src/households_cache_fetcher.cpp households_cache_fetcher_test.cpp \
     ../../src/persons_cache_fetcher.cpp persons_cache_fetcher_test.cpp \
-    ../../src/od_trips_cache_fetcher.cpp od_trips_cache_fetcher_test.cpp \
-    ../../src/places_cache_fetcher.cpp places_cache_fetcher_test.cpp
+    ../../src/od_trips_cache_fetcher.cpp od_trips_cache_fetcher_test.cpp
+#TODO #167 Place/Household removed while refactoring
+#../../src/places_cache_fetcher.cpp places_cache_fetcher_test.cpp
+#../../src/households_cache_fetcher.cpp households_cache_fetcher_test.cpp
 
 gtest_LDADD = $(top_srcdir)/tests/libgtest.la
 

--- a/tests/cache_fetch/data_sources_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/data_sources_cache_fetcher_test.cpp
@@ -12,8 +12,7 @@ namespace fs = std::filesystem;
 class DataSourceCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
-    std::vector<std::unique_ptr<TrRouting::DataSource>> objects;
-    std::map<boost::uuids::uuid, int> objectIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::DataSource> objects;
 
 public:
     void SetUp( ) override
@@ -33,14 +32,14 @@ public:
 
 TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesInvalid)
 {
-    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getDataSources(objects, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
 
 TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesValid)
 {
-    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getDataSources(objects, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     // TODO Test with actual data
     ASSERT_EQ(0, objects.size());
@@ -48,7 +47,7 @@ TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesValid)
 
 TEST_F(DataSourceCacheFetcherFixtureTests, TestGetDataSourcesFileNotExists)
 {
-    int retVal = cacheFetcher.getDataSources(objects, objectIndexesByUuid, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getDataSources(objects, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
@@ -13,15 +13,14 @@ class OdTripCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 protected:
     std::vector<std::unique_ptr<TrRouting::OdTrip>> objects;
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
-    std::map<boost::uuids::uuid, int> dataSourceIndexesByUuid;
-    std::map<boost::uuids::uuid, int> householdIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::DataSource> dataSources;
     std::map<boost::uuids::uuid, int> personIndexesByUuid;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
 };
 
 TEST_F(OdTripCacheFetcherFixtureTests, TestGetOdTripsValid)
 {
-    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, personIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSources, personIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/persons_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/persons_cache_fetcher_test.cpp
@@ -14,14 +14,12 @@ class PersonCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 protected:
     std::vector<std::unique_ptr<TrRouting::Person>> objects;
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
-    std::map<boost::uuids::uuid, int> dataSourceIndexesByUuid;
-    std::map<boost::uuids::uuid, int> householdIndexesByUuid;
-    std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::DataSource> dataSources;
 };
 
 TEST_F(PersonCacheFetcherFixtureTests, TestGetPersonsValid)
 {
-    int retVal = cacheFetcher.getPersons(objects, objectIndexesByUuid, dataSourceIndexesByUuid, householdIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPersons(objects, objectIndexesByUuid, dataSources, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
@@ -47,35 +47,55 @@ public:
 };
 
 void RouteOdTripsFixtureTests::setupDataSources() {
-    std::vector<std::unique_ptr<TrRouting::DataSource>>& array = calculator.dataSources;
-    std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.dataSourceIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::DataSource>& array = calculator.dataSources;
 
-    std::unique_ptr<TrRouting::DataSource> dataSource = std::make_unique<TrRouting::DataSource>();
-    dataSource->uuid = dataSourceUuid;
-    dataSource->shortname = "testDS";
-    dataSource->name = "Test Data Source";
+    TrRouting::DataSource dataSource;
+    dataSource.uuid = dataSourceUuid;
+    dataSource.shortname = "testDS";
+    dataSource.name = "Test Data Source";
 
-    arrayIndexesByUuid[dataSource->uuid] = array.size();
-    array.push_back(std::move(dataSource));
+    array[dataSourceUuid] = dataSource;
 }
 
 void RouteOdTripsFixtureTests::setupOdTrips() {
     std::vector<std::unique_ptr<TrRouting::OdTrip>>& array = calculator.odTrips;
     std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.odTripIndexesByUuid;
 
-    std::unique_ptr<TrRouting::OdTrip> odTrip = std::make_unique<TrRouting::OdTrip>();
-    odTrip->uuid = odTripUuid;
-    odTrip->dataSourceIdx = calculator.dataSourceIndexesByUuid[dataSourceUuid];
-    odTrip->departureTimeSeconds = getTimeInSeconds(9, 45);
-    odTrip->origin = std::make_unique<TrRouting::Point>(45.5242, -73.5817);
-    odTrip->destination = std::make_unique<TrRouting::Point>(45.54, -73.6146);
-    odTrip->originNodesIdx.push_back(calculator.nodeIndexesByUuid[nodeSouth2Uuid]);
-    odTrip->originNodesTravelTimesSeconds.push_back(469);
-    odTrip->originNodesDistancesMeters.push_back(500);
-    odTrip->destinationNodesIdx.push_back(calculator.nodeIndexesByUuid[nodeMidNodeUuid]);
-    odTrip->destinationNodesTravelTimesSeconds.push_back(138);
-    odTrip->destinationNodesDistancesMeters.push_back(150);
+    std::vector<int> originNodesIdx;
+    originNodesIdx.push_back(calculator.nodeIndexesByUuid[nodeSouth2Uuid]);
+    std::vector<int> originNodesTravelTimesSeconds;
+    originNodesTravelTimesSeconds.push_back(469);
+    std::vector<int> originNodesDistancesMeters;
+    originNodesDistancesMeters.push_back(500);        
+    std::vector<int> destinationNodesIdx;
+    destinationNodesIdx.push_back(calculator.nodeIndexesByUuid[nodeMidNodeUuid]);
+    std::vector<int> destinationNodesTravelTimesSeconds;
+    destinationNodesTravelTimesSeconds.push_back(138);
+    std::vector<int> destinationNodesDistancesMeters;
+    destinationNodesDistancesMeters.push_back(150);
 
+    std::unique_ptr<TrRouting::OdTrip> odTrip = std::make_unique<TrRouting::OdTrip>(odTripUuid,
+                                                                                    12345,
+                                                                                    "12345",
+                                                                                    calculator.dataSources.at(dataSourceUuid),
+                                                                                    -1,
+                                                                                    getTimeInSeconds(9, 45),
+                                                                                    -1,
+                                                                                    0,
+                                                                                    0,
+                                                                                    0,
+                                                                                    1.0,
+                                                                                    "",
+                                                                                    "",
+                                                                                    "",
+                                                                                    originNodesIdx,
+                                                                                    originNodesTravelTimesSeconds,
+                                                                                    originNodesDistancesMeters,
+                                                                                    destinationNodesIdx,
+                                                                                    destinationNodesTravelTimesSeconds,
+                                                                                    destinationNodesDistancesMeters,
+                                                                                    std::make_unique<TrRouting::Point>(45.5242, -73.5817),
+                                                                                    std::make_unique<TrRouting::Point>(45.54, -73.6146));
     arrayIndexesByUuid[odTrip->uuid] = array.size();
     array.push_back(std::move(odTrip));
 }
@@ -115,7 +135,7 @@ nlohmann::json RouteOdTripsFixtureTests::calculateOdTrips(std::vector<std::strin
         calculator.odTrips,
         calculator.nodeIndexesByUuid,
         calculator.nodes,
-        calculator.dataSourceIndexesByUuid);
+        calculator.dataSources);
     TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -385,7 +385,7 @@ std::unique_ptr<TrRouting::RoutingResult> RouteCalculationFixtureTests::calculat
         calculator.odTrips,
         calculator.nodeIndexesByUuid,
         calculator.nodes,
-        calculator.dataSourceIndexesByUuid);
+        calculator.dataSources);
     TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -193,7 +193,7 @@ TrRouting::AlternativesResult TAndACalculationFixtureTests::calculateWithAlterna
         calculator.odTrips,
         calculator.nodeIndexesByUuid,
         calculator.nodes,
-        calculator.dataSourceIndexesByUuid);
+        calculator.dataSources);
     TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;
 
     // TODO Shouldn't need to do this, but we do for now, benchmark needs to be started


### PR DESCRIPTION
Added == and != operators to DataSource

Since Person and OdTrip now store a reference to a DataSource, we added constructor for those.

While doing this, we observed that Households and Places are not used anywhere in the calculation.
We have commented out those files, references and initialization functions. Those were marked
with a TODO #167 (task number to restore them when needed/refactoring done)

Tested with Transition