### PR TITLE
Initialize global parameter object at startup

### DIFF
--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -139,6 +139,8 @@ int main(int argc, char** argv) {
   HttpServer server;
   server.config.port = programOptions.port;
 
+  // FIXME: Now, all endpoints, including v2 needs this param object to be initialized, so let's do it here, but it should not be necessary (see https://github.com/chairemobilite/trRouting/issues/58)
+  calculator.params.setDefaultValues();
 
 
   server.resource["^/saveCache[/]?$"]["POST"] = [&server, &calculator](std::shared_ptr<HttpServer::Response> serverResponse, std::shared_ptr<HttpServer::Request> request) {


### PR DESCRIPTION
Initializing those parameters is required for proper calculation as it still contains a few fields that are not really parameters, but are there (like accessMode and egressMode for footpath calculations).

This fixes instances planned to run only V2 queries, as this param object is not re-initialized by those requests, only the `transit/v1/route` query did it. v2 endpoints all returned no routing unless a v1 query was done first.