### PR TITLE
Dockerfile: Add a make clean step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
 COPY . /source    
 RUN autoreconf -i && \
     ./configure && \
+    make clean && \
     make -j5 && \
     make install
 


### PR DESCRIPTION
When building locally, we might have some old build file copied to the docker build setup.
Adding a make clean will make sure the docker build is made with the right files