### PR TITLE
Migrate Agency vector and index map to a single UUID:Agency map

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -153,8 +153,8 @@ namespace TrRouting
     std::vector<std::unique_ptr<OdTrip>>     odTrips;
     std::map<boost::uuids::uuid, int>        odTripIndexesByUuid;
 
-    std::vector<std::unique_ptr<Agency>>     agencies;
-    std::map<boost::uuids::uuid, int>        agencyIndexesByUuid;
+    std::map<boost::uuids::uuid, Agency>     agencies;
+    const std::map<boost::uuids::uuid, Agency> & getAgencies() {return agencies;}
 
     std::vector<std::unique_ptr<Service>>    services;
     std::map<boost::uuids::uuid, int>        serviceIndexesByUuid;

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -52,7 +52,6 @@ namespace TrRouting
       ConnectionTuple * journeyStepExitConnection;
       std::vector<boost::uuids::uuid>                   lineUuids;
       std::vector<int>                                  linesIdx;
-      std::vector<boost::uuids::uuid>                   agencyUuids;
       std::vector<boost::uuids::uuid>                   unboardingNodeUuids;
       std::vector<boost::uuids::uuid>                   boardingNodeUuids;
       std::vector<boost::uuids::uuid>                   tripUuids;
@@ -65,7 +64,6 @@ namespace TrRouting
       Trip *   journeyStepTrip;
       Line *   journeyStepLine;
       Path *   journeyStepPath;
-      Agency * journeyStepAgency;
 
       int totalInVehicleTime       { 0}; int transferArrivalTime    {-1}; int firstDepartureTime     {-1};
       int totalWalkingTime         { 0}; int transferReadyTime      {-1}; int minimizedDepartureTime {-1};
@@ -140,7 +138,6 @@ namespace TrRouting
             journeyStepNodeDeparture   = nodes[std::get<connectionIndexes::NODE_DEP>(*journeyStepEnterConnection)].get();
             journeyStepNodeArrival     = nodes[std::get<connectionIndexes::NODE_ARR>(*journeyStepExitConnection)].get();
             journeyStepTrip            = trips[std::get<journeyStepIndexes::FINAL_TRIP>(journeyStep)].get();
-            journeyStepAgency          = agencies[journeyStepTrip->agencyIdx].get();
             journeyStepLine            = lines[journeyStepTrip->lineIdx].get();
             journeyStepPath            = paths[journeyStepTrip->pathIdx].get();
             transferTime               = std::get<journeyStepIndexes::TRANSFER_TRAVEL_TIME>(journeyStep);
@@ -169,7 +166,6 @@ namespace TrRouting
             lineUuids.push_back(journeyStepLine->uuid);
             linesIdx.push_back(journeyStepTrip->lineIdx);
             inVehicleTravelTimesSeconds.push_back(inVehicleTime);
-            agencyUuids.push_back(journeyStepAgency->uuid);
             boardingNodeUuids.push_back(journeyStepNodeDeparture->uuid);
             unboardingNodeUuids.push_back(journeyStepNodeArrival->uuid);
             tripUuids.push_back(journeyStepTrip->uuid);
@@ -216,9 +212,9 @@ namespace TrRouting
             if (!params.returnAllNodesResult)
             {
               singleResult.get()->steps.push_back(std::make_unique<BoardingStep>(
-                journeyStepAgency->uuid,
-                journeyStepAgency->acronym,
-                journeyStepAgency->name,
+                journeyStepTrip->agency.uuid, //TODO change boardingstep constructor to take the agency object directly
+                journeyStepTrip->agency.acronym,
+                journeyStepTrip->agency.name,
                 journeyStepLine->uuid,
                 journeyStepLine->shortname,
                 journeyStepLine->longname,
@@ -237,9 +233,9 @@ namespace TrRouting
               ));
 
               singleResult.get()->steps.push_back(std::make_unique<UnboardingStep>(
-                journeyStepAgency->uuid,
-                journeyStepAgency->acronym,
-                journeyStepAgency->name,
+                journeyStepTrip->agency.uuid, //TODO change boardingstep constructor to take the agency object directly
+                journeyStepTrip->agency.acronym,
+                journeyStepTrip->agency.name,
                 journeyStepLine->uuid,
                 journeyStepLine->shortname,
                 journeyStepLine->longname,

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -49,7 +49,7 @@ namespace TrRouting
   */ 
   int Calculator::updateAgenciesFromCache(std::string customPath)
   {
-    return dataFetcher.getAgencies(agencies, agencyIndexesByUuid, customPath);
+    return dataFetcher.getAgencies(agencies, customPath);
   }
 
   int Calculator::updateServicesFromCache(std::string customPath)
@@ -59,7 +59,7 @@ namespace TrRouting
 
   int Calculator::updateLinesFromCache(std::string customPath)
   {
-    return dataFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, getModes(), customPath);
+    return dataFetcher.getLines(lines, lineIndexesByUuid, agencies, getModes(), customPath);
   }
 
   int Calculator::updatePathsFromCache(std::string customPath)
@@ -69,7 +69,7 @@ namespace TrRouting
 
   int Calculator::updateScenariosFromCache(std::string customPath)
   {
-    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, getModes(), customPath);
+    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencies, nodeIndexesByUuid, getModes(), customPath);
   }
 
   int Calculator::updateSchedulesFromCache(std::string customPath)
@@ -83,7 +83,6 @@ namespace TrRouting
       serviceIndexesByUuid,
       lineIndexesByUuid,
       pathIndexesByUuid,
-      agencyIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -7,6 +7,7 @@
 #include "od_trip.hpp"
 #include "routing_result.hpp"
 #include "mode.hpp"
+#include "agency.hpp"
 
 namespace TrRouting
 {
@@ -282,9 +283,9 @@ namespace TrRouting
           }(*/
         }
 
-        if (tripsEnabled[i] == 1 && parameters.getOnlyAgenciesIdx()->size() > 0)
+        if (tripsEnabled[i] == 1 && parameters.getOnlyAgencies().size() > 0)
         {
-          if (std::find(parameters.getOnlyAgenciesIdx()->begin(), parameters.getOnlyAgenciesIdx()->end(), trip->agencyIdx) == parameters.getOnlyAgenciesIdx()->end())
+          if (std::find(parameters.getOnlyAgencies().begin(), parameters.getOnlyAgencies().end(), trip->agency) == parameters.getOnlyAgencies().end())
           {
             tripsEnabled[i] = -1;
           }
@@ -325,9 +326,9 @@ namespace TrRouting
           }
         }
 
-        if (tripsEnabled[i] == 1 && parameters.getExceptAgenciesIdx()->size() > 0)
+        if (tripsEnabled[i] == 1 && parameters.getExceptAgencies().size() > 0)
         {
-          if (std::find(parameters.getExceptAgenciesIdx()->begin(), parameters.getExceptAgenciesIdx()->end(), trip->agencyIdx) != parameters.getExceptAgenciesIdx()->end())
+          if (std::find(parameters.getExceptAgencies().begin(), parameters.getExceptAgencies().end(), trip->agency) != parameters.getExceptAgencies().end())
           {
             tripsEnabled[i] = -1;
           }

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -6,8 +6,8 @@
 #include "line.hpp"
 #include "mode.hpp"
 #include "path.hpp"
-#include "agency.hpp"
 #include "routing_result.hpp"
+#include "agency.hpp"
 
 namespace TrRouting
 {
@@ -49,7 +49,6 @@ namespace TrRouting
       ConnectionTuple * journeyStepExitConnection;
       std::vector<boost::uuids::uuid>                   lineUuids;
       std::vector<int>                                  linesIdx;
-      std::vector<boost::uuids::uuid>                   agencyUuids;
       std::vector<boost::uuids::uuid>                   unboardingNodeUuids;
       std::vector<boost::uuids::uuid>                   boardingNodeUuids;
       std::vector<boost::uuids::uuid>                   tripUuids;
@@ -62,7 +61,6 @@ namespace TrRouting
       Trip *   journeyStepTrip;
       Line *   journeyStepLine;
       Path *   journeyStepPath;
-      Agency * journeyStepAgency;
 
       int totalInVehicleTime       { 0}; int transferArrivalTime    {-1}; int firstDepartureTime   {-1};
       int totalWalkingTime         { 0}; int transferReadyTime      {-1}; int numberOfTransfers    {-1};
@@ -172,7 +170,6 @@ namespace TrRouting
             journeyStepNodeDeparture    = nodes[std::get<connectionIndexes::NODE_DEP>(*journeyStepEnterConnection)].get();
             journeyStepNodeArrival      = nodes[std::get<connectionIndexes::NODE_ARR>(*journeyStepExitConnection)].get();
             journeyStepTrip             = trips[std::get<journeyStepIndexes::FINAL_TRIP>(journeyStep)].get();
-            journeyStepAgency           = agencies[journeyStepTrip->agencyIdx].get();
             journeyStepLine             = lines[journeyStepTrip->lineIdx].get();
             journeyStepPath             = paths[journeyStepTrip->pathIdx].get();
             transferTime                = std::get<journeyStepIndexes::TRANSFER_TRAVEL_TIME>(journeyStep);
@@ -201,7 +198,6 @@ namespace TrRouting
             lineUuids.push_back(journeyStepLine->uuid);
             linesIdx.push_back(journeyStepTrip->lineIdx);
             inVehicleTravelTimesSeconds.push_back(inVehicleTime);
-            agencyUuids.push_back(journeyStepAgency->uuid);
             boardingNodeUuids.push_back(journeyStepNodeDeparture->uuid);
             unboardingNodeUuids.push_back(journeyStepNodeArrival->uuid);
             tripUuids.push_back(journeyStepTrip->uuid);
@@ -247,9 +243,9 @@ namespace TrRouting
             if (!params.returnAllNodesResult)
             {
               singleResult.get()->steps.push_back(std::make_unique<BoardingStep>(
-                journeyStepAgency->uuid,
-                journeyStepAgency->acronym,
-                journeyStepAgency->name,
+                journeyStepTrip->agency.uuid,
+                journeyStepTrip->agency.acronym,
+                journeyStepTrip->agency.name,
                 journeyStepLine->uuid,
                 journeyStepLine->shortname,
                 journeyStepLine->longname,
@@ -268,9 +264,9 @@ namespace TrRouting
               ));
 
               singleResult.get()->steps.push_back(std::make_unique<UnboardingStep>(
-                journeyStepAgency->uuid,
-                journeyStepAgency->acronym,
-                journeyStepAgency->name,
+                journeyStepTrip->agency.uuid,
+                journeyStepTrip->agency.acronym,
+                journeyStepTrip->agency.name,
                 journeyStepLine->uuid,
                 journeyStepLine->shortname,
                 journeyStepLine->longname,

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -43,11 +43,11 @@ namespace TrRouting
     scenarioUuid = scenario.uuid;
     onlyServicesIdx = scenario.servicesIdx;
     onlyLinesIdx = scenario.onlyLinesIdx;
-    onlyAgenciesIdx = scenario.onlyAgenciesIdx;
+    onlyAgencies = scenario.onlyAgencies;
     onlyNodesIdx = scenario.onlyNodesIdx;
     onlyModes = scenario.onlyModes;
     exceptLinesIdx = scenario.exceptLinesIdx;
-    exceptAgenciesIdx = scenario.exceptAgenciesIdx;
+    exceptAgencies = scenario.exceptAgencies;
     exceptNodesIdx = scenario.exceptNodesIdx;
     exceptModes = scenario.exceptModes;
   }
@@ -68,11 +68,11 @@ namespace TrRouting
     scenarioUuid(routeParams.scenarioUuid),
     onlyServicesIdx(routeParams.onlyServicesIdx),
     onlyLinesIdx(routeParams.onlyLinesIdx),
-    onlyAgenciesIdx(routeParams.onlyAgenciesIdx),
+    onlyAgencies(routeParams.onlyAgencies),
     onlyNodesIdx(routeParams.onlyNodesIdx),
     onlyModes(routeParams.onlyModes),
     exceptLinesIdx(routeParams.exceptLinesIdx),
-    exceptAgenciesIdx(routeParams.exceptAgenciesIdx),
+    exceptAgencies(routeParams.exceptAgencies),
     exceptNodesIdx(routeParams.exceptNodesIdx),
     exceptModes(routeParams.exceptModes)
   {

--- a/include/agency.hpp
+++ b/include/agency.hpp
@@ -22,8 +22,15 @@ namespace TrRouting
       return "Agency " + boost::uuids::to_string(uuid) + "\n  acronym " + acronym + "\n  name " + name;
     }
 
+    // Equal operator. We only compare the uuid, since they should be unique.
+    inline bool operator==(const Agency& other ) const { return uuid == other.uuid; }
   };
 
+  // To use std::find with a vector<reference_wrapper<const Agency>>
+  inline bool operator==(const std::reference_wrapper<const TrRouting::Agency>& lhs, const Agency& rhs)
+  {
+    return lhs.get() == rhs;
+  }
 }
 
 #endif // TR_AGENCY

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -86,8 +86,7 @@ namespace TrRouting
     );
 
     virtual int getAgencies(
-      std::vector<std::unique_ptr<Agency>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Agency>& ts,
       std::string customPath = ""
     );
 
@@ -113,7 +112,7 @@ namespace TrRouting
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     );
@@ -131,7 +130,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
@@ -145,7 +144,6 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -124,8 +124,7 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getAgencies(
-      std::vector<std::unique_ptr<Agency>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Agency>& ts,
       std::string customPath = ""
     ) = 0;
 
@@ -187,7 +186,7 @@ namespace TrRouting
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     ) = 0;
@@ -223,7 +222,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
@@ -246,7 +245,6 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -59,8 +59,7 @@ namespace TrRouting
                            ) {return 0;}
 
     virtual int getAgencies(
-      std::vector<std::unique_ptr<Agency>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Agency>& ts,
       std::string customPath = ""
                             ) {return 0;}
 
@@ -86,7 +85,7 @@ namespace TrRouting
     virtual int getLines(
       std::vector<std::unique_ptr<Line>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
                          ) {return 0;}
@@ -113,7 +112,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+      const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
@@ -136,7 +135,6 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,

--- a/include/line.hpp
+++ b/include/line.hpp
@@ -9,19 +9,20 @@ namespace TrRouting
 {
 
   class Mode;
+  class Agency;
   
   struct Line {
   
   public:
     Line(const boost::uuids::uuid &auuid,
-         int aagencyIdx,
+         const Agency &aagency,
          const Mode &amode,
          const std::string &ashortname,
          const std::string &alongname,
          const std::string &ainternalId,
          short aallowSameLineTransfers):
       uuid(auuid),
-      agencyIdx(aagencyIdx),
+      agency(aagency),
       mode(amode),
       shortname(ashortname),
       longname(alongname),
@@ -29,7 +30,7 @@ namespace TrRouting
       allowSameLineTransfers(aallowSameLineTransfers) {}
 
     boost::uuids::uuid uuid;
-    int agencyIdx;
+    const Agency &agency;
     const Mode &mode;
     std::string shortname;
     std::string longname;

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -17,6 +17,7 @@ namespace TrRouting
   class Node;
   class Mode;
   class DataSource;
+  class Agency;
 
   class ParameterException : public std::exception
   {
@@ -75,8 +76,8 @@ namespace TrRouting
       // std::vector<int> exceptLinesIdx;
       std::vector<std::reference_wrapper<const Mode>> onlyModes;
       std::vector<std::reference_wrapper<const Mode>> exceptModes;
-      std::vector<int> onlyAgenciesIdx;
-      std::vector<int> exceptAgenciesIdx;
+      std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
+      std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
       std::vector<int> onlyNodesIdx;
       std::vector<int> exceptNodesIdx;
       bool withAlternatives; // calculate alternatives or not
@@ -129,8 +130,8 @@ namespace TrRouting
       std::vector<int>* getExceptLinesIdx() { return &exceptLinesIdx; }
       const std::vector<std::reference_wrapper<const Mode>>& getOnlyModes() { return onlyModes; }
       const std::vector<std::reference_wrapper<const Mode>>& getExceptModes() { return exceptModes; }
-      std::vector<int>* getOnlyAgenciesIdx() { return &onlyAgenciesIdx; }
-      std::vector<int>* getExceptAgenciesIdx() { return &exceptAgenciesIdx; }
+      const std::vector<std::reference_wrapper<const Agency>>& getOnlyAgencies() { return onlyAgencies; }
+      const std::vector<std::reference_wrapper<const Agency>>& getExceptAgencies() { return exceptAgencies; }
       std::vector<int>* getOnlyNodesIdx() { return &onlyNodesIdx; }
       std::vector<int>* getExceptNodesIdx() { return &exceptNodesIdx; }
 

--- a/include/scenario.hpp
+++ b/include/scenario.hpp
@@ -19,11 +19,11 @@ namespace TrRouting
     std::vector<int> servicesIdx;
     std::vector<std::reference_wrapper<const Mode>> onlyModes;
     std::vector<int> onlyLinesIdx;
-    std::vector<int> onlyAgenciesIdx;
+    std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
     std::vector<int> onlyNodesIdx;
     std::vector<std::reference_wrapper<const Mode>> exceptModes;
     std::vector<int> exceptLinesIdx;
-    std::vector<int> exceptAgenciesIdx;
+    std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
     std::vector<int> exceptNodesIdx;
 
     const std::string toString() {

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -12,7 +12,7 @@ namespace TrRouting
   
   public:
     Trip( boost::uuids::uuid auuid,
-          int aagencyIdx,
+          const Agency &aagency,
           int alineIdx,
           int apathIdx,
           const Mode &amode,
@@ -21,7 +21,7 @@ namespace TrRouting
           short aallowSameLineTransfers,
           int atotalCapacity = -1,
           int aseatedCapacity = -1): uuid(auuid),
-                                         agencyIdx(aagencyIdx),
+                                         agency(aagency),
                                          lineIdx(alineIdx),
                                          pathIdx(apathIdx),
                                          mode(amode),
@@ -32,7 +32,7 @@ namespace TrRouting
                                          allowSameLineTransfers(aallowSameLineTransfers) {}
    
     boost::uuids::uuid uuid;
-    int agencyIdx;
+    const Agency &agency;
     int lineIdx;
     int pathIdx;
     const Mode &mode;

--- a/src/agencies_cache_fetcher.cpp
+++ b/src/agencies_cache_fetcher.cpp
@@ -22,8 +22,7 @@ namespace TrRouting
 {
 
   int CacheFetcher::getAgencies(
-    std::vector<std::unique_ptr<Agency>>& ts,
-    std::map<boost::uuids::uuid, int>& tIndexesByUuid,
+    std::map<boost::uuids::uuid,Agency>& ts,
     std::string customPath
   )
   {
@@ -34,7 +33,6 @@ namespace TrRouting
     int ret = 0;
 
     ts.clear();
-    tIndexesByUuid.clear();
 
     std::string tStr  = "agencies";
     std::string TStr  = "Agencies";
@@ -71,16 +69,14 @@ namespace TrRouting
         std::string uuid           {capnpT.getUuid()};
         std::string simulationUuid {capnpT.getSimulationUuid()};
 
-        std::unique_ptr<T> t = std::make_unique<T>();
+        T t;
 
-        t->uuid           = uuidGenerator(uuid);
-        t->acronym        = capnpT.getAcronym();
-        t->name           = capnpT.getName();
-        t->internalId     = capnpT.getInternalId();
-        t->simulationUuid = simulationUuid.empty() ? uuidNilGenerator() : uuidGenerator(simulationUuid);
-        
-        tIndexesByUuid[t->uuid] = ts.size();
-        ts.push_back(std::move(t));
+        t.uuid           = uuidGenerator(uuid);
+        t.acronym        = capnpT.getAcronym();
+        t.name           = capnpT.getName();
+        t.internalId     = capnpT.getInternalId();
+        t.simulationUuid = simulationUuid.empty() ? uuidNilGenerator() : uuidGenerator(simulationUuid);
+        ts[t.uuid] = t;
       }
     }
     catch (const kj::Exception& e)

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -20,7 +20,7 @@ namespace TrRouting
   int CacheFetcher::getLines(
     std::vector<std::unique_ptr<Line>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
-    const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+    const std::map<boost::uuids::uuid, Agency>& agencies,
     const std::map<std::string, Mode>& modes, 
     std::string customPath
   )
@@ -70,7 +70,7 @@ namespace TrRouting
         
         std::unique_ptr<T> t = std::make_unique<T>(
                                                    uuidGenerator(uuid),
-                                                   agencyIndexesByUuid.at(uuidGenerator(agencyUuid)),
+                                                   agencies.at(uuidGenerator(agencyUuid)),
                                                    modes.at(capnpT.getMode()),
                                                    capnpT.getShortname(),
                                                    capnpT.getLongname(),

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -23,7 +23,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
-    const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
+    const std::map<boost::uuids::uuid, Agency>& agencies,
     const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     const std::map<std::string, Mode>& modes,
     std::string customPath
@@ -74,11 +74,11 @@ namespace TrRouting
 
         std::vector<int> servicesIdx;
         std::vector<int> onlyLinesIdx;
-        std::vector<int> onlyAgenciesIdx;
+        std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
         std::vector<int> onlyNodesIdx;
         std::vector<std::reference_wrapper<const Mode>> onlyModes;
         std::vector<int> exceptLinesIdx;
-        std::vector<int> exceptAgenciesIdx;
+        std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
         std::vector<int> exceptNodesIdx;
         std::vector<std::reference_wrapper<const Mode>> exceptModes;
         boost::uuids::uuid serviceUuid;
@@ -113,12 +113,12 @@ namespace TrRouting
         for (std::string agencyUuidStr : capnpT.getOnlyAgenciesUuids())
         {
           agencyUuid = uuidGenerator(agencyUuidStr);
-          if (agencyIndexesByUuid.count(agencyUuid) != 0)
+          if (agencies.count(agencyUuid) != 0)
           {
-            onlyAgenciesIdx.push_back(agencyIndexesByUuid.at(agencyUuid));
+            onlyAgencies.push_back(agencies.at(agencyUuid));
           }
         }
-        t->onlyAgenciesIdx = onlyAgenciesIdx;
+        t->onlyAgencies = onlyAgencies;
         for (std::string nodeUuidStr : capnpT.getOnlyNodesUuids())
         {
           nodeUuid = uuidGenerator(nodeUuidStr);
@@ -149,12 +149,12 @@ namespace TrRouting
         for (std::string agencyUuidStr : capnpT.getExceptAgenciesUuids())
         {
           agencyUuid = uuidGenerator(agencyUuidStr);
-          if (agencyIndexesByUuid.count(agencyUuid) != 0)
+          if (agencies.count(agencyUuid) != 0)
           {
-            exceptAgenciesIdx.push_back(agencyIndexesByUuid.at(agencyUuid));
+            exceptAgencies.push_back(agencies.at(agencyUuid));
           }
         }
-        t->exceptAgenciesIdx = exceptAgenciesIdx;
+        t->exceptAgencies = exceptAgencies;
         for (std::string nodeUuidStr : capnpT.getExceptNodesUuids())
         {
           nodeUuid = uuidGenerator(nodeUuidStr);

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -29,7 +29,6 @@ namespace TrRouting
     const std::map<boost::uuids::uuid, int>& serviceIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
-    const std::map<boost::uuids::uuid, int>& agencyIndexesByUuid,
     const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
     std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
@@ -121,7 +120,7 @@ namespace TrRouting
               }*/
 
               std::unique_ptr<Trip> trip = std::make_unique<Trip>(tripUuid,
-                                                                  line->agencyIdx,
+                                                                  line->agency,
                                                                   lineIndexesByUuid.at(line->uuid),
                                                                   pathIndexesByUuid.at(pathUuid),
                                                                   line->mode,

--- a/tests/cache_fetch/agencies_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/agencies_cache_fetcher_test.cpp
@@ -12,8 +12,7 @@ namespace fs = std::filesystem;
 class AgencyCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
-    std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
-    std::map<boost::uuids::uuid, int>        agencyIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
 
 public:
     void SetUp( ) override
@@ -33,21 +32,21 @@ public:
 
 TEST_F(AgencyCacheFetcherFixtureTests, TestGetAgenciesInvalid)
 {
-    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getAgencies(agencies, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, agencies.size());
 }
 
 TEST_F(AgencyCacheFetcherFixtureTests, TestGetAgenciesValid)
 {
-    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, agencies.size());
 }
 
 TEST_F(AgencyCacheFetcherFixtureTests, TestGetAgenciesFileNotExists)
 {
-    int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getAgencies(agencies, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, agencies.size());
 }

--- a/tests/cache_fetch/lines_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/lines_cache_fetcher_test.cpp
@@ -14,7 +14,7 @@ class LineCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 protected:
     std::vector<std::unique_ptr<TrRouting::Line>> objects;
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
-    std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
     std::map<std::string, TrRouting::Mode> modes;
 
 public:
@@ -25,8 +25,7 @@ public:
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines.capnpbin");
 
         // Load valid data 
-        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
-        int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+        int retVal = cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Line>> lines;
 
@@ -44,21 +43,21 @@ public:
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesInvalid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modes, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencies, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesValid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesFileNotExists)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencyIndexesByUuid, modes, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencies, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -25,14 +25,13 @@ public:
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/paths.capnpbin");
 
         // Load valid data 
-        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
-        std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
-        int retVal = cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+        std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
+        int retVal = cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Line>> lines;
 
         auto modes = cacheFetcher.getModes();
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
 
         // Empty Station
         std::map<boost::uuids::uuid, int>        stationIndexesByUuid;

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -16,7 +16,7 @@ protected:
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
     std::map<boost::uuids::uuid, int> serviceIndexesByUuid;
     std::map<boost::uuids::uuid, int> lineIndexesByUuid;
-    std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
     std::map<std::string, TrRouting::Mode> modes;
 
@@ -28,18 +28,17 @@ public:
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/scenarios.capnpbin");
 
         // Load valid data 
-        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
-        cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Line>> lines;
 
         modes = cacheFetcher.getModes();
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Station>>     stations;
         std::map<boost::uuids::uuid, int>        stationIndexesByUuid;
 
-        cacheFetcher.getStations(stations, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getStations(stations, stationIndexesByUuid, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Node>> nodes;
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
@@ -59,7 +58,7 @@ public:
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modes, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencies, nodeIndexesByUuid, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -67,14 +66,14 @@ TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosValid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modes, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencies, nodeIndexesByUuid, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosFileNotExists)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencyIndexesByUuid, nodeIndexesByUuid, modes, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, serviceIndexesByUuid, lineIndexesByUuid, agencies, nodeIndexesByUuid, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -23,7 +23,6 @@ protected:
     std::map<boost::uuids::uuid, int> serviceIndexesByUuid;
     std::map<boost::uuids::uuid, int> lineIndexesByUuid;
     std::map<boost::uuids::uuid, int> pathIndexesByUuid;
-    std::map<boost::uuids::uuid, int> agencyIndexesByUuid;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
     std::map<boost::uuids::uuid, int> stationIndexesByUuid;
     std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
@@ -35,14 +34,14 @@ public:
     {
         BaseCacheFetcherFixtureTests::SetUp();
         // Read valid data for agencies, lines and paths
-        std::vector<std::unique_ptr<TrRouting::Agency>>     agencies;
-        cacheFetcher.getAgencies(agencies, agencyIndexesByUuid, VALID_CUSTOM_PATH);
+        std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
+        cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
         auto modes = cacheFetcher.getModes();
         std::vector<std::unique_ptr<TrRouting::Service>> services;
         cacheFetcher.getServices(services, serviceIndexesByUuid, VALID_CUSTOM_PATH);
 
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, stationIndexesByUuid, VALID_CUSTOM_PATH);
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencyIndexesByUuid, modes, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, lineIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
         cacheFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
         // Create the invalid lines directory
         fs::create_directory(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
@@ -69,7 +68,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       serviceIndexesByUuid,
       lineIndexesByUuid,
       pathIndexesByUuid,
-      agencyIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
@@ -91,7 +89,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       serviceIndexesByUuid,
       lineIndexesByUuid,
       pathIndexesByUuid,
-      agencyIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
@@ -112,7 +109,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       serviceIndexesByUuid,
       lineIndexesByUuid,
       pathIndexesByUuid,
-      agencyIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -179,15 +179,11 @@ void BaseCsaFixtureTests::setUpNodes()
 
 void BaseCsaFixtureTests::setUpAgencies()
 {
-    std::vector<std::unique_ptr<TrRouting::Agency>>& array = calculator.agencies;
-    std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.agencyIndexesByUuid;
-
-    std::unique_ptr<TrRouting::Agency> agency = std::make_unique<TrRouting::Agency>();
-    agency->uuid = agencyUuid;
-    agency->name = "Unit Test Agency";
-    agency->acronym = "UT";
-    arrayIndexesByUuid[agency->uuid] = array.size();
-    array.push_back(std::move(agency));
+    TrRouting::Agency agency;
+    agency.uuid = agencyUuid;
+    agency.name = "Unit Test Agency";
+    agency.acronym = "UT";
+    calculator.agencies[agencyUuid] = agency;
 }
 
 void BaseCsaFixtureTests::setUpLines()
@@ -195,18 +191,19 @@ void BaseCsaFixtureTests::setUpLines()
     std::vector<std::unique_ptr<TrRouting::Line>>& array = calculator.lines;
     std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.lineIndexesByUuid;
     auto & busMode = calculator.getModes().at("bus");
+    const auto & defaultAgency = calculator.agencies.at(agencyUuid);
 
-    std::unique_ptr<TrRouting::Line> lineSN = std::make_unique<TrRouting::Line>(lineSNUuid, 0, busMode, "01", "South/North", "", 0);
+    std::unique_ptr<TrRouting::Line> lineSN = std::make_unique<TrRouting::Line>(lineSNUuid, defaultAgency, busMode, "01", "South/North", "", 0);
 
     arrayIndexesByUuid[lineSN->uuid] = array.size();
     array.push_back(std::move(lineSN));
 
-    std::unique_ptr<TrRouting::Line> lineEW = std::make_unique<TrRouting::Line>(lineEWUuid, 0, busMode, "02", "East/West", "", 0);
+    std::unique_ptr<TrRouting::Line> lineEW = std::make_unique<TrRouting::Line>(lineEWUuid, defaultAgency, busMode, "02", "East/West", "", 0);
 
     arrayIndexesByUuid[lineEW->uuid] = array.size();
     array.push_back(std::move(lineEW));
 
-    std::unique_ptr<TrRouting::Line> lineExtra = std::make_unique<TrRouting::Line>(lineExtraUuid, 0, busMode, "03", "Extra", "", 0);
+    std::unique_ptr<TrRouting::Line> lineExtra = std::make_unique<TrRouting::Line>(lineExtraUuid, defaultAgency, busMode, "03", "Extra", "", 0);
 
     arrayIndexesByUuid[lineExtra->uuid] = array.size();
     array.push_back(std::move(lineExtra));
@@ -341,7 +338,7 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
 
     // South/North trip 1 at 10
     std::unique_ptr<TrRouting::Trip> snTrip1 = std::make_unique<TrRouting::Trip>(trip1SNUuid,
-                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.agencies.at(agencyUuid),
                                                                                  calculator.lineIndexesByUuid[lineSNUuid],
                                                                                  calculator.pathIndexesByUuid[pathSNUuid],
                                                                                  busMode,
@@ -359,7 +356,7 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
 
     // South/North trip 2 at 11
     std::unique_ptr<TrRouting::Trip> snTrip2 = std::make_unique<TrRouting::Trip>(trip2SNUuid,
-                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.agencies.at(agencyUuid),
                                                                                  calculator.lineIndexesByUuid[lineSNUuid],
                                                                                  calculator.pathIndexesByUuid[pathSNUuid],
                                                                                  busMode,
@@ -377,7 +374,7 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
 
     // East/West trip 1 at 9
     std::unique_ptr<TrRouting::Trip> ewTrip1 = std::make_unique<TrRouting::Trip>(trip1EWUuid,
-                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.agencies.at(agencyUuid),
                                                                                  calculator.lineIndexesByUuid[lineEWUuid],
                                                                                  calculator.pathIndexesByUuid[pathEWUuid],
                                                                                  busMode,
@@ -395,7 +392,7 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
 
     // East/West trip 2 at 10:02
     std::unique_ptr<TrRouting::Trip> ewTrip2 = std::make_unique<TrRouting::Trip>(trip2EWUuid,
-                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.agencies.at(agencyUuid),
                                                                                  calculator.lineIndexesByUuid[lineEWUuid],
                                                                                  calculator.pathIndexesByUuid[pathEWUuid],
                                                                                  busMode,
@@ -413,7 +410,7 @@ void BaseCsaFixtureTests::setUpSchedules(std::vector<std::shared_ptr<TrRouting::
 
     // Extra trip at 10h20
     std::unique_ptr<TrRouting::Trip> extraTrip1 = std::make_unique<TrRouting::Trip>(trip1ExtraUuid,
-                                                                                 calculator.agencyIndexesByUuid[agencyUuid],
+                                                                                 calculator.agencies.at(agencyUuid),
                                                                                  calculator.lineIndexesByUuid[lineExtraUuid],
                                                                                  calculator.pathIndexesByUuid[pathExtraUuid],
                                                                                  busMode,


### PR DESCRIPTION
Added == and != operators to Agency

Line, Trip and Scenario now contain references to an Agency object. This allowed
for simplifications in *_journey files