### PR TITLE
Migrate Odtrip vector and index map to a single UUID:OdTrip map

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -146,8 +146,8 @@ namespace TrRouting
     std::map<boost::uuids::uuid, Person>     persons;
     const std::map<boost::uuids::uuid, Person> & getPersons() {return persons;}
 
-    std::vector<std::unique_ptr<OdTrip>>     odTrips;
-    std::map<boost::uuids::uuid, int>        odTripIndexesByUuid;
+    std::map<boost::uuids::uuid, OdTrip>     odTrips;
+    const std::map<boost::uuids::uuid, OdTrip> & getOdTrips() {return odTrips;}
 
     std::map<boost::uuids::uuid, Agency>     agencies;
     const std::map<boost::uuids::uuid, Agency> & getAgencies() {return agencies;}
@@ -179,7 +179,8 @@ namespace TrRouting
     CalculationTime algorithmCalculationTime;
     DataFetcher &dataFetcher;
 
-    OdTrip * odTrip;
+    // TODO Added Glob suffix to easily track which one was local and which was global
+    std::optional<std::reference_wrapper<const OdTrip>> odTripGlob;
 
   private:
 

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -22,7 +22,7 @@ namespace TrRouting
 
   Calculator::Calculator(DataFetcher& fetcher) :
     dataFetcher(fetcher),
-    odTrip(nullptr),
+    odTripGlob(std::nullopt),
     algorithmCalculationTime(CalculationTime()),
     departureTimeSeconds(0),
     initialDepartureTimeSeconds(0),

--- a/connection_scan_algorithm/src/parameters.cpp
+++ b/connection_scan_algorithm/src/parameters.cpp
@@ -72,8 +72,7 @@ namespace TrRouting
 
   RouteParameters Parameters::update(std::vector<std::string> &parameters,
     const std::map<boost::uuids::uuid, Scenario> &scenarios,
-    std::map<boost::uuids::uuid, int> &odTripIndexesByUuid,
-    std::vector<std::unique_ptr<OdTrip>> &odTrips,
+    const std::map<boost::uuids::uuid, OdTrip> &odTrips,
     const std::map<boost::uuids::uuid, Node> &nodes,
     const std::map<boost::uuids::uuid, DataSource> &dataSources)
   {
@@ -311,13 +310,13 @@ namespace TrRouting
         // TODO: Use a new endpoint for od trip uuid. Now we get its od and add them to parameters
         boost::uuids::uuid odTripUuid = uuidGenerator(parameterWithValueVector[1]);
 
-        if (odTripIndexesByUuid.count(odTripUuid) == 1)
+        if (odTrips.count(odTripUuid) == 1)
         {
-          OdTrip *odTrip = odTrips[odTripIndexesByUuid[odTripUuid]].get();
-          spdlog::info("od trip uuid {} dts {}", to_string(odTrip->uuid), odTrip->departureTimeSeconds);
+          const OdTrip & odTrip = odTrips.at(odTripUuid);
+          spdlog::info("od trip uuid {} dts {}", to_string(odTrip.uuid), odTrip.departureTimeSeconds);
 
-          newParametersWithValues.push_back(std::make_pair("origin", std::to_string(odTrip->origin.get()->latitude) + ',' + std::to_string(odTrip->origin.get()->longitude)));
-          newParametersWithValues.push_back(std::make_pair("destination", std::to_string(odTrip->destination.get()->latitude) + ',' + std::to_string(odTrip->destination.get()->longitude)));
+          newParametersWithValues.push_back(std::make_pair("origin", std::to_string(odTrip.origin.get()->latitude) + ',' + std::to_string(odTrip.origin.get()->longitude)));
+          newParametersWithValues.push_back(std::make_pair("destination", std::to_string(odTrip.destination.get()->latitude) + ',' + std::to_string(odTrip.destination.get()->longitude)));
           // TODO Add parameter for the departure_time? It was not in the original code path
         }
         continue;

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -30,7 +30,7 @@ namespace TrRouting
   
   int Calculator::updateOdTripsFromCache(std::string customPath)
   {
-    return dataFetcher.getOdTrips(odTrips, odTripIndexesByUuid, dataSources, getPersons(), getNodes(), customPath);
+    return dataFetcher.getOdTrips(odTrips, dataSources, getPersons(), getNodes(), customPath);
   }
   /* TODO #167
   int Calculator::updatePlacesFromCache(std::string customPath)

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -50,9 +50,9 @@ namespace TrRouting
     departureTimeSeconds = -1;
     arrivalTimeSeconds   = -1;
     
-    if(odTrip != nullptr && params.forwardCalculation == true)
+    if(odTripGlob.has_value() && params.forwardCalculation == true)
     {
-      departureTimeSeconds = odTrip->departureTimeSeconds;
+      departureTimeSeconds = odTripGlob.value().get().departureTimeSeconds;
     }
     else if (parameters.isForwardCalculation())
     {
@@ -80,13 +80,13 @@ namespace TrRouting
 
         spdlog::debug("  resetting access paths ");
 
-        if(odTrip != nullptr)
+        if(odTripGlob.has_value())
         {
-          spdlog::debug("  using odTrip with {} accessible nodes", odTrip->originNodes.size());
+          spdlog::debug("  using odTrip with {} accessible nodes", odTripGlob.value().get().originNodes.size());
 
           accessFootpaths.clear();
           //TODO This can be a std::copy
-          for (auto & accessNode : odTrip->originNodes)
+          for (auto & accessNode : odTripGlob.value().get().originNodes)
           {
             accessFootpaths.push_back(accessNode);
           }
@@ -150,14 +150,14 @@ namespace TrRouting
       if (resetAccessPaths)
       {
         // fetch nodes footpaths accessible to destination using params or osrm fetcher if not provided:
-        if(odTrip != nullptr)
+        if(odTripGlob.has_value())
         {
 
-          spdlog::debug("  using odTrip with {} egressible nodes", odTrip->destinationNodes.size());
+          spdlog::debug("  using odTrip with {} egressible nodes", odTripGlob.value().get().destinationNodes.size());
 
           egressFootpaths.clear();
           //TODO This could be a std::copy
-          for (auto & egressNode : odTrip->destinationNodes)
+          for (auto & egressNode : odTripGlob.value().get().destinationNodes)
           {
             egressFootpaths.push_back(egressNode);
           }

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -368,7 +368,6 @@ int main(int argc, char** argv) {
       calculator.params.setDefaultValues();
       RouteParameters routeParams = calculator.params.update(parametersWithValues,
         calculator.scenarios,
-        calculator.odTripIndexesByUuid,
         calculator.odTrips,
         calculator.nodes,
         calculator.dataSources);
@@ -376,16 +375,16 @@ int main(int argc, char** argv) {
       // find OdTrip if provided:
       bool   foundOdTrip{false};
 
-      calculator.odTrip      = nullptr;
+      calculator.odTripGlob = std::nullopt;
 
       try {
 
-        if (calculator.params.odTripUuid.has_value() && calculator.odTripIndexesByUuid.count(calculator.params.odTripUuid.value()))
+        if (calculator.params.odTripUuid.has_value() && calculator.odTrips.count(calculator.params.odTripUuid.value()))
         {
-          calculator.odTrip = calculator.odTrips[calculator.odTripIndexesByUuid[calculator.params.odTripUuid.value()]].get();
+          calculator.odTripGlob = calculator.odTrips.at(calculator.params.odTripUuid.value());
           foundOdTrip = true;
-          spdlog::info("od trip uuid {}", to_string(calculator.odTrip->uuid));
-          spdlog::info("dts {} ", calculator.odTrip->departureTimeSeconds);
+          spdlog::info("od trip uuid {}", to_string(calculator.odTripGlob.value().get().uuid));
+          spdlog::info("dts {} ", calculator.odTripGlob.value().get().departureTimeSeconds);
           if (routeParams.isWithAlternatives())
           {
             alternativeResult = calculator.alternativesRouting(routeParams);

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -73,8 +73,7 @@ namespace TrRouting
     );
 
     virtual int getOdTrips(
-      std::vector<std::unique_ptr<OdTrip>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, OdTrip>& ts,
       const std::map<boost::uuids::uuid, DataSource>& dataSources,
       const std::map<boost::uuids::uuid, Person>& persons,
       const std::map<boost::uuids::uuid, Node>& nodes,

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -86,8 +86,7 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getOdTrips(
-      std::vector<std::unique_ptr<OdTrip>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, OdTrip>& ts,
       const std::map<boost::uuids::uuid, DataSource>& dataSources,
       const std::map<boost::uuids::uuid, Person>& persons,
       const std::map<boost::uuids::uuid, Node>& nodes,

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -47,8 +47,7 @@ namespace TrRouting
                            ) {return 0;}
 
     virtual int getOdTrips(
-      std::vector<std::unique_ptr<OdTrip>>& ts,
-      std::map<boost::uuids::uuid, int>& tIndexesById, 
+      std::map<boost::uuids::uuid, OdTrip>& ts,
       const std::map<boost::uuids::uuid, DataSource>& dataSources,
       const std::map<boost::uuids::uuid, Person>& persons,
       const std::map<boost::uuids::uuid, Node>& nodes,

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -214,9 +214,8 @@ namespace TrRouting
        * */
       RouteParameters update(std::vector<std::string> &parameters,
                              const std::map<boost::uuids::uuid, Scenario> &scenario,
-                             std::map<boost::uuids::uuid, int> &odTripIndexesByUuid,
-                             std::vector<std::unique_ptr<OdTrip>> &odTrips,
-                             const std::map<boost::uuids::uuid,Node> &nodes,
+                             const std::map<boost::uuids::uuid, OdTrip> &odTrips,
+                             const std::map<boost::uuids::uuid, Node> &nodes,
                              const std::map<boost::uuids::uuid, DataSource> &dataSources);
 
   };

--- a/src/od_trips_cache_fetcher.cpp
+++ b/src/od_trips_cache_fetcher.cpp
@@ -74,8 +74,7 @@ namespace TrRouting
   }
 
   int CacheFetcher::getOdTrips(
-    std::vector<std::unique_ptr<OdTrip>>& ts,
-    std::map<boost::uuids::uuid, int>& tIndexesByUuid,
+    std::map<boost::uuids::uuid, OdTrip>& ts,
     const std::map<boost::uuids::uuid, DataSource>& dataSources,
     const std::map<boost::uuids::uuid, Person>& persons,
     const std::map<boost::uuids::uuid, Node>& nodes,
@@ -172,29 +171,26 @@ namespace TrRouting
             }
 
             // Create new odTrip
-            std::unique_ptr<T> t = std::make_unique<T>(uuidGenerator(uuid),
-                                                       capnpT.getId(),
-                                                       capnpT.getInternalId(),
-                                                       dataSources.at(uuidGenerator(dataSourceUuid)),
-                                                       person,
-                                                       capnpT.getDepartureTimeSeconds(),
-                                                       capnpT.getArrivalTimeSeconds(),
-                                                       capnpT.getWalkingTravelTimeSeconds(),
-                                                       capnpT.getCyclingTravelTimeSeconds(),
-                                                       capnpT.getDrivingTravelTimeSeconds(),
-                                                       //TODO comparison with float is fishy, confirm it's ok
-                                                       capnpT.getExpansionFactor() == -1.0 ? 1.0 : capnpT.getExpansionFactor(),
-                                                       getOdTripModeStr(capnpT.getMode()),
-                                                       getOdTripActivityStr(capnpT.getOriginActivity()),
-                                                       getOdTripActivityStr(capnpT.getDestinationActivity()),
-                                                       originNodes,
-                                                       destinationNodes,
-                                                       std::move(origin),
-                                                       std::move(destination)
-                                                       );
-            tIndexesByUuid[t->uuid] = ts.size();
-            ts.push_back(std::move(t));
-
+            ts.emplace(uuidGenerator(uuid), T(uuidGenerator(uuid),
+                                              capnpT.getId(),
+                                              capnpT.getInternalId(),
+                                              dataSources.at(uuidGenerator(dataSourceUuid)),
+                                              person,
+                                              capnpT.getDepartureTimeSeconds(),
+                                              capnpT.getArrivalTimeSeconds(),
+                                              capnpT.getWalkingTravelTimeSeconds(),
+                                              capnpT.getCyclingTravelTimeSeconds(),
+                                              capnpT.getDrivingTravelTimeSeconds(),
+                                              //TODO comparison with float is fishy, confirm it's ok
+                                              capnpT.getExpansionFactor() == -1.0 ? 1.0 : capnpT.getExpansionFactor(),
+                                              getOdTripModeStr(capnpT.getMode()),
+                                              getOdTripActivityStr(capnpT.getOriginActivity()),
+                                              getOdTripActivityStr(capnpT.getDestinationActivity()),
+                                              originNodes,
+                                              destinationNodes,
+                                              std::move(origin),
+                                              std::move(destination)
+                                              ));
           }
 
           spdlog::info("parsed {} od trips", ts.size());

--- a/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/od_trips_cache_fetcher_test.cpp
@@ -11,8 +11,7 @@ namespace fs = std::filesystem;
 class OdTripCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
-    std::vector<std::unique_ptr<TrRouting::OdTrip>> objects;
-    std::map<boost::uuids::uuid, int> objectIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::OdTrip> objects;
     std::map<boost::uuids::uuid, TrRouting::DataSource> dataSources;
     std::map<boost::uuids::uuid, TrRouting::Person> persons;
     std::map<boost::uuids::uuid, TrRouting::Node> nodes;
@@ -20,7 +19,7 @@ protected:
 
 TEST_F(OdTripCacheFetcherFixtureTests, TestGetOdTripsValid)
 {
-    int retVal = cacheFetcher.getOdTrips(objects, objectIndexesByUuid, dataSources, persons, nodes, VALID_CUSTOM_PATH);
+    int retVal = cacheFetcher.getOdTrips(objects, dataSources, persons, nodes, VALID_CUSTOM_PATH);
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0, objects.size());
 }

--- a/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_odtrips_calculation_test.cpp
@@ -56,34 +56,31 @@ void RouteOdTripsFixtureTests::setupDataSources() {
 }
 
 void RouteOdTripsFixtureTests::setupOdTrips() {
-    std::vector<std::unique_ptr<TrRouting::OdTrip>>& array = calculator.odTrips;
-    std::map<boost::uuids::uuid, int>& arrayIndexesByUuid = calculator.odTripIndexesByUuid;
+    std::map<boost::uuids::uuid, TrRouting::OdTrip>& array = calculator.odTrips;
 
     std::vector<TrRouting::NodeTimeDistance> originNodes;
     originNodes.push_back(TrRouting::NodeTimeDistance(calculator.nodes.at(nodeSouth2Uuid), 469, 500));
     std::vector<TrRouting::NodeTimeDistance> destinationNodes;
     destinationNodes.push_back(TrRouting::NodeTimeDistance(calculator.nodes.at(nodeMidNodeUuid), 138, 150));
 
-    std::unique_ptr<TrRouting::OdTrip> odTrip = std::make_unique<TrRouting::OdTrip>(odTripUuid,
-                                                                                    12345,
-                                                                                    "12345",
-                                                                                    calculator.dataSources.at(dataSourceUuid),
-                                                                                    std::nullopt,
-                                                                                    getTimeInSeconds(9, 45),
-                                                                                    -1,
-                                                                                    0,
-                                                                                    0,
-                                                                                    0,
-                                                                                    1.0,
-                                                                                    "",
-                                                                                    "",
-                                                                                    "",
-                                                                                    originNodes,
-                                                                                    destinationNodes,
-                                                                                    std::make_unique<TrRouting::Point>(45.5242, -73.5817),
-                                                                                    std::make_unique<TrRouting::Point>(45.54, -73.6146));
-    arrayIndexesByUuid[odTrip->uuid] = array.size();
-    array.push_back(std::move(odTrip));
+    array.emplace(odTripUuid, TrRouting::OdTrip(odTripUuid,
+                                                12345,
+                                                "12345",
+                                                calculator.dataSources.at(dataSourceUuid),
+                                                std::nullopt,
+                                                getTimeInSeconds(9, 45),
+                                                -1,
+                                                0,
+                                                0,
+                                                0,
+                                                1.0,
+                                                "",
+                                                "",
+                                                "",
+                                                originNodes,
+                                                destinationNodes,
+                                                std::make_unique<TrRouting::Point>(45.5242, -73.5817),
+                                                std::make_unique<TrRouting::Point>(45.54, -73.6146)));
 }
 
 // Simple test to make sure this code path still works
@@ -116,7 +113,6 @@ nlohmann::json RouteOdTripsFixtureTests::calculateOdTrips(std::vector<std::strin
     calculator.params.setDefaultValues();
     TrRouting::RouteParameters routeParams = calculator.params.update(parameters,
         calculator.scenarios,
-        calculator.odTripIndexesByUuid,
         calculator.odTrips,
         calculator.nodes,
         calculator.dataSources);
@@ -131,3 +127,5 @@ nlohmann::json RouteOdTripsFixtureTests::calculateOdTrips(std::vector<std::strin
     nlohmann::json jsonResult = json.parse(result);
     return jsonResult;
 }
+
+//TODO Add a test that validate the shuffle of the odTrips list

--- a/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_simple_calculation_test.cpp
@@ -380,7 +380,6 @@ std::unique_ptr<TrRouting::RoutingResult> RouteCalculationFixtureTests::calculat
     calculator.params.setDefaultValues();
     TrRouting::RouteParameters routeParams = calculator.params.update(parameters,
         calculator.scenarios,
-        calculator.odTripIndexesByUuid,
         calculator.odTrips,
         calculator.nodes,
         calculator.dataSources);

--- a/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_v1_transfer_and_alternatives_test.cpp
@@ -186,7 +186,6 @@ TrRouting::AlternativesResult TAndACalculationFixtureTests::calculateWithAlterna
     calculator.params.setDefaultValues();
     TrRouting::RouteParameters routeParams = calculator.params.update(parameters,
         calculator.scenarios,
-        calculator.odTripIndexesByUuid,
         calculator.odTrips,
         calculator.nodes,
         calculator.dataSources);


### PR DESCRIPTION
We changed the name of the global odTrip variable to odTripGlob to highlight which one was global and which was local, we had some clashes. We should aim to remove the global one in the future