### PR TITLE
Migrate Line vector and index map to a single UUID:Line map

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -35,8 +35,8 @@ namespace TrRouting
   class AlternativesResult;
   class DataFetcher;
 
-  // tuple representing a connection: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, lineIndex, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
-  using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,int,short,short>;
+  // tuple representing a connection: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
+  using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,short,short>;
 
   class Calculator {
 
@@ -157,8 +157,8 @@ namespace TrRouting
     std::vector<std::unique_ptr<Node>>       nodes;
     std::map<boost::uuids::uuid, int>        nodeIndexesByUuid;
 
-    std::vector<std::unique_ptr<Line>>       lines;
-    std::map<boost::uuids::uuid, int>        lineIndexesByUuid;
+    std::map<boost::uuids::uuid, Line>       lines;
+    const std::map<boost::uuids::uuid, Line> & getLines() {return lines;}
 
     std::vector<std::unique_ptr<Path>>       paths;
     std::map<boost::uuids::uuid, int>        pathIndexesByUuid;
@@ -181,7 +181,7 @@ namespace TrRouting
 
   private:
 
-    enum connectionIndexes : short { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, LINE = 8, CAN_TRANSFER_SAME_LINE = 9, MIN_WAITING_TIME_SECONDS = 10 };
+    enum connectionIndexes : short { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, CAN_TRANSFER_SAME_LINE = 8, MIN_WAITING_TIME_SECONDS = 9 };
     enum journeyStepIndexes: short { FINAL_ENTER_CONNECTION = 0, FINAL_EXIT_CONNECTION = 1, FINAL_TRANSFERRING_NODE = 2, FINAL_TRIP = 3, TRANSFER_TRAVEL_TIME = 4, IS_SAME_NODE_TRANSFER = 5, TRANSFER_DISTANCE = 6 };
 
     int              departureTimeSeconds;

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -50,19 +50,16 @@ namespace TrRouting
       std::tuple<int,int,int,int,int,short,int>         emptyJourneyStep {-1,-1,-1,-1,-1,-1,-1};
       ConnectionTuple * journeyStepEnterConnection; // connection tuple: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequenceinTrip
       ConnectionTuple * journeyStepExitConnection;
-      std::vector<boost::uuids::uuid>                   lineUuids;
-      std::vector<int>                                  linesIdx;
       std::vector<boost::uuids::uuid>                   unboardingNodeUuids;
       std::vector<boost::uuids::uuid>                   boardingNodeUuids;
       std::vector<boost::uuids::uuid>                   tripUuids;
       std::vector<int>                                  tripsIdx;
       std::vector<int>                                  inVehicleTravelTimesSeconds; // the in vehicle travel time for each segment
-      std::vector<std::tuple<int, int, int, int, int>>  legs; // tuple: tripIdx, lineIdx, pathIdx, start connection index, end connection index
+      std::vector<Leg>  legs;
 
       Node *   journeyStepNodeDeparture;
       Node *   journeyStepNodeArrival;
       Trip *   journeyStepTrip;
-      Line *   journeyStepLine;
       Path *   journeyStepPath;
 
       int totalInVehicleTime       { 0}; int transferArrivalTime    {-1}; int firstDepartureTime     {-1};
@@ -82,8 +79,7 @@ namespace TrRouting
 
         legs.clear();
         journey.clear();
-        lineUuids.clear();
-        linesIdx.clear();
+
         boardingNodeUuids.clear();
         unboardingNodeUuids.clear();
         tripUuids.clear();
@@ -138,7 +134,6 @@ namespace TrRouting
             journeyStepNodeDeparture   = nodes[std::get<connectionIndexes::NODE_DEP>(*journeyStepEnterConnection)].get();
             journeyStepNodeArrival     = nodes[std::get<connectionIndexes::NODE_ARR>(*journeyStepExitConnection)].get();
             journeyStepTrip            = trips[std::get<journeyStepIndexes::FINAL_TRIP>(journeyStep)].get();
-            journeyStepLine            = lines[journeyStepTrip->lineIdx].get();
             journeyStepPath            = paths[journeyStepTrip->pathIdx].get();
             transferTime               = std::get<journeyStepIndexes::TRANSFER_TRAVEL_TIME>(journeyStep);
             distance                   = std::get<journeyStepIndexes::TRANSFER_DISTANCE>(journeyStep);
@@ -159,18 +154,16 @@ namespace TrRouting
 
             totalInVehicleTime         += inVehicleTime;
             totalWaitingTime           += waitingTime;
-            if (Mode::TRANSFERABLE != journeyStepLine->mode.shortname)
+            if (Mode::TRANSFERABLE != journeyStepTrip->line.mode.shortname)
             {
               numberOfTransfers += 1;
             }
-            lineUuids.push_back(journeyStepLine->uuid);
-            linesIdx.push_back(journeyStepTrip->lineIdx);
             inVehicleTravelTimesSeconds.push_back(inVehicleTime);
             boardingNodeUuids.push_back(journeyStepNodeDeparture->uuid);
             unboardingNodeUuids.push_back(journeyStepNodeArrival->uuid);
             tripUuids.push_back(journeyStepTrip->uuid);
             tripsIdx.push_back(std::get<journeyStepIndexes::FINAL_TRIP>(journeyStep));
-            legs.push_back(std::make_tuple(std::get<journeyStepIndexes::FINAL_TRIP>(journeyStep), journeyStepTrip->lineIdx, journeyStepTrip->pathIdx, boardingSequence - 1, unboardingSequence - 1));
+            legs.push_back(std::make_tuple(std::get<journeyStepIndexes::FINAL_TRIP>(journeyStep), std::ref(journeyStepTrip->line), journeyStepTrip->pathIdx, boardingSequence - 1, unboardingSequence - 1));
 
             if (unboardingSequence - 1 < journeyStepPath->segmentsDistanceMeters.size()) // check if distances are available for this path
             {
@@ -179,7 +172,7 @@ namespace TrRouting
                 inVehicleDistance += journeyStepPath->segmentsDistanceMeters[seqI];
               }
               totalDistance += inVehicleDistance;
-              if (Mode::TRANSFERABLE == journeyStepLine->mode.shortname)
+              if (Mode::TRANSFERABLE == journeyStepTrip->line.mode.shortname)
               {
                 totalWalkingDistance     += inVehicleDistance;
                 totalWalkingTime         += inVehicleTime;
@@ -215,12 +208,12 @@ namespace TrRouting
                 journeyStepTrip->agency.uuid, //TODO change boardingstep constructor to take the agency object directly
                 journeyStepTrip->agency.acronym,
                 journeyStepTrip->agency.name,
-                journeyStepLine->uuid,
-                journeyStepLine->shortname,
-                journeyStepLine->longname,
+                journeyStepTrip->line.uuid,
+                journeyStepTrip->line.shortname,
+                journeyStepTrip->line.longname,
                 journeyStepPath->uuid,
-                journeyStepLine->mode.name,
-                journeyStepLine->mode.shortname,
+                journeyStepTrip->line.mode.name,
+                journeyStepTrip->line.mode.shortname,
                 journeyStepTrip->uuid,
                 boardingSequence,
                 boardingSequence,
@@ -236,12 +229,12 @@ namespace TrRouting
                 journeyStepTrip->agency.uuid, //TODO change boardingstep constructor to take the agency object directly
                 journeyStepTrip->agency.acronym,
                 journeyStepTrip->agency.name,
-                journeyStepLine->uuid,
-                journeyStepLine->shortname,
-                journeyStepLine->longname,
+                journeyStepTrip->line.uuid,
+                journeyStepTrip->line.shortname,
+                journeyStepTrip->line.longname,
                 journeyStepPath->uuid,
-                journeyStepLine->mode.name,
-                journeyStepLine->mode.shortname,
+                journeyStepTrip->line.mode.name,
+                journeyStepTrip->line.mode.shortname,
                 journeyStepTrip->uuid,
                 unboardingSequence,
                 unboardingSequence + 1,

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -158,7 +158,7 @@ namespace TrRouting
       std::stable_sort(forwardConnections.begin(), forwardConnections.end(), [](const std::shared_ptr<ConnectionTuple>& connectionA, const std::shared_ptr<ConnectionTuple>& connectionB)
       {
         // Copied from calculator.hpp
-        // { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, LINE = 8, CAN_TRANSFER_SAME_LINE = 9, MIN_WAITING_TIME_SECONDS = 10 };
+        // { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, CAN_TRANSFER_SAME_LINE = 8, MIN_WAITING_TIME_SECONDS = 8 };
         if (std::get<connectionIndexes::TIME_DEP>(*connectionA) < std::get<connectionIndexes::TIME_DEP>(*connectionB))
         {
           return true;

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -50,17 +50,17 @@ namespace TrRouting
 
   int Calculator::updateLinesFromCache(std::string customPath)
   {
-    return dataFetcher.getLines(lines, lineIndexesByUuid, agencies, getModes(), customPath);
+    return dataFetcher.getLines(lines, agencies, getModes(), customPath);
   }
 
   int Calculator::updatePathsFromCache(std::string customPath)
   {
-    return dataFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getPaths(paths, pathIndexesByUuid, lines, nodeIndexesByUuid, customPath);
   }
 
   int Calculator::updateScenariosFromCache(std::string customPath)
   {
-    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, services, lineIndexesByUuid, agencies, nodeIndexesByUuid, getModes(), customPath);
+    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, getModes(), customPath);
   }
 
   int Calculator::updateSchedulesFromCache(std::string customPath)
@@ -72,7 +72,6 @@ namespace TrRouting
       paths,
       tripIndexesByUuid,
       services,
-      lineIndexesByUuid,
       pathIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -9,6 +9,7 @@
 #include "mode.hpp"
 #include "agency.hpp"
 #include "service.hpp"
+#include "line.hpp"
 
 namespace TrRouting
 {
@@ -258,9 +259,9 @@ namespace TrRouting
           }
         }
 
-        if (tripsEnabled[i] == 1 && parameters.getOnlyLinesIdx()->size() > 0)
+        if (tripsEnabled[i] == 1 && parameters.getOnlyLines().size() > 0)
         {
-          if (std::find(parameters.getOnlyLinesIdx()->begin(), parameters.getOnlyLinesIdx()->end(), trip->lineIdx) == parameters.getOnlyLinesIdx()->end())
+          if (std::find(parameters.getOnlyLines().begin(), parameters.getOnlyLines().end(), trip->line) == parameters.getOnlyLines().end())
           {
             tripsEnabled[i] = -1;
           }
@@ -300,9 +301,9 @@ namespace TrRouting
           }
         }
 
-        if (tripsEnabled[i] == 1 && parameters.getExceptLinesIdx()->size() > 0)
+        if (tripsEnabled[i] == 1 && parameters.getExceptLines().size() > 0)
         {
-          if (std::find(parameters.getExceptLinesIdx()->begin(), parameters.getExceptLinesIdx()->end(), trip->lineIdx) != parameters.getExceptLinesIdx()->end())
+          if (std::find(parameters.getExceptLines().begin(), parameters.getExceptLines().end(), trip->line) != parameters.getExceptLines().end())
           {
             tripsEnabled[i] = -1;
           }

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -42,11 +42,11 @@ namespace TrRouting
   {
     scenarioUuid = scenario.uuid;
     onlyServices = scenario.servicesList;
-    onlyLinesIdx = scenario.onlyLinesIdx;
+    onlyLines = scenario.onlyLines;
     onlyAgencies = scenario.onlyAgencies;
     onlyNodesIdx = scenario.onlyNodesIdx;
     onlyModes = scenario.onlyModes;
-    exceptLinesIdx = scenario.exceptLinesIdx;
+    exceptLines = scenario.exceptLines;
     exceptAgencies = scenario.exceptAgencies;
     exceptNodesIdx = scenario.exceptNodesIdx;
     exceptModes = scenario.exceptModes;
@@ -67,11 +67,11 @@ namespace TrRouting
     forwardCalculation(routeParams.forwardCalculation),
     scenarioUuid(routeParams.scenarioUuid),
     onlyServices(routeParams.onlyServices),
-    onlyLinesIdx(routeParams.onlyLinesIdx),
+    onlyLines(routeParams.onlyLines),
     onlyAgencies(routeParams.onlyAgencies),
     onlyNodesIdx(routeParams.onlyNodesIdx),
     onlyModes(routeParams.onlyModes),
-    exceptLinesIdx(routeParams.exceptLinesIdx),
+    exceptLines(routeParams.exceptLines),
     exceptAgencies(routeParams.exceptAgencies),
     exceptNodesIdx(routeParams.exceptNodesIdx),
     exceptModes(routeParams.exceptModes)

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -99,8 +99,7 @@ namespace TrRouting
     );
 
     virtual int getLines(
-      std::vector<std::unique_ptr<Line>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Line>& ts,
       const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
@@ -109,7 +108,7 @@ namespace TrRouting
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     );
@@ -118,7 +117,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<std::string, Mode>& modes,
@@ -127,16 +126,15 @@ namespace TrRouting
 
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
-      const std::vector<std::unique_ptr<Line>>& lines,
+      const std::map<boost::uuids::uuid, Line>& lines,
       std::vector<std::unique_ptr<Path>>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,short,short>>>& connections,
+      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>>& connections,
       std::string customPath = ""
     );
         

--- a/include/combinations.hpp
+++ b/include/combinations.hpp
@@ -1,5 +1,6 @@
 // combinations.hpp 
 // from https://stackoverflow.com/a/25497877
+// With later  modifications to adapt for std::reference_wrapper
 #include <vector>
 
 template<typename T> class Combinations {
@@ -10,11 +11,11 @@ template<typename T> class Combinations {
 // {2, 3, 4}, {2, 3, 5}, {2, 4, 5}, {3, 4, 5}
 
 public:
-    Combinations(std::vector<T> s, int m) : M(m), set(s), partial(std::vector<T>(M))
+    Combinations(std::vector<T> s, int m) : M(m), set(s)
     {
         N = s.size(); // unsigned long can't be casted to int in initialization
-
-        out = std::vector<std::vector<T>>(comb(N,M), std::vector<T>(M)); // allocate space
+        
+        partial.resize(M); //Preallocate space
 
         generate(0, N-1, M-1);
     };
@@ -31,11 +32,11 @@ private:
 
     int N;
     int M;
-    std::vector<T> set;
-    std::vector<T> partial;
-    std::vector<std::vector<T>> out;   
-
-    int count{0}; 
+    const std::vector<T> set;
+    // Use std::optional, so we can resize vector and the beginning and use object than don't have a
+    // default value like std::reference_wrapper
+    std::vector<std::optional<T>> partial;
+    std::vector<std::vector<T>> out;
 };
 
 template<typename T> 
@@ -50,23 +51,12 @@ void Combinations<T>::generate(int i, int j, int m) {
         // last position
         for (int z=i; z<j-m+1; z++) { 
             partial[M-m-1] = set[z];
-            out[count++] = std::vector<T>(partial); // add to output vector
+            // copy to output vector after dropping the std::optional
+            std::vector<T> fullPartial;
+            std::for_each(partial.begin(), partial.end(), [&fullPartial](std::optional<T>& t) {
+              fullPartial.push_back(t.value());
+            });
+            out.push_back(fullPartial);
         }
     }
-}
-
-template<typename T> 
-unsigned long long
-Combinations<T>::comb(unsigned long long n, unsigned long long k) {
-    // this is from Knuth vol 3
-
-    if (k > n) {
-        return 0;
-    }
-    unsigned long long r = 1;
-    for (unsigned long long d = 1; d <= k; ++d) {
-        r *= n--;
-        r /= d;
-    }
-    return r;
 }

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -165,8 +165,7 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getLines(
-      std::vector<std::unique_ptr<Line>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Line>& ts,
       const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
@@ -184,7 +183,7 @@ namespace TrRouting
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
     ) = 0;
@@ -202,7 +201,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<std::string, Mode>& modes,
@@ -220,16 +219,15 @@ namespace TrRouting
      */
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
-      const std::vector<std::unique_ptr<Line>>& lines,
+      const std::map<boost::uuids::uuid, Line>& lines,
       std::vector<std::unique_ptr<Path>>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,short,short>>>& connections,
+      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>>& connections,
       std::string customPath = "") = 0;
 
   };    

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -73,8 +73,7 @@ namespace TrRouting
                          ) {return 0;}
 
     virtual int getLines(
-      std::vector<std::unique_ptr<Line>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Line>& ts,
       const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
@@ -83,7 +82,7 @@ namespace TrRouting
     virtual int getPaths(
       std::vector<std::unique_ptr<Path>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::string customPath = ""
                          ) {return 0;}
@@ -101,7 +100,7 @@ namespace TrRouting
       std::vector<std::unique_ptr<Scenario>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+      const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, Agency>& agencies,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<std::string, Mode>& modes,
@@ -119,16 +118,15 @@ namespace TrRouting
      */
     virtual int getSchedules(
       std::vector<std::unique_ptr<Trip>>& trips,
-      const std::vector<std::unique_ptr<Line>>& lines,
+      const std::map<boost::uuids::uuid, Line>& lines,
       std::vector<std::unique_ptr<Path>>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& pathIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,short,short>>>& connections,
+      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>>& connections,
       std::string customPath = "") {return 0;}
 
   };    

--- a/include/line.hpp
+++ b/include/line.hpp
@@ -11,7 +11,7 @@ namespace TrRouting
   class Mode;
   class Agency;
   
-  struct Line {
+  class Line {
   
   public:
     Line(const boost::uuids::uuid &auuid,
@@ -41,8 +41,25 @@ namespace TrRouting
       return "Line " + boost::uuids::to_string(uuid) + "\n  shortname " + shortname + "\n  longname " + longname;
     }
 
+    // Equal operator. We only compare the uuid, since they should be unique.
+    inline bool operator==(const Line& other ) const { return uuid == other.uuid; }
   };
 
+  // To use std::find with a vector<reference_wrapper<const Line>>
+  inline bool operator==(const std::reference_wrapper<const TrRouting::Line>& lhs, const Line& rhs)
+  {
+    return lhs.get() == rhs;
+  }
+
+  inline bool operator==(const std::reference_wrapper<const TrRouting::Line>& lhs, const std::reference_wrapper<const Line>& rhs)
+  {
+    return lhs.get() == rhs.get();
+  }
+  // For sorting and std::map usage
+  inline bool operator<(const std::reference_wrapper<const TrRouting::Line>& lhs, const std::reference_wrapper<const Line>& rhs)
+  {
+    return lhs.get().uuid < rhs.get().uuid;
+  }
 }
 
 #endif // TR_LINE

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -19,6 +19,7 @@ namespace TrRouting
   class DataSource;
   class Agency;
   class Service;
+  class Line;
 
   class ParameterException : public std::exception
   {
@@ -72,7 +73,7 @@ namespace TrRouting
       std::vector<std::reference_wrapper<const Service>> onlyServices;
       //TODO exceptServices is never filled with anything
       std::vector<std::reference_wrapper<const Service>> exceptServices;
-      std::vector<int> onlyLinesIdx;
+      std::vector<std::reference_wrapper<const Line>> onlyLines;
       // FIXME: Temporarily moved to public until calculation specific parameters exist. This is used directly by alternatives routing.
       // see https://github.com/chairemobilite/trRouting/issues/95
       // std::vector<int> exceptLinesIdx;
@@ -128,8 +129,8 @@ namespace TrRouting
       );
       const std::vector<std::reference_wrapper<const Service>>& getOnlyServices() { return onlyServices; }
       const std::vector<std::reference_wrapper<const Service>>& getExceptServices() { return exceptServices; }
-      std::vector<int>* getOnlyLinesIdx() { return &onlyLinesIdx; }
-      std::vector<int>* getExceptLinesIdx() { return &exceptLinesIdx; }
+      const std::vector<std::reference_wrapper<const Line>>& getOnlyLines() { return onlyLines; }
+      const std::vector<std::reference_wrapper<const Line>>& getExceptLines() { return exceptLines; }
       const std::vector<std::reference_wrapper<const Mode>>& getOnlyModes() { return onlyModes; }
       const std::vector<std::reference_wrapper<const Mode>>& getExceptModes() { return exceptModes; }
       const std::vector<std::reference_wrapper<const Agency>>& getOnlyAgencies() { return onlyAgencies; }
@@ -139,7 +140,7 @@ namespace TrRouting
 
       // FIXME: Temporarily moved to public until calculation specific parameters exist. This is used directly by alternatives routing.
       // see https://github.com/chairemobilite/trRouting/issues/95
-      std::vector<int> exceptLinesIdx;
+      std::vector<std::reference_wrapper<const Line>> exceptLines;
   };
 
   class Parameters {

--- a/include/path.hpp
+++ b/include/path.hpp
@@ -7,13 +7,30 @@
 
 namespace TrRouting
 {
+  class Line;
   
-  struct Path {
+  class Path {
   
   public:
+    Path(const boost::uuids::uuid &auuid,
+         const Line &aline,
+         const std::string &adirection,
+         const std::string &ainternalId,
+         const std::vector<int> &anodesIdx,
+         const std::vector<int> &atripsIdx,
+         const std::vector<int> &asegmentsTravelTimeSeconds,
+         const std::vector<int> &asegmentsDistanceMeters):
+      uuid(auuid),
+      line(aline),
+      direction(adirection),
+      internalId(ainternalId),
+      nodesIdx(anodesIdx),
+      tripsIdx(atripsIdx),
+      segmentsTravelTimeSeconds(asegmentsTravelTimeSeconds),
+      segmentsDistanceMeters(asegmentsDistanceMeters) {}
    
     boost::uuids::uuid uuid;
-    int lineIdx;
+    const Line &line;
     std::string direction;
     std::string internalId;
     std::vector<int> nodesIdx;

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -8,6 +8,7 @@
 #include "routing_result_visitor.hpp"
 #include "json.hpp"
 #include "point.hpp" //Not using a forward declaration, as we use it more directly, see issue #129
+#include "line.hpp" //For Leg
 
 namespace TrRouting
 {
@@ -226,6 +227,9 @@ namespace TrRouting
    * @brief Class detailing a single trip detail. It describes a single alternative trip.
    * 
    */
+   // tuple: tripIdx, line, pathIdx, start connection index, end connection index
+  typedef std::tuple<int, std::reference_wrapper<const Line>, int, int, int> Leg;
+
   class SingleCalculationResult : public RoutingResult {
   public:
     int departureTime;
@@ -249,7 +253,7 @@ namespace TrRouting
     int totalWaitingTime;
     std::vector<std::unique_ptr<RoutingStep>> steps;
     // TODO Legs are used in the od_trip_routing function. They are kept here to avoid having to rewrite this code handling now, but eventually, it should the steps detail instead
-    std::vector<std::tuple<int, int, int, int, int>> legs; // tuple: tripIdx, lineIdx, pathIdx, start connection index, end connection index
+    std::vector<Leg> legs;
     SingleCalculationResult():
       RoutingResult(result_type::SINGLE_CALCULATION)
     {}

--- a/include/scenario.hpp
+++ b/include/scenario.hpp
@@ -20,11 +20,11 @@ namespace TrRouting
     boost::uuids::uuid simulationUuid;
     std::vector<std::reference_wrapper<const Service>> servicesList;
     std::vector<std::reference_wrapper<const Mode>> onlyModes;
-    std::vector<int> onlyLinesIdx;
+    std::vector<std::reference_wrapper<const Line>> onlyLines;
     std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
     std::vector<int> onlyNodesIdx;
     std::vector<std::reference_wrapper<const Mode>> exceptModes;
-    std::vector<int> exceptLinesIdx;
+    std::vector<std::reference_wrapper<const Line>> exceptLines;
     std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
     std::vector<int> exceptNodesIdx;
 

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -15,7 +15,7 @@ namespace TrRouting
   public:
     Trip( boost::uuids::uuid auuid,
           const Agency &aagency,
-          int alineIdx,
+          const Line &aline,
           int apathIdx,
           const Mode &amode,
           const Service &aservice,
@@ -23,7 +23,7 @@ namespace TrRouting
           int atotalCapacity = -1,
           int aseatedCapacity = -1): uuid(auuid),
                                          agency(aagency),
-                                         lineIdx(alineIdx),
+                                         line(aline),
                                          pathIdx(apathIdx),
                                          mode(amode),
                                          service(aservice),
@@ -32,10 +32,10 @@ namespace TrRouting
                                          allowSameLineTransfers(aallowSameLineTransfers) {}
    
     boost::uuids::uuid uuid;
-    const Agency &agency;
-    int lineIdx;
+    const Agency &agency; //TODO Agency is part of line, we could merge them
+    const Line &line;
     int pathIdx;
-    const Mode &mode;
+    const Mode &mode; //TODO Mode is part of Line, we could merge them
     const Service &service;
     short allowSameLineTransfers;
     int totalCapacity; //Unused

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -18,8 +18,7 @@ namespace TrRouting
 {
 
   int CacheFetcher::getLines(
-    std::vector<std::unique_ptr<Line>>& ts,
-    std::map<boost::uuids::uuid, int>& tIndexesByUuid,
+    std::map<boost::uuids::uuid, Line>& ts,
     const std::map<boost::uuids::uuid, Agency>& agencies,
     const std::map<std::string, Mode>& modes, 
     std::string customPath
@@ -32,7 +31,6 @@ namespace TrRouting
     int ret = 0;
 
     ts.clear();
-    tIndexesByUuid.clear();
 
     std::string tStr  = "lines";
     std::string TStr  = "Lines";
@@ -68,17 +66,13 @@ namespace TrRouting
         std::string uuid       {capnpT.getUuid()};
         std::string agencyUuid {capnpT.getAgencyUuid()};
         
-        std::unique_ptr<T> t = std::make_unique<T>(
-                                                   uuidGenerator(uuid),
-                                                   agencies.at(uuidGenerator(agencyUuid)),
-                                                   modes.at(capnpT.getMode()),
-                                                   capnpT.getShortname(),
-                                                   capnpT.getLongname(),
-                                                   capnpT.getInternalId(),
-                                                   capnpT.getAllowSameLineTransfers());
-
-        tIndexesByUuid[t->uuid] = ts.size();
-        ts.push_back(std::move(t));
+        ts.emplace(uuidGenerator(uuid), T(uuidGenerator(uuid),
+                                          agencies.at(uuidGenerator(agencyUuid)),
+                                          modes.at(capnpT.getMode()),
+                                          capnpT.getShortname(),
+                                          capnpT.getLongname(),
+                                          capnpT.getInternalId(),
+                                          capnpT.getAllowSameLineTransfers()));
       }
     }
     catch (const kj::Exception& e)

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -22,7 +22,7 @@ namespace TrRouting
     std::vector<std::unique_ptr<Scenario>>& ts,
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     const std::map<boost::uuids::uuid, Service>& services,
-    const std::map<boost::uuids::uuid, int>& lineIndexesByUuid,
+    const std::map<boost::uuids::uuid, Line>& lines,
     const std::map<boost::uuids::uuid, Agency>& agencies,
     const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     const std::map<std::string, Mode>& modes,
@@ -73,16 +73,15 @@ namespace TrRouting
         std::string simulationUuid {capnpT.getSimulationUuid()};
 
         std::vector<std::reference_wrapper<const Service>> servicesList;
-        std::vector<int> onlyLinesIdx;
+        std::vector<std::reference_wrapper<const Line>> onlyLines;
         std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
         std::vector<int> onlyNodesIdx;
         std::vector<std::reference_wrapper<const Mode>> onlyModes;
-        std::vector<int> exceptLinesIdx;
+        std::vector<std::reference_wrapper<const Line>> exceptLines;
         std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
         std::vector<int> exceptNodesIdx;
         std::vector<std::reference_wrapper<const Mode>> exceptModes;
         boost::uuids::uuid serviceUuid;
-        boost::uuids::uuid lineUuid;
         boost::uuids::uuid agencyUuid;
         boost::uuids::uuid nodeUuid;
 
@@ -103,13 +102,13 @@ namespace TrRouting
         t->servicesList = servicesList;
         for (std::string lineUuidStr : capnpT.getOnlyLinesUuids())
         {
-          lineUuid = uuidGenerator(lineUuidStr);
-          if (lineIndexesByUuid.count(lineUuid) != 0)
+          boost::uuids::uuid lineUuid = uuidGenerator(lineUuidStr);
+          if (lines.count(lineUuid) != 0)
           {
-            onlyLinesIdx.push_back(lineIndexesByUuid.at(lineUuid));
+            onlyLines.push_back(lines.at(lineUuid));
           }
         }
-        t->onlyLinesIdx = onlyLinesIdx;
+        t->onlyLines = onlyLines;
         for (std::string agencyUuidStr : capnpT.getOnlyAgenciesUuids())
         {
           agencyUuid = uuidGenerator(agencyUuidStr);
@@ -139,13 +138,13 @@ namespace TrRouting
 
         for (std::string lineUuidStr : capnpT.getExceptLinesUuids())
         {
-          lineUuid = uuidGenerator(lineUuidStr);
-          if (lineIndexesByUuid.count(lineUuid) != 0)
+          boost::uuids::uuid lineUuid = uuidGenerator(lineUuidStr);
+          if (lines.count(lineUuid) != 0)
           {
-            exceptLinesIdx.push_back(lineIndexesByUuid.at(lineUuid));
+            exceptLines.push_back(lines.at(lineUuid));
           }
         }
-        t->exceptLinesIdx = exceptLinesIdx;
+        t->exceptLines = exceptLines;
         for (std::string agencyUuidStr : capnpT.getExceptAgenciesUuids())
         {
           agencyUuid = uuidGenerator(agencyUuidStr);

--- a/tests/cache_fetch/lines_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/lines_cache_fetcher_test.cpp
@@ -12,8 +12,7 @@ namespace fs = std::filesystem;
 class LineCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
-    std::vector<std::unique_ptr<TrRouting::Line>> objects;
-    std::map<boost::uuids::uuid, int> objectIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
     std::map<std::string, TrRouting::Mode> modes;
 
@@ -43,22 +42,22 @@ public:
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesInvalid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencies, modes, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(lines, agencies, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
-    ASSERT_EQ(0, objects.size());
+    ASSERT_EQ(0, lines.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesValid)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
-    ASSERT_EQ(2, objects.size());
+    ASSERT_EQ(2, lines.size());
 }
 
 TEST_F(LineCacheFetcherFixtureTests, TestGetLinesFileNotExists)
 {
-    int retVal = cacheFetcher.getLines(objects, objectIndexesByUuid, agencies, modes, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getLines(lines, agencies, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
-    ASSERT_EQ(0, objects.size());
+    ASSERT_EQ(0, lines.size());
 }
 

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -14,7 +14,7 @@ class PathCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 protected:
     std::vector<std::unique_ptr<TrRouting::Path>> objects;
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
-    std::map<boost::uuids::uuid, int> lineIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
 
 public:
@@ -28,10 +28,8 @@ public:
         std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
         int retVal = cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
 
-        std::vector<std::unique_ptr<TrRouting::Line>> lines;
-
         auto modes = cacheFetcher.getModes();
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Node>> nodes;
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
@@ -47,7 +45,7 @@ public:
 
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsInvalid)
 {
-    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lines, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -55,14 +53,14 @@ TEST_F(PathCacheFetcherFixtureTests, TestGetPathsInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsValid)
 {
-    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lines, nodeIndexesByUuid, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(4, objects.size());
 }
 
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsFileNotExists)
 {
-    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, objectIndexesByUuid, lines, nodeIndexesByUuid, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -15,7 +15,7 @@ protected:
     std::vector<std::unique_ptr<TrRouting::Scenario>> objects;
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
-    std::map<boost::uuids::uuid, int> lineIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
     std::map<std::string, TrRouting::Mode> modes;
@@ -30,10 +30,8 @@ public:
         // Load valid data 
         cacheFetcher.getAgencies(agencies, VALID_CUSTOM_PATH);
 
-        std::vector<std::unique_ptr<TrRouting::Line>> lines;
-
         modes = cacheFetcher.getModes();
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
 
         std::vector<std::unique_ptr<TrRouting::Node>> nodes;
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
@@ -52,7 +50,7 @@ public:
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lineIndexesByUuid, agencies, nodeIndexesByUuid, modes, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -60,14 +58,14 @@ TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosValid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lineIndexesByUuid, agencies, nodeIndexesByUuid, modes, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosFileNotExists)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lineIndexesByUuid, agencies, nodeIndexesByUuid, modes, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -15,17 +15,16 @@ class ScheduleCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
     std::vector<std::unique_ptr<TrRouting::Trip>> trips;
-    std::vector<std::unique_ptr<TrRouting::Line>> lines;
+    std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::vector<std::unique_ptr<TrRouting::Path>> paths;
     std::vector<std::unique_ptr<TrRouting::Node>> nodes;
     std::map<boost::uuids::uuid, int> tripIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
-    std::map<boost::uuids::uuid, int> lineIndexesByUuid;
     std::map<boost::uuids::uuid, int> pathIndexesByUuid;
     std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
     std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,int,short,short>>> connections;
+    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>> connections;
 
 public:
     void SetUp( ) override
@@ -38,8 +37,8 @@ public:
         cacheFetcher.getServices(services, VALID_CUSTOM_PATH);
 
         cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
-        cacheFetcher.getLines(lines, lineIndexesByUuid, agencies, modes, VALID_CUSTOM_PATH);
-        cacheFetcher.getPaths(paths, pathIndexesByUuid, lineIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
+        cacheFetcher.getPaths(paths, pathIndexesByUuid, lines, nodeIndexesByUuid, VALID_CUSTOM_PATH);
         // Create the invalid lines directory
         fs::create_directory(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
     }
@@ -55,7 +54,7 @@ public:
 TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
 {
     // Copy the invalid file for the first line 
-    std::string node0Uuid = boost::uuids::to_string(lines[0].get()->uuid);
+    std::string node0Uuid = boost::uuids::to_string(lines.begin()->second.uuid);
     fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines/line_ " + node0Uuid.c_str() + ".capnpbin");
     int retVal = cacheFetcher.getSchedules(
       trips,
@@ -63,7 +62,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       paths,
       tripIndexesByUuid,
       services,
-      lineIndexesByUuid,
       pathIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,
@@ -84,7 +82,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       paths,
       tripIndexesByUuid,
       services,
-      lineIndexesByUuid,
       pathIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,
@@ -104,7 +101,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       paths,
       tripIndexesByUuid,
       services,
-      lineIndexesByUuid,
       pathIndexesByUuid,
       nodeIndexesByUuid,
       tripConnectionDepartureTimes,

--- a/tests/connection_scan_algorithm/Makefile.am
+++ b/tests/connection_scan_algorithm/Makefile.am
@@ -12,7 +12,8 @@ csa_test_SOURCES = gtest.cpp \
     csa_route_calculation_test.cpp \
     csa_route_transfer_alternatives_test.cpp \
     csa_result_to_v1_test.cpp \
-    route_parameters_test.cpp
+    route_parameters_test.cpp \
+    combinations_test.cpp
 
 csa_test_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 

--- a/tests/connection_scan_algorithm/combinations_test.cpp
+++ b/tests/connection_scan_algorithm/combinations_test.cpp
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+#include "combinations.hpp"
+
+TEST(CombinationsTest, simple) {
+    std::vector<int> testSet = {1,2,3};
+    
+    Combinations<int> combo(testSet, 2);
+
+    auto out = combo.get();
+
+    EXPECT_EQ(3, out.size());
+    EXPECT_EQ(std::vector<int>({1,2}), out[0]);
+    EXPECT_EQ(std::vector<int>({1,3}), out[1]);
+    EXPECT_EQ(std::vector<int>({2,3}), out[2]);
+}
+
+TEST(CombinationsTest, referenceWrapper) {
+    std::vector<int> testSet = {1,2,3};
+    std::vector<std::reference_wrapper<int>> testRefSet;
+    testRefSet.push_back(std::ref(testSet[0]));
+    testRefSet.push_back(std::ref(testSet[1]));
+    testRefSet.push_back(std::ref(testSet[2]));
+    //Change last number to make sure we had a reference
+    testSet[2] = 4;
+    
+    Combinations<std::reference_wrapper<int>> combo(testRefSet, 2);
+
+    auto out = combo.get();
+
+    EXPECT_EQ(3, out.size());
+    EXPECT_EQ(1, out[0][0].get());
+    EXPECT_EQ(2, out[0][1].get());
+    EXPECT_EQ(1, out[1][0].get());
+    EXPECT_EQ(4, out[1][1].get());
+    EXPECT_EQ(2, out[2][0].get());
+    EXPECT_EQ(4, out[2][1].get());
+}
+
+TEST(CombinationsTest, long) {
+    std::vector<int> testSet = {1,2,3,4,5,6};
+    
+    Combinations<int> combo(testSet, 3);
+
+    auto out = combo.get();
+
+    EXPECT_EQ(20, out.size());
+}


### PR DESCRIPTION
There was a few cases where the LineIndex was saved but not used, so those where removed.
This include the ConnectionTuple, which included a LineIdx.

In areas where you had a Trip object, the Line object can be accessed directly instead of
going to the full vector

Combination class had to be changed to be able to accommodate std::reference_wrapper.