### PR TITLE
Migrate Node vector and index to a UUID:Node map

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <deque>
 #include <tuple>
@@ -12,6 +13,8 @@
 
 #include "calculation_time.hpp"
 #include "parameters.hpp"
+#include "connection.hpp"
+#include "node.hpp"
 
 namespace TrRouting
 {
@@ -26,7 +29,6 @@ namespace TrRouting
   class Agency;
   class Service;
   class Station;
-  class Node;
   class Line;
   class Path;
   class Scenario;
@@ -35,8 +37,7 @@ namespace TrRouting
   class AlternativesResult;
   class DataFetcher;
 
-  // tuple representing a connection: departureNodeIndex, arrivalNodeIndex, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
-  using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,short,short>;
+  using JourneyStep = std::tuple<int,int,int,int,short,int>; //final enter connection, final exit connection, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
 
   class Calculator {
 
@@ -82,16 +83,16 @@ namespace TrRouting
     // a concrete result object instead of pointer (that alternatives could use directly), but still
     // use common calculation functions
     std::unique_ptr<RoutingResult> calculate(RouteParameters &parameters, bool resetAccessPaths = true, bool resetFilters = true);
-    std::tuple<int,int,int,int> forwardCalculation(RouteParameters &parameters); // best arrival time,   best egress node index, best egress travel time: MAX_INT,-1,-1 if non routable, too long or all nodes result
-    std::tuple<int,int,int,int> reverseCalculation(RouteParameters &parameters); // best departure time, best access node index, best access travel time: -1,-1,-1 if non routable, too long or all nodes result
+    std::optional<std::tuple<int, std::reference_wrapper<const Node>>> forwardCalculation(RouteParameters &parameters); // best arrival time,   best egress node
+    std::optional<std::tuple<int, std::reference_wrapper<const Node>>> reverseCalculation(RouteParameters &parameters); // best departure time, best access node
     // TODO See calculate
-    std::unique_ptr<RoutingResult> forwardJourneyStep(RouteParameters &parameters, int bestArrivalTime, int bestEgressNodeIndex, int bestEgressTravelTime, int bestEgressDistance);
+    std::unique_ptr<RoutingResult> forwardJourneyStep(RouteParameters &parameters, int bestArrivalTime, std::optional<std::reference_wrapper<const Node>> bestEgressNode);
     // TODO See calculate
-    std::unique_ptr<RoutingResult> reverseJourneyStep(RouteParameters &parameters, int bestDepartureTime, int bestAccessNodeIndex, int bestAccessTravelTime, int bestAccessDistance);
+    std::unique_ptr<RoutingResult> reverseJourneyStep(RouteParameters &parameters, int bestDepartureTime, std::optional<std::reference_wrapper<const Node>> bestAccessNode);
     AlternativesResult alternativesRouting(RouteParameters &parameters);
     std::string             odTripsRouting(RouteParameters &parameters);
 
-    std::vector<int>        optimizeJourney(std::deque<std::tuple<int,int,int,int,int,short,int>> &journey);
+    std::vector<int>        optimizeJourney(std::deque<JourneyStep> &journey);
 
     /**
      * The update*FromCache methods get the data from the cache
@@ -154,8 +155,8 @@ namespace TrRouting
     std::map<boost::uuids::uuid, Service>    services;
     const std::map<boost::uuids::uuid, Service> & getServices() {return services;}
 
-    std::vector<std::unique_ptr<Node>>       nodes;
-    std::map<boost::uuids::uuid, int>        nodeIndexesByUuid;
+    std::map<boost::uuids::uuid, Node>       nodes;
+    const std::map<boost::uuids::uuid, Node> & getNodes() {return nodes;}
 
     std::map<boost::uuids::uuid, Line>       lines;
     const std::map<boost::uuids::uuid, Line> & getLines() {return lines;}
@@ -181,8 +182,7 @@ namespace TrRouting
 
   private:
 
-    enum connectionIndexes : short { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, CAN_TRANSFER_SAME_LINE = 8, MIN_WAITING_TIME_SECONDS = 9 };
-    enum journeyStepIndexes: short { FINAL_ENTER_CONNECTION = 0, FINAL_EXIT_CONNECTION = 1, FINAL_TRANSFERRING_NODE = 2, FINAL_TRIP = 3, TRANSFER_TRAVEL_TIME = 4, IS_SAME_NODE_TRANSFER = 5, TRANSFER_DISTANCE = 6 };
+    enum journeyStepIndexes: short { FINAL_ENTER_CONNECTION = 0, FINAL_EXIT_CONNECTION = 1, FINAL_TRIP = 2, TRANSFER_TRAVEL_TIME = 3, IS_SAME_NODE_TRANSFER = 4, TRANSFER_DISTANCE = 5 };
 
     int              departureTimeSeconds;
     int              initialDepartureTimeSeconds;
@@ -199,26 +199,26 @@ namespace TrRouting
     std::string      egressMode;
     std::vector<int> forwardConnectionsIndexPerDepartureTimeHour;
     std::vector<int> reverseConnectionsIndexPerArrivalTimeHour;
-    std::vector<int> nodesTentativeTime; // arrival time at node (MAX_INT if not yet reached or unreachable)
-    std::vector<int> nodesReverseTentativeTime; // departure time at node (MAX_INT if not yet reached or unreachable)
-    std::vector<int> nodesAccessTravelTime; // travel time from origin to accessible nodes (-1 if unreachable by access mode)
-    std::vector<int> nodesEgressTravelTime; // travel time to reach destination (-1 if unreachable by egress mode)
-    std::vector<int> nodesAccessDistance; // distance from origin to accessible nodes (-1 if unreachable by access mode)
-    std::vector<int> nodesEgressDistance; // distance to reach destination (-1 if unreachable by egress mode)
+
+    std::unordered_map<Node::uid_t, int> nodesTentativeTime; // arrival time at node
+    std::unordered_map<Node::uid_t, int> nodesReverseTentativeTime; // departure time at node
+    std::unordered_map<Node::uid_t, NodeTimeDistance> nodesAccess; // travel time/distance from origin to accessible nodes
+    std::unordered_map<Node::uid_t, NodeTimeDistance> nodesEgress; // travel time/distance to reach destination;
+
     std::vector<int> tripsEnterConnection; // index of the entering connection for each trip index
     std::vector<int> tripsEnterConnectionTransferTravelTime; // index of the entering connection for each trip index
     std::vector<int> tripsExitConnection; // index of the exiting connection for each trip index
     std::vector<int> tripsExitConnectionTransferTravelTime; // index of the exiting connection for each trip index
     std::vector<int> tripsEnabled; // allow/disallow use of this trip during calculation
     std::vector<int> tripsUsable; // after forward calculation, keep a list of usable trips in time range for reverse calculation
-    std::vector<std::tuple<int,int,int>> accessFootpaths; // pair: accessNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
-    std::vector<std::tuple<int,int,int>> egressFootpaths; // pair: egressNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
+    std::vector<NodeTimeDistance> accessFootpaths; // pair: accessNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
+    std::vector<NodeTimeDistance> egressFootpaths; // pair: egressNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
     std::vector<std::shared_ptr<ConnectionTuple>> forwardConnections; // Forward connections, sorted by departure time ascending
     std::vector<std::shared_ptr<ConnectionTuple>> reverseConnections; // Reverse connections, sorted by arrival time descending
-    std::vector<std::tuple<int,int,int,int,int,short,int>> forwardJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
-    std::vector<std::tuple<int,int,int,int,int,short,int>> forwardEgressJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
-    std::vector<std::tuple<int,int,int,int,int,short,int>> reverseJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
-    std::vector<std::tuple<int,int,int,int,int,short,int>> reverseAccessJourneysSteps; // index = node index, tuple: final enter connection, final exit connection, final transferring node index, final trip index, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
+    std::unordered_map<Node::uid_t, JourneyStep> forwardJourneysSteps; 
+    std::unordered_map<Node::uid_t, JourneyStep> forwardEgressJourneysSteps;
+    std::unordered_map<Node::uid_t, JourneyStep> reverseJourneysSteps;
+    std::unordered_map<Node::uid_t, JourneyStep> reverseAccessJourneysSteps;
 
   };
 

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -43,35 +43,13 @@ namespace TrRouting
 
   void Calculator::initializeCalculationData() {
     nodesTentativeTime.clear();
-    nodesTentativeTime.shrink_to_fit();
-    nodesTentativeTime.resize(nodes.size());
     nodesReverseTentativeTime.clear();
-    nodesReverseTentativeTime.shrink_to_fit();
-    nodesReverseTentativeTime.resize(nodes.size());
-    nodesAccessTravelTime.clear();
-    nodesAccessTravelTime.shrink_to_fit();
-    nodesAccessTravelTime.resize(nodes.size());
-    nodesAccessDistance.clear();
-    nodesAccessDistance.shrink_to_fit();
-    nodesAccessDistance.resize(nodes.size());
-    nodesEgressTravelTime.clear();
-    nodesEgressTravelTime.shrink_to_fit();
-    nodesEgressTravelTime.resize(nodes.size());
-    nodesEgressDistance.clear();
-    nodesEgressDistance.shrink_to_fit();
-    nodesEgressDistance.resize(nodes.size());
+    nodesAccess.clear();
+    nodesEgress.clear();
     forwardJourneysSteps.clear();
-    forwardJourneysSteps.shrink_to_fit();
-    forwardJourneysSteps.resize(nodes.size());
     forwardEgressJourneysSteps.clear();
-    forwardEgressJourneysSteps.shrink_to_fit();
-    forwardEgressJourneysSteps.resize(nodes.size());
     reverseJourneysSteps.clear();
-    reverseJourneysSteps.shrink_to_fit();
-    reverseJourneysSteps.resize(nodes.size());
     reverseAccessJourneysSteps.clear();
-    reverseAccessJourneysSteps.shrink_to_fit();
-    reverseAccessJourneysSteps.resize(nodes.size());
 
     tripsEnabled.clear();
     tripsEnabled.shrink_to_fit();
@@ -135,6 +113,7 @@ namespace TrRouting
 
   }
 
+  //TODO This should probably take a reference to the connections object and later not use the std::move semantic
   int Calculator::setConnections(std::vector<std::shared_ptr<ConnectionTuple>> connections)
   {
 

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -11,6 +11,7 @@
 #include "trip.hpp"
 #include "routing_result.hpp"
 #include "od_trip.hpp"
+#include "node.hpp"
 
 namespace TrRouting
 {
@@ -323,8 +324,8 @@ namespace TrRouting
 
               if (pathProfiles.find(legPath.uuid) == pathProfiles.end())
               {
-                pathProfiles[legPath.uuid] = std::vector<std::vector<float>>(legPath.nodesIdx.size() - 1, demandByHourOfDay);
-                pathTotalProfiles[legPath.uuid] = std::vector<float>(legPath.nodesIdx.size() - 1, 0.0);
+                pathProfiles[legPath.uuid] = std::vector<std::vector<float>>(legPath.nodesRef.size() - 1, demandByHourOfDay);
+                pathTotalProfiles[legPath.uuid] = std::vector<float>(legPath.nodesRef.size() - 1, 0.0);
               }
               for (int connectionIndex = legConnectionStartIdx; connectionIndex <= legConnectionEndIdx; connectionIndex++)
               {

--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -19,10 +19,10 @@ namespace TrRouting
     odTripsActivities.clear();
     odTripsModes.clear();
 
-    accessNodesIdx.clear();
+    accessNodesRef.clear();
     accessNodeTravelTimesSeconds.clear();
     accessNodeDistancesMeters.clear();
-    egressNodesIdx.clear();
+    egressNodesRef.clear();
     egressNodeTravelTimesSeconds.clear();
     egressNodeDistancesMeters.clear();
 
@@ -75,8 +75,7 @@ namespace TrRouting
     std::vector<std::unique_ptr<Scenario>> &scenarios,
     std::map<boost::uuids::uuid, int> &odTripIndexesByUuid,
     std::vector<std::unique_ptr<OdTrip>> &odTrips,
-    std::map<boost::uuids::uuid, int> &nodeIndexesByUuid,
-    std::vector<std::unique_ptr<Node>> &nodes,
+    const std::map<boost::uuids::uuid, Node> &nodes,
     const std::map<boost::uuids::uuid, DataSource> &dataSources)
   {
 
@@ -106,8 +105,6 @@ namespace TrRouting
     std::vector<std::string> onlyAgencyUuidsVector;
     std::vector<std::string> exceptAgencyUuidsVector;
     std::vector<std::string> onlyNodeUuidsVector;
-    std::vector<std::string> exceptNodeUuidsVector;
-    std::vector<std::string> accessNodeUuidsVector;
     std::vector<std::string> accessNodeTravelTimesSecondsVector;
     std::vector<std::string> accessNodeDistancesMetersVector;
     std::vector<std::string> egressNodeUuidsVector;
@@ -151,10 +148,11 @@ namespace TrRouting
               )
       {
         originNodeUuid = uuidGenerator(parameterWithValueVector[1]);
-        if (nodeIndexesByUuid.count(originNodeUuid) == 1)
+        //TODO Replace map.count()/at() combos with map.find(). (Do this elsewhere)
+        if (nodes.count(originNodeUuid) == 1)
         {
-          Node *originNode = nodes[nodeIndexesByUuid[originNodeUuid]].get();
-          newParametersWithValues.push_back(std::make_pair("origin", std::to_string(originNode->point.get()->longitude) + ',' + std::to_string(originNode->point.get()->latitude)));
+          const Node &originNode = nodes.at(originNodeUuid);
+          newParametersWithValues.push_back(std::make_pair("origin", std::to_string(originNode.point.get()->longitude) + ',' + std::to_string(originNode.point.get()->latitude)));
         }
         continue;
       }
@@ -164,10 +162,10 @@ namespace TrRouting
               )
       {
         destinationNodeUuid = uuidGenerator(parameterWithValueVector[1]);
-        if (nodeIndexesByUuid.count(destinationNodeUuid) == 1)
+        if (nodes.count(destinationNodeUuid) == 1)
         {
-          Node *destinationNode = nodes[nodeIndexesByUuid[destinationNodeUuid]].get();
-          newParametersWithValues.push_back(std::make_pair("destination", std::to_string(destinationNode->point.get()->longitude) + ',' + std::to_string(destinationNode->point.get()->latitude)));
+          const Node & destinationNode = nodes.at(destinationNodeUuid);
+          newParametersWithValues.push_back(std::make_pair("destination", std::to_string(destinationNode.point.get()->longitude) + ',' + std::to_string(destinationNode.point.get()->latitude)));
         }
         continue;
       }
@@ -511,28 +509,30 @@ namespace TrRouting
       // not sure we want to keep this: or supply node indexes instead, to limit request size?
       else if (parameterWithValueVector[0] == "access_node_uuids")
       {
+        std::vector<std::string> accessNodeUuidsVector;
         boost::split(accessNodeUuidsVector, parameterWithValueVector[1], boost::is_any_of(","));
         boost::uuids::uuid accessNodeUuid;
         for(std::string accessNodeUuidStr : accessNodeUuidsVector)
         {
           accessNodeUuid = uuidGenerator(accessNodeUuidStr);
-          if (nodeIndexesByUuid.count(accessNodeUuid) == 1)
+          if (nodes.count(accessNodeUuid) == 1)
           {
-            accessNodesIdx.push_back(nodeIndexesByUuid[accessNodeUuid]);
+            accessNodesRef.push_back(nodes.at(accessNodeUuid));
           }
         }
         continue;
       }
       else if (parameterWithValueVector[0] == "egress_node_uuids")
       {
+        std::vector<std::string> exceptNodeUuidsVector;
         boost::split(egressNodeUuidsVector, parameterWithValueVector[1], boost::is_any_of(","));
         boost::uuids::uuid egressNodeUuid;
         for(std::string egressNodeUuidStr : egressNodeUuidsVector)
         {
           egressNodeUuid = uuidGenerator(egressNodeUuidStr);
-          if (nodeIndexesByUuid.count(egressNodeUuid) == 1)
+          if (nodes.count(egressNodeUuid) == 1)
           {
-            egressNodesIdx.push_back(nodeIndexesByUuid[egressNodeUuid]);
+            egressNodesRef.push_back(nodes.at(egressNodeUuid));
           }
         }
         continue;

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -10,7 +10,7 @@ namespace TrRouting
   // TODO now that we have a "generic" data fetcher interface, we should remove the FromCache from these function name
   int Calculator::updateNodesFromCache(std::string customPath)
   {
-    return dataFetcher.getNodes(nodes, nodeIndexesByUuid, customPath);
+    return dataFetcher.getNodes(nodes, customPath);
   }
 
   int Calculator::updateDataSourcesFromCache(std::string customPath)
@@ -30,7 +30,7 @@ namespace TrRouting
   
   int Calculator::updateOdTripsFromCache(std::string customPath)
   {
-    return dataFetcher.getOdTrips(odTrips, odTripIndexesByUuid, dataSources, personIndexesByUuid, nodeIndexesByUuid, customPath);
+    return dataFetcher.getOdTrips(odTrips, odTripIndexesByUuid, dataSources, personIndexesByUuid, getNodes(), customPath);
   }
   /* TODO #167
   int Calculator::updatePlacesFromCache(std::string customPath)
@@ -55,12 +55,12 @@ namespace TrRouting
 
   int Calculator::updatePathsFromCache(std::string customPath)
   {
-    return dataFetcher.getPaths(paths, lines, nodeIndexesByUuid, customPath);
+    return dataFetcher.getPaths(paths, lines, getNodes(), customPath);
   }
 
   int Calculator::updateScenariosFromCache(std::string customPath)
   {
-    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, getModes(), customPath);
+    return dataFetcher.getScenarios(scenarios, scenarioIndexesByUuid, services, lines, agencies, getNodes(), getModes(), customPath);
   }
 
   int Calculator::updateSchedulesFromCache(std::string customPath)
@@ -72,7 +72,6 @@ namespace TrRouting
       paths,
       tripIndexesByUuid,
       services,
-      nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,

--- a/connection_scan_algorithm/src/route_parameters.cpp
+++ b/connection_scan_algorithm/src/route_parameters.cpp
@@ -44,11 +44,11 @@ namespace TrRouting
     onlyServices = scenario.servicesList;
     onlyLines = scenario.onlyLines;
     onlyAgencies = scenario.onlyAgencies;
-    onlyNodesIdx = scenario.onlyNodesIdx;
+    onlyNodes = scenario.onlyNodes;
     onlyModes = scenario.onlyModes;
     exceptLines = scenario.exceptLines;
     exceptAgencies = scenario.exceptAgencies;
-    exceptNodesIdx = scenario.exceptNodesIdx;
+    exceptNodes = scenario.exceptNodes;
     exceptModes = scenario.exceptModes;
   }
 
@@ -69,11 +69,11 @@ namespace TrRouting
     onlyServices(routeParams.onlyServices),
     onlyLines(routeParams.onlyLines),
     onlyAgencies(routeParams.onlyAgencies),
-    onlyNodesIdx(routeParams.onlyNodesIdx),
+    onlyNodes(routeParams.onlyNodes),
     onlyModes(routeParams.onlyModes),
     exceptLines(routeParams.exceptLines),
     exceptAgencies(routeParams.exceptAgencies),
-    exceptNodesIdx(routeParams.exceptNodesIdx),
+    exceptNodes(routeParams.exceptNodes),
     exceptModes(routeParams.exceptModes)
   {
   }

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -328,7 +328,6 @@ int main(int argc, char** argv) {
         calculator.scenarios,
         calculator.odTripIndexesByUuid,
         calculator.odTrips,
-        calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSources);
 

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -78,7 +78,7 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       const std::map<boost::uuids::uuid, DataSource>& dataSources,
       const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       std::string customPath = ""
     );
 
@@ -93,8 +93,7 @@ namespace TrRouting
     );
 
     virtual int getNodes(
-      std::vector<std::unique_ptr<Node>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Node>& ts,
       std::string customPath = ""
     );
 
@@ -108,7 +107,7 @@ namespace TrRouting
     virtual int getPaths(
       std::map<boost::uuids::uuid, Path>& ts,
       const std::map<boost::uuids::uuid, Line>& lines,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       std::string customPath = ""
     );
 
@@ -118,7 +117,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Service>& services,
       const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, Agency>& agencies,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     );
@@ -129,10 +128,9 @@ namespace TrRouting
       std::map<boost::uuids::uuid, Path>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>>& connections,
+      std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = ""
     );
         

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -1,0 +1,16 @@
+#ifndef TR_CONNECTION
+#define TR_CONNECTION
+
+namespace TrRouting
+{
+  class Node;
+  
+  // tuple representing a connection: departureNode, arrivalNode, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
+  using ConnectionTuple = std::tuple<std::reference_wrapper<const Node>,std::reference_wrapper<const Node>,int,int,int,short,short,int,short,short>;
+
+  enum connectionIndexes : short { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, CAN_TRANSFER_SAME_LINE = 8, MIN_WAITING_TIME_SECONDS = 9 };
+
+
+}
+
+#endif

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <boost/uuid/uuid.hpp>
+#include "connection.hpp"
 
 namespace TrRouting
 {
@@ -89,8 +90,8 @@ namespace TrRouting
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       const std::map<boost::uuids::uuid, DataSource>& dataSources,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       std::string customPath = ""
     ) = 0;
 
@@ -150,8 +151,7 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getNodes(
-      std::vector<std::unique_ptr<Node>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Node>& ts,
       std::string customPath = ""
     ) = 0;
 
@@ -183,7 +183,7 @@ namespace TrRouting
     virtual int getPaths(
       std::map<boost::uuids::uuid, Path>& ts,
       const std::map<boost::uuids::uuid, Line>& lines,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       std::string customPath = ""
     ) = 0;
 
@@ -202,7 +202,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Service>& services,
       const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, Agency>& agencies,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
     ) = 0;
@@ -222,10 +222,9 @@ namespace TrRouting
       std::map<boost::uuids::uuid, Path>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>>& connections,
+      std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = "") = 0;
 
   };    

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -51,8 +51,8 @@ namespace TrRouting
       std::vector<std::unique_ptr<OdTrip>>& ts,
       std::map<boost::uuids::uuid, int>& tIndexesById, 
       const std::map<boost::uuids::uuid, DataSource>& dataSources,
-      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,     
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       std::string customPath = ""
                            ) {return 0;}
 
@@ -67,8 +67,7 @@ namespace TrRouting
                             ) {return 0;}
 
     virtual int getNodes(
-      std::vector<std::unique_ptr<Node>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById,
+      std::map<boost::uuids::uuid, Node>& ts,
       std::string customPath = ""
                          ) {return 0;}
 
@@ -82,7 +81,7 @@ namespace TrRouting
     virtual int getPaths(
       std::map<boost::uuids::uuid, Path>& ts,
       const std::map<boost::uuids::uuid, Line>& lines,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       std::string customPath = ""
                          ) {return 0;}
 
@@ -101,7 +100,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Service>& services,
       const std::map<boost::uuids::uuid, Line>& lines,
       const std::map<boost::uuids::uuid, Agency>& agencies,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+      const std::map<boost::uuids::uuid, Node>& nodes,
       const std::map<std::string, Mode>& modes,
       std::string customPath = ""
                              ) {return 0;}
@@ -121,10 +120,9 @@ namespace TrRouting
       std::map<boost::uuids::uuid, Path>& paths,
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
-      std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>>& connections,
+      std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = "") {return 0;}
 
   };    

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -7,31 +7,87 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "point.hpp"
+#include <boost/functional/hash.hpp>
 
 namespace TrRouting
 {
+  class NodeTimeDistance;
   
-  struct Node {
-  
+  class Node {
   public:
+
+    typedef int uid_t; //Type for a local temporary ID
+
+    Node(const boost::uuids::uuid &_uuid,
+         unsigned long long _id,
+         const std::string &_code,
+         const std::string &_name,
+         const std::string &_internalId,
+         std::unique_ptr<Point> _point
+         ) : uuid(_uuid),
+             id(_id),
+             code(_code),
+             name(_name),
+             internalId(_internalId),
+             uid(++global_uid)
+             {
+               point = std::move(_point);
+             }
    
     boost::uuids::uuid uuid;
+    uid_t uid; //Local, temporary unique id, used to speed up lookups
     unsigned long long id;
     std::string code;
     std::string name;
     std::string internalId;
-    std::unique_ptr<Point> point;
-    std::vector<int> transferableNodesIdx;
-    std::vector<int> transferableTravelTimesSeconds;
-    std::vector<int> transferableDistancesMeters;
-    std::vector<int> reverseTransferableNodesIdx;
-    std::vector<int> reverseTransferableTravelTimesSeconds;
-    std::vector<int> reverseTransferableDistancesMeters;
+    std::unique_ptr<Point> point; //TODO Does this need to be a ptr or could be part of the object?
+    std::vector<NodeTimeDistance> transferableNodes;
+    std::vector<NodeTimeDistance> reverseTransferableNodes; //TODO Add comment on what this is
 
     const std::string toString() {
       return "Node " + boost::uuids::to_string(uuid) + " (id " + std::to_string(id) + ")\n  code " + code + "\n  name " + name + "\n  latitude " + std::to_string(point.get()->latitude)  + "\n  longitude " + std::to_string(point.get()->longitude);
     }
+    // Equal operator. We only compare the local uid, since they should be unique.
+    inline bool operator==(const Node& other ) const { return uid == other.uid; }
+    inline bool operator<(const Node& other ) const { return uid < other.uid; }
 
+  private:
+    //TODO, this could probably be an unsigned long, but current MAX_INT is good enough for our needs
+    inline static uid_t global_uid = 0;
+  };
+
+  inline bool operator==(const std::reference_wrapper<const TrRouting::Node>& lhs, const std::reference_wrapper<const Node>& rhs)
+  {
+    return lhs.get() == rhs.get();
+  }
+  // For sorting and std::map usage
+  inline bool operator<(const std::reference_wrapper<const TrRouting::Node>& lhs, const std::reference_wrapper<const Node>& rhs)
+  {
+    return lhs.get() < rhs.get();
+  }
+
+  // Store information about access time and distance to a specific Node
+  class NodeTimeDistance {
+
+  public:
+    NodeTimeDistance(const Node& _node, int _time, int _distance) :
+      node(_node),
+      time(_time),
+      distance(_distance)
+    {
+
+    }
+    NodeTimeDistance(const NodeTimeDistance &_node):
+      node(_node.node),
+      time(_node.time),
+      distance(_node.distance)
+    {
+
+    }
+
+    const Node & node;
+    const int time;
+    const int distance;
   };
 
 }

--- a/include/od_trip.hpp
+++ b/include/od_trip.hpp
@@ -26,12 +26,8 @@ namespace TrRouting
            const std::string &amode,
            const std::string &aoriginActivity,
            const std::string &adestinationActivity,
-           const std::vector<int> &aoriginNodesIdx,
-           const std::vector<int> &aoriginNodesTravelTimesSeconds,
-           const std::vector<int> &aoriginNodesDistancesMeters,
-           const std::vector<int> &adestinationNodesIdx,
-           const std::vector<int> &adestinationNodesTravelTimesSeconds,
-           const std::vector<int> &adestinationNodesDistancesMeters,
+           const std::vector<NodeTimeDistance> &aoriginNodes,
+           const std::vector<NodeTimeDistance> &adestinationNodes,
            std::unique_ptr<Point> aorigin,
            std::unique_ptr<Point> adestination)
     : uuid(auuid),
@@ -48,12 +44,8 @@ namespace TrRouting
       mode(amode),
       originActivity(aoriginActivity),
       destinationActivity(adestinationActivity),
-      originNodesIdx(aoriginNodesIdx),
-      originNodesTravelTimesSeconds(aoriginNodesTravelTimesSeconds),
-      originNodesDistancesMeters(aoriginNodesDistancesMeters),
-      destinationNodesIdx(adestinationNodesIdx),
-      destinationNodesTravelTimesSeconds(adestinationNodesTravelTimesSeconds),
-      destinationNodesDistancesMeters(adestinationNodesDistancesMeters),
+      originNodes(aoriginNodes),
+      destinationNodes(adestinationNodes),
       origin(std::move(aorigin)),
       destination(std::move(adestination)) {}
 
@@ -73,13 +65,8 @@ namespace TrRouting
     std::string originActivity;
     std::string destinationActivity;
     std::string internalId;
-    //TODO Combine those 3 into an object
-    std::vector<int> originNodesIdx;
-    std::vector<int> originNodesTravelTimesSeconds;
-    std::vector<int> originNodesDistancesMeters;
-    std::vector<int> destinationNodesIdx;
-    std::vector<int> destinationNodesTravelTimesSeconds;
-    std::vector<int> destinationNodesDistancesMeters;
+    std::vector<NodeTimeDistance> originNodes;
+    std::vector<NodeTimeDistance> destinationNodes;
     std::unique_ptr<Point> origin;
     std::unique_ptr<Point> destination;
 

--- a/include/osrm_fetcher.hpp
+++ b/include/osrm_fetcher.hpp
@@ -7,10 +7,15 @@
 #include <memory>
 #include <tuple>
 
+#include <map> //For node map types, TODO have a typedef somewhere for the nodes array
+#include <boost/uuid/uuid.hpp>
+
+
 namespace TrRouting
 {
   class Point;
   class Node;
+  class NodeTimeDistance;
 
   class OsrmFetcher
   {
@@ -27,11 +32,11 @@ namespace TrRouting
     //TODO This should be managed outside of the osrm_fetcher, with a dedicated data fetcher
     static bool birdDistanceAccessibilityEnabled; // true if the accessibility information is obtained using bird distances instead of osrm
 
-    static std::vector<std::tuple<int, int, int>> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
+    static std::vector<NodeTimeDistance> getAccessibleNodesFootpathsFromPoint(const Point &point, const std::map<boost::uuids::uuid, Node> &nodes, std::string mode, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed = false);
 
   protected:
-    static std::vector<std::tuple<int, int, int>> getNodesFromBirdDistance(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
-    static std::vector<std::tuple<int, int, int>> getNodesFromOsrm(const Point &point, const std::vector<std::unique_ptr<Node>> &nodes, std::string mode, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
+    static std::vector<NodeTimeDistance> getNodesFromBirdDistance(const Point &point, const std::map<boost::uuids::uuid, Node> &nodes, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond);
+    static std::vector<NodeTimeDistance> getNodesFromOsrm(const Point &point, const std::map<boost::uuids::uuid, Node> &nodes, std::string mode, int maxWalkingTravelTime, float walkingSpeedMetersPerSecond, bool reversed);
 
     static std::tuple<float, float> calculateLengthOfOneDegree(const Point &point);
     static float calculateMaxDistanceSquared(int maxWalkingTravelTime, float walkingSpeed);

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -81,8 +81,8 @@ namespace TrRouting
       std::vector<std::reference_wrapper<const Mode>> exceptModes;
       std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
       std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
-      std::vector<int> onlyNodesIdx;
-      std::vector<int> exceptNodesIdx;
+      std::vector<std::reference_wrapper<const Node>> onlyNodes;
+      std::vector<std::reference_wrapper<const Node>> exceptNodes;
       bool withAlternatives; // calculate alternatives or not
       bool forwardCalculation; // forward calculation: default true. if false: reverse calculation, will ride connections backward (useful when setting the arrival time)
 
@@ -135,8 +135,8 @@ namespace TrRouting
       const std::vector<std::reference_wrapper<const Mode>>& getExceptModes() { return exceptModes; }
       const std::vector<std::reference_wrapper<const Agency>>& getOnlyAgencies() { return onlyAgencies; }
       const std::vector<std::reference_wrapper<const Agency>>& getExceptAgencies() { return exceptAgencies; }
-      std::vector<int>* getOnlyNodesIdx() { return &onlyNodesIdx; }
-      std::vector<int>* getExceptNodesIdx() { return &exceptNodesIdx; }
+      const std::vector<std::reference_wrapper<const Node>>& getOnlyNodes() { return onlyNodes; }
+      const std::vector<std::reference_wrapper<const Node>>& getExceptNodes() { return exceptNodes; }
 
       // FIXME: Temporarily moved to public until calculation specific parameters exist. This is used directly by alternatives routing.
       // see https://github.com/chairemobilite/trRouting/issues/95
@@ -157,10 +157,11 @@ namespace TrRouting
       int routingDateDay;    // not implemented, use onlyServicesIdx or exceptServicesIdx for now
       //TODO Make it a reference or not??
       std::optional<DataSource> onlyDataSource;
-      std::vector<int> accessNodesIdx;
+      //TODO We could convert those to NodeTimeDistance object
+      std::vector<std::reference_wrapper<const Node>> accessNodesRef;
       std::vector<int> accessNodeTravelTimesSeconds;
       std::vector<int> accessNodeDistancesMeters;
-      std::vector<int> egressNodesIdx;
+      std::vector<std::reference_wrapper<const Node>> egressNodesRef;
       std::vector<int> egressNodeTravelTimesSeconds;
       std::vector<int> egressNodeDistancesMeters;
 
@@ -217,8 +218,7 @@ namespace TrRouting
         std::vector<std::unique_ptr<Scenario>> &scenarios,
         std::map<boost::uuids::uuid, int> &odTripIndexesByUuid,
         std::vector<std::unique_ptr<OdTrip>> &odTrips,
-        std::map<boost::uuids::uuid, int> &nodeIndexesByUuid,
-        std::vector<std::unique_ptr<Node>> &nodes,
+                             const std::map<boost::uuids::uuid,Node> &nodes,
                              const std::map<boost::uuids::uuid, DataSource> &dataSources);
 
   };

--- a/include/path.hpp
+++ b/include/path.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <boost/uuid/uuid.hpp>
+#include "node.hpp"
 
 namespace TrRouting
 {
@@ -16,7 +17,7 @@ namespace TrRouting
          const Line &aline,
          const std::string &adirection,
          const std::string &ainternalId,
-         const std::vector<int> &anodesIdx,
+         const std::vector<std::reference_wrapper<const Node>> &anodesRef,
          const std::vector<int> &atripsIdx,
          const std::vector<int> &asegmentsTravelTimeSeconds,
          const std::vector<int> &asegmentsDistanceMeters):
@@ -24,17 +25,40 @@ namespace TrRouting
       line(aline),
       direction(adirection),
       internalId(ainternalId),
-      nodesIdx(anodesIdx),
+      nodesRef(anodesRef),
       tripsIdx(atripsIdx),
       segmentsTravelTimeSeconds(asegmentsTravelTimeSeconds),
       segmentsDistanceMeters(asegmentsDistanceMeters) {}
-   
+
+    /* Alternative constructor where we pass a NodeTimeDistance vector instead of
+     separate vectors for nodes, segments time and distance. Easier to handle in some cases */
+    Path(const boost::uuids::uuid &auuid,
+         const Line &aline,
+         const std::string &adirection,
+         const std::string &ainternalId,
+         const std::vector<NodeTimeDistance> &anodesTimeDistance,
+         const std::vector<int> &atripsIdx):
+      uuid(auuid),
+      line(aline),
+      direction(adirection),
+      internalId(ainternalId),
+      tripsIdx(atripsIdx)
+      {
+        for (const NodeTimeDistance & ntd: anodesTimeDistance) {
+          nodesRef.push_back(ntd.node);
+          segmentsTravelTimeSeconds.push_back(ntd.time);
+          segmentsDistanceMeters.push_back(ntd.distance);
+        }
+      }
+
     boost::uuids::uuid uuid;
     const Line &line;
     std::string direction;
     std::string internalId;
-    std::vector<int> nodesIdx;
+    std::vector<std::reference_wrapper<const Node>> nodesRef;
     std::vector<int> tripsIdx;
+    //TODO Should probably be integrated with nodes as a NodeTimeDistance object. Need
+    // to validate their usage
     std::vector<int> segmentsTravelTimeSeconds;
     std::vector<int> segmentsDistanceMeters;
 

--- a/include/scenario.hpp
+++ b/include/scenario.hpp
@@ -22,11 +22,11 @@ namespace TrRouting
     std::vector<std::reference_wrapper<const Mode>> onlyModes;
     std::vector<std::reference_wrapper<const Line>> onlyLines;
     std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
-    std::vector<int> onlyNodesIdx;
+    std::vector<std::reference_wrapper<const Node>> onlyNodes;
     std::vector<std::reference_wrapper<const Mode>> exceptModes;
     std::vector<std::reference_wrapper<const Line>> exceptLines;
     std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
-    std::vector<int> exceptNodesIdx;
+    std::vector<std::reference_wrapper<const Node>> exceptNodes;
 
     const std::string toString() {
       return "Scenario " + boost::uuids::to_string(uuid) + "\n  name " + name;

--- a/src/od_trips_cache_fetcher.cpp
+++ b/src/od_trips_cache_fetcher.cpp
@@ -78,7 +78,7 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tIndexesByUuid,
     const std::map<boost::uuids::uuid, DataSource>& dataSources,
     const std::map<boost::uuids::uuid, int>& personIndexesByUuid,
-    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, Node>& nodes,
     std::string customPath
   )
   {
@@ -146,27 +146,23 @@ namespace TrRouting
             destination->longitude    = ((double)capnpT.getDestinationLongitude()) / 1000000.0;
 
             const unsigned int originNodesCount {capnpT.getOriginNodesUuids().size()};
-            std::vector<int> originNodesIdx(originNodesCount);
-            std::vector<int> originNodesTravelTimesSeconds(originNodesCount);
-            std::vector<int> originNodesDistancesMeters(originNodesCount);
+            std::vector<NodeTimeDistance> originNodes;
             for (int i = 0; i < originNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getOriginNodesUuids()[i]};
-              originNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
-              originNodesTravelTimesSeconds[i] = capnpT.getOriginNodesTravelTimes()[i];
-              originNodesDistancesMeters   [i] = capnpT.getOriginNodesDistances()[i];
+              originNodes.push_back(NodeTimeDistance(nodes.at(uuidGenerator(nodeUuid)),
+                                                     capnpT.getOriginNodesTravelTimes()[i],
+                                                     capnpT.getOriginNodesDistances()[i]));
             }
 
             const unsigned int destinationNodesCount {capnpT.getDestinationNodesUuids().size()};
-            std::vector<int> destinationNodesIdx(destinationNodesCount);
-            std::vector<int> destinationNodesTravelTimesSeconds(destinationNodesCount);
-            std::vector<int> destinationNodesDistancesMeters(destinationNodesCount);
+            std::vector<NodeTimeDistance> destinationNodes;
             for (int i = 0; i < destinationNodesCount; i++)
             {
               std::string nodeUuid {capnpT.getDestinationNodesUuids()[i]};
-              destinationNodesIdx               [i] = nodeIndexesByUuid.at(uuidGenerator(nodeUuid));
-              destinationNodesTravelTimesSeconds[i] = capnpT.getDestinationNodesTravelTimes()[i];
-              destinationNodesDistancesMeters   [i] = capnpT.getDestinationNodesDistances()[i];
+              destinationNodes.push_back(NodeTimeDistance(nodes.at(uuidGenerator(nodeUuid)),
+                                                          capnpT.getDestinationNodesTravelTimes()[i],
+                                                          capnpT.getDestinationNodesDistances()[i]));
             }
 
             // Create new odTrip
@@ -185,12 +181,8 @@ namespace TrRouting
                                                        getOdTripModeStr(capnpT.getMode()),
                                                        getOdTripActivityStr(capnpT.getOriginActivity()),
                                                        getOdTripActivityStr(capnpT.getDestinationActivity()),
-                                                       originNodesIdx,
-                                                       originNodesTravelTimesSeconds,
-                                                       originNodesDistancesMeters,
-                                                       destinationNodesIdx,
-                                                       destinationNodesTravelTimesSeconds,
-                                                       destinationNodesDistancesMeters,
+                                                       originNodes,
+                                                       destinationNodes,
                                                        std::move(origin),
                                                        std::move(destination)
                                                        );

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -21,7 +21,7 @@ namespace TrRouting
   int CacheFetcher::getPaths(
     std::map<boost::uuids::uuid, Path>& ts,
     const std::map<boost::uuids::uuid, Line>& lines,
-    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, Node>& nodes,
     std::string customPath
   )
   {
@@ -65,7 +65,7 @@ namespace TrRouting
       {
         std::string uuid     {capnpT.getUuid()};
         std::string lineUuid {capnpT.getLineUuid()};
-        std::vector<int> nodesIdx;
+        std::vector<std::reference_wrapper<const Node>> nodesRef;
         std::vector<int> tripsIdx;
         std::vector<int> distancesMeters;
         std::vector<int> travelTimesSeconds;
@@ -74,12 +74,12 @@ namespace TrRouting
         for (std::string nodeUuidStr : capnpT.getNodesUuids())
         {
           nodeUuid = uuidGenerator(nodeUuidStr);
-          nodesIdx.push_back(nodeIndexesByUuid.at(nodeUuid));
+          nodesRef.push_back(nodes.at(nodeUuid));
         }
 
         auto jsonData = nlohmann::json::parse(capnpT.getData());
 
-        for (int i=0; i < nodesIdx.size(); i++)
+        for (int i=0; i < nodesRef.size(); i++)
         {
           if (jsonData["segments"][i]["distanceMeters"] != nullptr)
           {
@@ -95,7 +95,7 @@ namespace TrRouting
                                lines.at(uuidGenerator(lineUuid)),
                                capnpT.getDirection(),
                                capnpT.getInternalId(),
-                               nodesIdx,
+                               nodesRef,
                                tripsIdx, //TODO This is empty
                                travelTimesSeconds,
                                distancesMeters));

--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -24,7 +24,7 @@ namespace TrRouting
     const std::map<boost::uuids::uuid, Service>& services,
     const std::map<boost::uuids::uuid, Line>& lines,
     const std::map<boost::uuids::uuid, Agency>& agencies,
-    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
+    const std::map<boost::uuids::uuid, Node>& nodes,
     const std::map<std::string, Mode>& modes,
     std::string customPath
   ) {
@@ -75,11 +75,11 @@ namespace TrRouting
         std::vector<std::reference_wrapper<const Service>> servicesList;
         std::vector<std::reference_wrapper<const Line>> onlyLines;
         std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
-        std::vector<int> onlyNodesIdx;
+        std::vector<std::reference_wrapper<const Node>> onlyNodes;
         std::vector<std::reference_wrapper<const Mode>> onlyModes;
         std::vector<std::reference_wrapper<const Line>> exceptLines;
         std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
-        std::vector<int> exceptNodesIdx;
+        std::vector<std::reference_wrapper<const Node>> exceptNodes;
         std::vector<std::reference_wrapper<const Mode>> exceptModes;
         boost::uuids::uuid serviceUuid;
         boost::uuids::uuid agencyUuid;
@@ -121,12 +121,12 @@ namespace TrRouting
         for (std::string nodeUuidStr : capnpT.getOnlyNodesUuids())
         {
           nodeUuid = uuidGenerator(nodeUuidStr);
-          if (nodeIndexesByUuid.count(nodeUuid) != 0)
+          if (nodes.count(nodeUuid) != 0)
           {
-            onlyNodesIdx.push_back(nodeIndexesByUuid.at(nodeUuid));
+            onlyNodes.push_back(nodes.at(nodeUuid));
           }
         }
-        t->onlyNodesIdx = onlyNodesIdx;
+        t->onlyNodes = onlyNodes;
         for (std::string modeShortnameStr : capnpT.getOnlyModesShortnames())
         {
           if (modes.count(modeShortnameStr) != 0)
@@ -157,12 +157,12 @@ namespace TrRouting
         for (std::string nodeUuidStr : capnpT.getExceptNodesUuids())
         {
           nodeUuid = uuidGenerator(nodeUuidStr);
-          if (nodeIndexesByUuid.count(nodeUuid) != 0)
+          if (nodes.count(nodeUuid) != 0)
           {
-            exceptNodesIdx.push_back(nodeIndexesByUuid.at(nodeUuid));
+            exceptNodes.push_back(nodes.at(nodeUuid));
           }
         }
-        t->exceptNodesIdx = exceptNodesIdx;
+        t->exceptNodes = exceptNodes;
         for (std::string modeShortnameStr : capnpT.getExceptModesShortnames())
         {
           if (modes.count(modeShortnameStr) != 0)

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -20,16 +20,12 @@
 
 namespace TrRouting
 {
-  // FIXME ConnectionTuple is defined in calculator.hpp. Should it be elsewhere? Cache fetcher should work for any algorithm, is this tuple csa-specific or should it go somewhere common.
-  using ConnectionTuple = std::tuple<int,int,int,int,int,short,short,int,short,short>;
-  
   int CacheFetcher::getSchedules(
     std::vector<std::unique_ptr<Trip>>& trips,
     const std::map<boost::uuids::uuid, Line>& lines,
     std::map<boost::uuids::uuid, Path>& paths,
     std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
     const std::map<boost::uuids::uuid, Service>& services,
-    const std::map<boost::uuids::uuid, int>& nodeIndexesByUuid,
     std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
     std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
     std::vector<std::shared_ptr<ConnectionTuple>>& connections,
@@ -117,14 +113,12 @@ namespace TrRouting
               std::vector<std::unique_ptr<int>>   connectionDepartureTimes = std::vector<std::unique_ptr<int>>(nodeTimesCount);
               std::vector<std::unique_ptr<float>> connectionDemands        = std::vector<std::unique_ptr<float>>(nodeTimesCount);
 
-              for (int nodeTimeI = 0; nodeTimeI < nodeTimesCount; nodeTimeI++)
+              // nodeTimesCount - 1, since we process node pairs, we have to stop and the second from last
+              for (int nodeTimeI = 0; nodeTimeI < nodeTimesCount - 1; nodeTimeI++)
               {
-                if (nodeTimeI < nodeTimesCount - 1)
-                {
-
                   std::shared_ptr<ConnectionTuple> forwardConnection(std::make_shared<ConnectionTuple>(ConnectionTuple(
-                    path.nodesIdx[nodeTimeI],
-                    path.nodesIdx[nodeTimeI + 1],
+                    path.nodesRef[nodeTimeI],
+                    path.nodesRef[nodeTimeI + 1],
                     departureTimesSeconds[nodeTimeI],
                     arrivalTimesSeconds[nodeTimeI + 1],
                     tripIdx,
@@ -140,7 +134,6 @@ namespace TrRouting
                   connectionDepartureTimes[nodeTimeI] = std::make_unique<int>(departureTimesSeconds[nodeTimeI]);
                   connectionDemands[nodeTimeI]        = std::make_unique<float>(0.0);
 
-                }
               }
               trips.push_back(std::move(trip));
 

--- a/tests/benchmark_csa/benchmark_CSA_test.cpp
+++ b/tests/benchmark_csa/benchmark_CSA_test.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/string_generator.hpp>
+#include "spdlog/spdlog.h"
 
 #include "calculator.hpp"
 #include "cache_fetcher.hpp"
@@ -114,6 +115,7 @@ public:
     double results[nbIter];
     for (int i = 0; i < nbIter; i++)
     {
+      spdlog::info("Benchmark iteration {} of {} ...", i, nbIter);
 
       auto start = std::chrono::high_resolution_clock::now();
 

--- a/tests/cache_fetch/nodes_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/nodes_cache_fetcher_test.cpp
@@ -13,8 +13,7 @@ namespace fs = std::filesystem;
 class NodeCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
-    std::vector<std::unique_ptr<TrRouting::Node>>     nodes;
-    std::map<boost::uuids::uuid, int>        nodeIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Node>     nodes;
 
 public:
     void SetUp( ) override
@@ -37,7 +36,7 @@ public:
 
 TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesInvalidNodesFile)
 {
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, nodes.size());
 }
@@ -46,7 +45,7 @@ TEST_F(NodeCacheFetcherFixtureTests, TestGetUnexistingSingleNodeFile)
 {
     // Copy the file from the valid nodes, but have nodes be unexisting
     fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + VALID_CUSTOM_PATH + "/nodes.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes.capnpbin", fs::copy_options::overwrite_existing);
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, INVALID_CUSTOM_PATH);
     // TODO: Is this right?
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(11, nodes.size());
@@ -61,20 +60,20 @@ TEST_F(NodeCacheFetcherFixtureTests, TestGetSingleInvalidNodeFile)
         // Copy the invalid file for each node name
         fs::copy_file(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/genericInvalid.capnpbin", BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/nodes/" + p.path().filename().c_str());
     }
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
 }
 
 TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesValid)
 {
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(11, nodes.size());
 }
 
 TEST_F(NodeCacheFetcherFixtureTests, TestGetNodesFileNotExists)
 {
-    int retVal = cacheFetcher.getNodes(nodes, nodeIndexesByUuid, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getNodes(nodes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, nodes.size());
 }

--- a/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
@@ -15,12 +15,12 @@ protected:
     std::map<boost::uuids::uuid, int> objectIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::DataSource> dataSources;
     std::map<boost::uuids::uuid, int> personIndexesByUuid;
-    std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Node> nodes;
 };
 
 TEST_F(OdTripCacheFetcherFixtureTests, TestGetOdTripsValid)
 {
-    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSources, personIndexesByUuid, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSources, personIndexesByUuid, nodes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/paths_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/paths_cache_fetcher_test.cpp
@@ -14,7 +14,7 @@ class PathCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 protected:
     std::map<boost::uuids::uuid, TrRouting::Path> objects;
     std::map<boost::uuids::uuid, TrRouting::Line> lines;
-    std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Node> nodes;
 
 public:
     void SetUp( ) override
@@ -30,8 +30,7 @@ public:
         auto modes = cacheFetcher.getModes();
         cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
 
-        std::vector<std::unique_ptr<TrRouting::Node>> nodes;
-        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getNodes(nodes, VALID_CUSTOM_PATH);
     }
 
     void TearDown( ) override
@@ -44,7 +43,7 @@ public:
 
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsInvalid)
 {
-    int retVal = cacheFetcher.getPaths(objects, lines, nodeIndexesByUuid, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, lines, nodes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -52,14 +51,14 @@ TEST_F(PathCacheFetcherFixtureTests, TestGetPathsInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsValid)
 {
-    int retVal = cacheFetcher.getPaths(objects, lines, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, lines, nodes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(4, objects.size());
 }
 
 TEST_F(PathCacheFetcherFixtureTests, TestGetPathsFileNotExists)
 {
-    int retVal = cacheFetcher.getPaths(objects, lines, nodeIndexesByUuid, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getPaths(objects, lines, nodes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/scenarios_cache_fetcher_test.cpp
@@ -17,7 +17,7 @@ protected:
     std::map<boost::uuids::uuid, TrRouting::Service> services;
     std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::map<boost::uuids::uuid, TrRouting::Agency> agencies;
-    std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::Node> nodes;
     std::map<std::string, TrRouting::Mode> modes;
 
 public:
@@ -33,8 +33,7 @@ public:
         modes = cacheFetcher.getModes();
         cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
 
-        std::vector<std::unique_ptr<TrRouting::Node>> nodes;
-        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getNodes(nodes, VALID_CUSTOM_PATH);
 
         cacheFetcher.getServices(services, VALID_CUSTOM_PATH);
 
@@ -50,7 +49,7 @@ public:
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, modes, INVALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodes, modes, INVALID_CUSTOM_PATH);
     ASSERT_EQ(-EBADMSG, retVal);
     ASSERT_EQ(0, objects.size());
 }
@@ -58,14 +57,14 @@ TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosInvalid)
 // TODO Add tests for various services, lines, agencies that don't exist. But first, we should be able to create cache files with mock test data
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosValid)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, modes, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodes, modes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(2, objects.size());
 }
 
 TEST_F(ScenarioCacheFetcherFixtureTests, TestGetScenariosFileNotExists)
 {
-    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodeIndexesByUuid, modes, BASE_CUSTOM_PATH);
+    int retVal = cacheFetcher.getScenarios(objects, objectIndexesByUuid, services, lines, agencies, nodes, modes, BASE_CUSTOM_PATH);
     ASSERT_EQ(-ENOENT, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -17,13 +17,12 @@ protected:
     std::vector<std::unique_ptr<TrRouting::Trip>> trips;
     std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::map<boost::uuids::uuid, TrRouting::Path> paths;
-    std::vector<std::unique_ptr<TrRouting::Node>> nodes;
+    std::map<boost::uuids::uuid, TrRouting::Node> nodes;
     std::map<boost::uuids::uuid, int> tripIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
-    std::map<boost::uuids::uuid, int> nodeIndexesByUuid;
     std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
     std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;
-    std::vector<std::shared_ptr<std::tuple<int,int,int,int,int,short,short,int,short,short>>> connections;
+    std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> connections;
 
 public:
     void SetUp( ) override
@@ -35,9 +34,9 @@ public:
         auto modes = cacheFetcher.getModes();
         cacheFetcher.getServices(services, VALID_CUSTOM_PATH);
 
-        cacheFetcher.getNodes(nodes, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getNodes(nodes, VALID_CUSTOM_PATH);
         cacheFetcher.getLines(lines, agencies, modes, VALID_CUSTOM_PATH);
-        cacheFetcher.getPaths(paths, lines, nodeIndexesByUuid, VALID_CUSTOM_PATH);
+        cacheFetcher.getPaths(paths, lines, nodes, VALID_CUSTOM_PATH);
         // Create the invalid lines directory
         fs::create_directory(BASE_CACHE_DIRECTORY_NAME + "/" + INVALID_CUSTOM_PATH + "/lines");
     }
@@ -61,7 +60,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       paths,
       tripIndexesByUuid,
       services,
-      nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
@@ -80,7 +78,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       paths,
       tripIndexesByUuid,
       services,
-      nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,
@@ -98,7 +95,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       paths,
       tripIndexesByUuid,
       services,
-      nodeIndexesByUuid,
       tripConnectionDepartureTimes,
       tripConnectionDemands,
       connections,

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -62,122 +62,128 @@ void BaseCsaFixtureTests::SetUp() {
     calculator.initializeCalculationData();
 }
 
-void addTransferableNode(TrRouting::Node* node, int index, int distance, int time)
+void addSelfTransferableNode(TrRouting::Node& node) {
+
+  node.transferableNodes.push_back(TrRouting::NodeTimeDistance(node, 0, 0));
+  node.reverseTransferableNodes.push_back(TrRouting::NodeTimeDistance(node, 0, 0));
+
+}
+
+void addTransferableNode(TrRouting::Node& node, const TrRouting::NodeTimeDistance &ntd)
 {
-    node->transferableNodesIdx.push_back(index);
-    node->transferableDistancesMeters.push_back(distance);
-    node->transferableTravelTimesSeconds.push_back(time);
-    node->reverseTransferableNodesIdx.push_back(index);
-    node->reverseTransferableDistancesMeters.push_back(distance);
-    node->reverseTransferableTravelTimesSeconds.push_back(time);
+    node.transferableNodes.push_back(ntd);
+
+    //TODO is this right? Shouldn't we add node to the one in ntd?
+    node.reverseTransferableNodes.push_back(ntd);
 }
 
 void BaseCsaFixtureTests::setUpNodes()
 {
-    std::vector<std::unique_ptr<TrRouting::Node>>& array = calculator.nodes;
-    std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.nodeIndexesByUuid;
+    std::map<boost::uuids::uuid,TrRouting::Node>& array = calculator.nodes;
 
     // Create all 9 points, from south to north, then east to west. Each node MUST be transferable with itself
     // South2 has no transferable node
-    std::unique_ptr<TrRouting::Node> south2 = std::make_unique<TrRouting::Node>();
-    south2->uuid = nodeSouth2Uuid;
-    south2->name = "South2";
-    south2->point = std::make_unique<TrRouting::Point>(45.5269,-73.58912);
-    addTransferableNode(south2.get(), array.size(), 0, 0);
-    arrayIndexesByUuid[south2->uuid] = array.size();
-    array.push_back(std::move(south2));
+    array.emplace(nodeSouth2Uuid, TrRouting::Node(nodeSouth2Uuid,
+                                                  0,
+                                                  "",
+                                                  "South2",
+                                                  "",
+                                                  std::make_unique<TrRouting::Point>(45.5269,-73.58912)));
+    addSelfTransferableNode(array.at(nodeSouth2Uuid));
 
     // South1 has no transferable node
-    std::unique_ptr<TrRouting::Node> south1 = std::make_unique<TrRouting::Node>();
-    south1->uuid = nodeSouth1Uuid;
-    south1->name = "South1";
-    south1->point = std::make_unique<TrRouting::Point>(45.53258,-73.60196);
-    addTransferableNode(south1.get(), array.size(), 0, 0);
-    arrayIndexesByUuid[south1->uuid] = array.size();
-    array.push_back(std::move(south1));
+    array.emplace(nodeSouth1Uuid, TrRouting::Node(nodeSouth1Uuid,
+                                                  0,
+                                                  "",
+                                                  "South1",
+                                                  "",
+                                                  std::make_unique<TrRouting::Point>(45.53258,-73.60196)));
+    addSelfTransferableNode(array.at(nodeSouth1Uuid));
 
     // midNode is transferable with west1, east1 and north1
-    std::unique_ptr<TrRouting::Node> midNode = std::make_unique<TrRouting::Node>();
-    midNode->uuid = nodeMidNodeUuid;
-    midNode->name = "MidPoint";
-    midNode->point = std::make_unique<TrRouting::Point>(45.53827,-73.614436);
-    addTransferableNode(midNode.get(), array.size(), 0, 0);
-    addTransferableNode(midNode.get(), 7, 522, 558);
-    addTransferableNode(midNode.get(), 6, 532, 480);
-    addTransferableNode(midNode.get(), 3, 983, 801);
-    arrayIndexesByUuid[midNode->uuid] = array.size();
-    array.push_back(std::move(midNode));
+    array.emplace(nodeMidNodeUuid, TrRouting::Node(nodeMidNodeUuid,
+                                                   0,
+                                                   "",
+                                                   "MidPoint",
+                                                   "",
+                                                   std::make_unique<TrRouting::Point>(45.53827,-73.614436)));
+    addSelfTransferableNode(array.at(nodeMidNodeUuid));
 
     // transferable with midNode
-    std::unique_ptr<TrRouting::Node> north1 = std::make_unique<TrRouting::Node>();
-    north1->uuid = nodeNorth1Uuid;
-    north1->name = "North1";
-    north1->point = std::make_unique<TrRouting::Point>(45.54165,-73.62603);
-    addTransferableNode(north1.get(), array.size(), 0, 0);
-    addTransferableNode(north1.get(), 2, 983, 801);
-    arrayIndexesByUuid[north1->uuid] = array.size();
-    array.push_back(std::move(north1));
+    array.emplace(nodeNorth1Uuid, TrRouting::Node(nodeNorth1Uuid,
+                                                  0,
+                                                  "",
+                                                  "North1",
+                                                  "",
+                                                  std::make_unique<TrRouting::Point>(45.54165,-73.62603)));
+    addSelfTransferableNode(array.at(nodeNorth1Uuid));
 
     // No transferable node
-    std::unique_ptr<TrRouting::Node> north2 = std::make_unique<TrRouting::Node>();
-    north2->uuid = nodeNorth2Uuid;
-    north2->name = "North2";
-    north2->point = std::make_unique<TrRouting::Point>(45.54634,-73.64266);
-    addTransferableNode(north2.get(), array.size(), 0, 0);
-    arrayIndexesByUuid[north2->uuid] = array.size();
-    array.push_back(std::move(north2));
+    array.emplace(nodeNorth2Uuid, TrRouting::Node(nodeNorth2Uuid,
+                                                  0,
+                                                  "",
+                                                  "North1",
+                                                  "",
+                                                  std::make_unique<TrRouting::Point>(45.54634,-73.64266)));
+    addSelfTransferableNode(array.at(nodeNorth2Uuid));
 
     // Transferable with east1
-    std::unique_ptr<TrRouting::Node> east2 = std::make_unique<TrRouting::Node>();
-    east2->uuid = nodeEast2Uuid;
-    east2->name = "East2";
-    east2->point = std::make_unique<TrRouting::Point>(45.55027,-73.60496);
-    addTransferableNode(east2.get(), array.size(), 0, 0);
-    addTransferableNode(east2.get(), 6, 1030, 857);
-    arrayIndexesByUuid[east2->uuid] = array.size();
-    array.push_back(std::move(east2));
+    array.emplace(nodeEast2Uuid, TrRouting::Node(nodeEast2Uuid,
+                                                 0,
+                                                 "",
+                                                 "East2",
+                                                 "",
+                                                 std::make_unique<TrRouting::Point>(45.55027,-73.60496)));
+    addSelfTransferableNode(array.at(nodeEast2Uuid));
 
     // Transferable with east2 and midNode
-    std::unique_ptr<TrRouting::Node> east1 = std::make_unique<TrRouting::Node>();
-    east1->uuid = nodeEast1Uuid;
-    east1->name = "East1";
-    east1->point = std::make_unique<TrRouting::Point>(45.54249,-73.61199);
-    addTransferableNode(east1.get(), array.size(), 0, 0);
-    addTransferableNode(east1.get(), 2, 532, 480);
-    addTransferableNode(east1.get(), 5, 1030, 857);
-    arrayIndexesByUuid[east1->uuid] = array.size();
-    array.push_back(std::move(east1));
-
+    array.emplace(nodeEast1Uuid, TrRouting::Node(nodeEast1Uuid,
+                                                 0,
+                                                 "",
+                                                 "East1",
+                                                 "",
+                                                 std::make_unique<TrRouting::Point>(45.54249,-73.61199)));
+    addSelfTransferableNode(array.at(nodeEast1Uuid));
+        
     // Transferable with midNode and west2
-    std::unique_ptr<TrRouting::Node> west1 = std::make_unique<TrRouting::Node>();
-    west1->uuid = nodeWest1Uuid;
-    west1->name = "West1";
-    west1->point = std::make_unique<TrRouting::Point>(45.53473,-73.61825);
-    addTransferableNode(west1.get(), array.size(), 0, 0);
-    addTransferableNode(west1.get(), 2, 522, 558);
-    addTransferableNode(west1.get(), 8, 824, 655);
-    arrayIndexesByUuid[west1->uuid] = array.size();
-    array.push_back(std::move(west1));
+    array.emplace(nodeWest1Uuid, TrRouting::Node(nodeWest1Uuid,
+                                                 0,
+                                                 "",
+                                                 "West1",
+                                                 "",
+                                                 std::make_unique<TrRouting::Point>(45.53473,-73.61825)));
+    addSelfTransferableNode(array.at(nodeWest1Uuid));
 
     // Transferable with west1
-    std::unique_ptr<TrRouting::Node> west2 = std::make_unique<TrRouting::Node>();
-    west2->uuid = nodeWest2Uuid;
-    west2->name = "West2";
-    west2->point = std::make_unique<TrRouting::Point>(45.52962,-73.62265);
-    addTransferableNode(west2.get(), array.size(), 0, 0);
-    addTransferableNode(west2.get(), 7, 824, 655);
-    arrayIndexesByUuid[west2->uuid] = array.size();
-    array.push_back(std::move(west2));
+    array.emplace(nodeWest2Uuid, TrRouting::Node(nodeWest2Uuid,
+                                                 0,
+                                                 "",
+                                                 "West2",
+                                                 "",
+                                                 std::make_unique<TrRouting::Point>(45.52962,-73.62265)));
+    addSelfTransferableNode(array.at(nodeWest2Uuid));
 
+    
     // Extra1 has no transferable node
-    std::unique_ptr<TrRouting::Node> extra1 = std::make_unique<TrRouting::Node>();
-    extra1->uuid = nodeExtra1Uuid;
-    extra1->name = "Extra1";
-    extra1->point = std::make_unique<TrRouting::Point>(45.55316,-73.61894);
-    addTransferableNode(extra1.get(), array.size(), 0, 0);
-    arrayIndexesByUuid[extra1->uuid] = array.size();
-    array.push_back(std::move(extra1));
+    array.emplace(nodeExtra1Uuid, TrRouting::Node(nodeExtra1Uuid,
+                                                 0,
+                                                 "",
+                                                 "Extra1",
+                                                 "",
+                                                 std::make_unique<TrRouting::Point>(45.55316,-73.61894)));
+    addSelfTransferableNode(array.at(nodeExtra1Uuid));
 
+    // Add all transferable nodes
+    addTransferableNode(array.at(nodeWest1Uuid), TrRouting::NodeTimeDistance(array.at(nodeWest2Uuid), 655,824));
+    addTransferableNode(array.at(nodeWest2Uuid), TrRouting::NodeTimeDistance(array.at(nodeWest1Uuid), 665,824));
+    addTransferableNode(array.at(nodeWest1Uuid), TrRouting::NodeTimeDistance(array.at(nodeMidNodeUuid), 558, 522));
+    addTransferableNode(array.at(nodeEast1Uuid), TrRouting::NodeTimeDistance(array.at(nodeMidNodeUuid), 480, 532));
+    addTransferableNode(array.at(nodeEast1Uuid), TrRouting::NodeTimeDistance(array.at(nodeEast2Uuid), 857, 1030));
+    addTransferableNode(array.at(nodeEast2Uuid), TrRouting::NodeTimeDistance(array.at(nodeEast1Uuid), 857, 1030));
+    addTransferableNode(array.at(nodeNorth1Uuid), TrRouting::NodeTimeDistance(array.at(nodeMidNodeUuid), 801, 983));
+    addTransferableNode(array.at(nodeMidNodeUuid), TrRouting::NodeTimeDistance(array.at(nodeNorth1Uuid), 801, 983));
+    addTransferableNode(array.at(nodeMidNodeUuid), TrRouting::NodeTimeDistance(array.at(nodeWest1Uuid), 558, 522));
+    addTransferableNode(array.at(nodeMidNodeUuid), TrRouting::NodeTimeDistance(array.at(nodeEast1Uuid), 480, 532));
 }
 
 void BaseCsaFixtureTests::setUpAgencies()
@@ -224,60 +230,51 @@ void BaseCsaFixtureTests::setUpScenarios()
     array.push_back(std::move(scenario));
 }
 
-void addNodeToPath(TrRouting::Path& path, int nodeIdx, int timeTraveled, int distance) {
-    path.nodesIdx.push_back(nodeIdx);
-    if (distance > 0) {
-        path.segmentsDistanceMeters.push_back(distance);
-    }
-    if (timeTraveled > 0) {
-        path.segmentsTravelTimeSeconds.push_back(timeTraveled);
-    }
+void addNodeToPath(std::vector<TrRouting::NodeTimeDistance>& nodesref, const TrRouting::Node &node, int timeTraveled, int distance) {
+  nodesref.push_back(TrRouting::NodeTimeDistance(node,timeTraveled, distance));
 }
 
 void BaseCsaFixtureTests::setUpPaths()
 {
 
     std::vector<int> emptyVector;
+    std::vector<TrRouting::NodeTimeDistance> nodesref;
+    addNodeToPath(nodesref, calculator.nodes.at(nodeSouth2Uuid), 210, 1186);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeSouth1Uuid), 190, 1160);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeMidNodeUuid), 180, 980);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeNorth1Uuid), 270, 1544);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeNorth2Uuid), -1, -1);
     calculator.paths.emplace(pathSNUuid, TrRouting::Path(pathSNUuid,
                                                          calculator.lines.at(lineSNUuid),
                                                          "outbound",
                                                          "",
-                                                         emptyVector,
-                                                         emptyVector,
-                                                         emptyVector,
+                                                         nodesref,
                                                          emptyVector));
-    addNodeToPath(calculator.paths.at(pathSNUuid), calculator.nodeIndexesByUuid[nodeSouth2Uuid], 210, 1186);
-    addNodeToPath(calculator.paths.at(pathSNUuid), calculator.nodeIndexesByUuid[nodeSouth1Uuid], 190, 1160);
-    addNodeToPath(calculator.paths.at(pathSNUuid), calculator.nodeIndexesByUuid[nodeMidNodeUuid], 180, 980);
-    addNodeToPath(calculator.paths.at(pathSNUuid), calculator.nodeIndexesByUuid[nodeNorth1Uuid], 270, 1544);
-    addNodeToPath(calculator.paths.at(pathSNUuid), calculator.nodeIndexesByUuid[nodeNorth2Uuid], -1, -1);
     // Path's trip data will be filled in the setUpSchedules
-
+    
+    nodesref.clear();
+    addNodeToPath(nodesref, calculator.nodes.at(nodeEast2Uuid), 150, 1025);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeEast1Uuid), 110, 510);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeMidNodeUuid), 150, 498);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeWest1Uuid), 120, 668);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeWest2Uuid), -1, -1);
     calculator.paths.emplace(pathEWUuid, TrRouting::Path(pathEWUuid,
                                                          calculator.lines.at(lineEWUuid),
                                                          "outbound",
                                                          "",
-                                                         emptyVector,
-                                                         emptyVector,
-                                                         emptyVector,
+                                                         nodesref,
                                                          emptyVector));
-    addNodeToPath(calculator.paths.at(pathEWUuid), calculator.nodeIndexesByUuid[nodeEast2Uuid], 150, 1025);
-    addNodeToPath(calculator.paths.at(pathEWUuid), calculator.nodeIndexesByUuid[nodeEast1Uuid], 110, 510);
-    addNodeToPath(calculator.paths.at(pathEWUuid), calculator.nodeIndexesByUuid[nodeMidNodeUuid], 150, 498);
-    addNodeToPath(calculator.paths.at(pathEWUuid), calculator.nodeIndexesByUuid[nodeWest1Uuid], 120, 668);
-    addNodeToPath(calculator.paths.at(pathEWUuid), calculator.nodeIndexesByUuid[nodeWest2Uuid], -1, -1);
     // Path's trip data will be filled in the setUpSchedules
 
+    nodesref.clear();
+    addNodeToPath(nodesref, calculator.nodes.at(nodeEast1Uuid), 300, 1760);
+    addNodeToPath(nodesref, calculator.nodes.at(nodeExtra1Uuid), -1, -1);
     calculator.paths.emplace(pathExtraUuid, TrRouting::Path(pathExtraUuid,
                                                             calculator.lines.at(lineExtraUuid),
                                                             "outbound",
                                                             "",
-                                                            emptyVector,
-                                                            emptyVector,
-                                                            emptyVector,
+                                                            nodesref,
                                                             emptyVector));
-    addNodeToPath(calculator.paths.at(pathExtraUuid), calculator.nodeIndexesByUuid[nodeEast1Uuid], 300, 1760);
-    addNodeToPath(calculator.paths.at(pathExtraUuid), calculator.nodeIndexesByUuid[nodeExtra1Uuid], -1, -1);
     // Path's trip data will be filled in the setUpSchedules
 
 }
@@ -291,8 +288,8 @@ void addTripData(TrRouting::Calculator& calculator, TrRouting::Trip *trip, TrRou
 
     for (int nodeTimeI = 0; nodeTimeI < arraySize - 1; nodeTimeI++) {
         std::shared_ptr<TrRouting::ConnectionTuple> forwardConnection(std::make_shared<TrRouting::ConnectionTuple>(TrRouting::ConnectionTuple(
-            path.nodesIdx[nodeTimeI],
-            path.nodesIdx[nodeTimeI + 1],
+            path.nodesRef[nodeTimeI],
+            path.nodesRef[nodeTimeI + 1],
             departureTimes[nodeTimeI],
             arrivalTimes[nodeTimeI + 1],
             tripIdx,

--- a/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
@@ -59,18 +59,10 @@ void RouteOdTripsFixtureTests::setupOdTrips() {
     std::vector<std::unique_ptr<TrRouting::OdTrip>>& array = calculator.odTrips;
     std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.odTripIndexesByUuid;
 
-    std::vector<int> originNodesIdx;
-    originNodesIdx.push_back(calculator.nodeIndexesByUuid[nodeSouth2Uuid]);
-    std::vector<int> originNodesTravelTimesSeconds;
-    originNodesTravelTimesSeconds.push_back(469);
-    std::vector<int> originNodesDistancesMeters;
-    originNodesDistancesMeters.push_back(500);        
-    std::vector<int> destinationNodesIdx;
-    destinationNodesIdx.push_back(calculator.nodeIndexesByUuid[nodeMidNodeUuid]);
-    std::vector<int> destinationNodesTravelTimesSeconds;
-    destinationNodesTravelTimesSeconds.push_back(138);
-    std::vector<int> destinationNodesDistancesMeters;
-    destinationNodesDistancesMeters.push_back(150);
+    std::vector<TrRouting::NodeTimeDistance> originNodes;
+    originNodes.push_back(TrRouting::NodeTimeDistance(calculator.nodes.at(nodeSouth2Uuid), 469, 500));
+    std::vector<TrRouting::NodeTimeDistance> destinationNodes;
+    destinationNodes.push_back(TrRouting::NodeTimeDistance(calculator.nodes.at(nodeMidNodeUuid), 138, 150));
 
     std::unique_ptr<TrRouting::OdTrip> odTrip = std::make_unique<TrRouting::OdTrip>(odTripUuid,
                                                                                     12345,
@@ -86,12 +78,8 @@ void RouteOdTripsFixtureTests::setupOdTrips() {
                                                                                     "",
                                                                                     "",
                                                                                     "",
-                                                                                    originNodesIdx,
-                                                                                    originNodesTravelTimesSeconds,
-                                                                                    originNodesDistancesMeters,
-                                                                                    destinationNodesIdx,
-                                                                                    destinationNodesTravelTimesSeconds,
-                                                                                    destinationNodesDistancesMeters,
+                                                                                    originNodes,
+                                                                                    destinationNodes,
                                                                                     std::make_unique<TrRouting::Point>(45.5242, -73.5817),
                                                                                     std::make_unique<TrRouting::Point>(45.54, -73.6146));
     arrayIndexesByUuid[odTrip->uuid] = array.size();
@@ -131,7 +119,6 @@ nlohmann::json RouteOdTripsFixtureTests::calculateOdTrips(std::vector<std::strin
         calculator.scenarios,
         calculator.odTripIndexesByUuid,
         calculator.odTrips,
-        calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSources);
     TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -360,6 +360,8 @@ TEST_F(RouteCalculationFixtureTests, NoRoutingTravelTimeLongerTrip)
         FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
     } catch (TrRouting::NoRoutingFoundException const & e) {
         assertNoRouting(e, TrRouting::NoRoutingReason::NO_ROUTING_FOUND);
+    } catch(const  std::exception &e) {
+      FAIL() << "Expected TrRouting::NoRoutingFoundException, std::exception was thrown " << e.what();
     } catch(...) {
         FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
     }
@@ -381,7 +383,6 @@ std::unique_ptr<TrRouting::RoutingResult> RouteCalculationFixtureTests::calculat
         calculator.scenarios,
         calculator.odTripIndexesByUuid,
         calculator.odTrips,
-        calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSources);
     TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -189,7 +189,6 @@ TrRouting::AlternativesResult TAndACalculationFixtureTests::calculateWithAlterna
         calculator.scenarios,
         calculator.odTripIndexesByUuid,
         calculator.odTrips,
-        calculator.nodeIndexesByUuid,
         calculator.nodes,
         calculator.dataSources);
     TrRouting::OsrmFetcher::birdDistanceAccessibilityEnabled = true;


### PR DESCRIPTION
Currently benchmarks are about 2x slower than before. Main time is spent doing the looking into the map<uuid:int> for some query specificy computation. It was speed up significantly by using unordered_map instead of map for those. We also added a "local" only "int" id to replace the uuid lookup. (Maybe we won't need this extra id with further optimisations.)

There's probably more optimisations to be done, but I think we can wait until we restructure the code to be able to run multiple queries in parallel.