### PR TITLE
Migration Trip from vector to map storage. 

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -172,8 +172,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>        tripIndexesByUuid;
 
     std::vector<std::vector<std::unique_ptr<int>>>   tripConnectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
-    std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;        // tripIndex: [connectionIndex (sequence in trip): sum of od trips weights using this connection (demand)]
-    //std::vector<std::unique_ptr<std::vector<std::unique_ptr<int>>>>   tripIndexesByPathIndex;
 
     Parameters params;
     CalculationTime algorithmCalculationTime;

--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -5,6 +5,7 @@
 #include "parameters.hpp"
 #include "routing_result.hpp"
 #include "node.hpp"
+#include "trip.hpp"
 
 
 namespace TrRouting
@@ -122,9 +123,12 @@ namespace TrRouting
     {
       departureTimeSeconds = -1;
       initialDepartureTimeSeconds = -1;
-      std::fill(tripsUsable.begin(), tripsUsable.end(), 1);
-      //tripsUsable = std::vector<std::unique_ptr<int>>(trips.size(), std::make_unique<int>(1));
-      //std::fill(tripsUsable.begin(), tripsUsable.end(), std::make_unique<int>(1)); // we need to make all trips usable when not coming from forward result because reverse calculation, by default, checks for usableTrips == 1
+      //TODO maybe we can do something different in that case, like a query flag
+      // we need to make all trips usable when not coming from forward result because reverse calculation, by default, checks for usableTrips
+      for (auto && tripIte : trips) {
+        const Trip & trip = tripIte.second;
+        tripsQueryOverlay[trip.uid].usable = true;
+      }
 
       auto resultCalculation = reverseCalculation(parameters);
       if (resultCalculation) {

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -52,23 +52,7 @@ namespace TrRouting
     reverseAccessJourneysSteps.clear();
 
     tripsEnabled.clear();
-    tripsEnabled.shrink_to_fit();
-    tripsEnabled.resize(trips.size());
-    tripsUsable.clear();
-    tripsUsable.shrink_to_fit();
-    tripsUsable.resize(trips.size());
-    tripsEnterConnection.clear();
-    tripsEnterConnection.shrink_to_fit();
-    tripsEnterConnection.resize(trips.size());
-    tripsExitConnection.clear();
-    tripsExitConnection.shrink_to_fit();
-    tripsExitConnection.resize(trips.size());
-    tripsEnterConnectionTransferTravelTime.clear();
-    tripsEnterConnectionTransferTravelTime.shrink_to_fit();
-    tripsEnterConnectionTransferTravelTime.resize(trips.size());
-    tripsExitConnectionTransferTravelTime.clear();
-    tripsExitConnectionTransferTravelTime.shrink_to_fit();
-    tripsExitConnectionTransferTravelTime.resize(trips.size());
+    tripsQueryOverlay.clear();
 
     spdlog::info("{} connections", forwardConnections.size());;
 
@@ -129,7 +113,6 @@ namespace TrRouting
     forwardConnections.shrink_to_fit();
     reverseConnections.shrink_to_fit();
 
-    int tripIdx {-1};
     try
     {
       spdlog::info("Sorting connections...");
@@ -146,11 +129,12 @@ namespace TrRouting
         {
           return false;
         }
-        if (std::get<connectionIndexes::TRIP>(*connectionA) < std::get<connectionIndexes::TRIP>(*connectionB))
+        //TODO We could do something  better than comparing uuud for trip. We just need something to have a stable sort
+        if (std::get<connectionIndexes::TRIP>(*connectionA).get().uuid < std::get<connectionIndexes::TRIP>(*connectionB).get().uuid)
         {
           return true;
         }
-        else if (std::get<connectionIndexes::TRIP>(*connectionA) > std::get<connectionIndexes::TRIP>(*connectionB))
+        else if (std::get<connectionIndexes::TRIP>(*connectionA).get().uuid > std::get<connectionIndexes::TRIP>(*connectionB).get().uuid)
         {
           return false;
         }
@@ -175,11 +159,11 @@ namespace TrRouting
         {
           return false;
         }
-        if (std::get<connectionIndexes::TRIP>(*connectionA) > std::get<connectionIndexes::TRIP>(*connectionB)) // here we need to reverse sequence!
+        if (std::get<connectionIndexes::TRIP>(*connectionA).get().uuid > std::get<connectionIndexes::TRIP>(*connectionB).get().uuid) // here we need to reverse sequence!
         {
           return true;
         }
-        else if (std::get<connectionIndexes::TRIP>(*connectionA) < std::get<connectionIndexes::TRIP>(*connectionB))
+        else if (std::get<connectionIndexes::TRIP>(*connectionA).get().uuid < std::get<connectionIndexes::TRIP>(*connectionB).get().uuid)
         {
           return false;
         }
@@ -203,16 +187,16 @@ namespace TrRouting
       int i {0};
       for(auto & connection : forwardConnections)
       {
-        tripIdx = std::get<connectionIndexes::TRIP>(*connection);
-        trips[tripIdx]->forwardConnectionsIdx.push_back(i);
+        Trip & trip = std::get<connectionIndexes::TRIP>(*connection);
+        trip.forwardConnectionsIdx.push_back(i);
         i++;
       }
 
       i = 0;
       for(auto & connection : reverseConnections)
       {
-        tripIdx = std::get<connectionIndexes::TRIP>(*connection);
-        trips[tripIdx]->reverseConnectionsIdx.push_back(i);
+        Trip & trip = std::get<connectionIndexes::TRIP>(*connection);
+        trip.reverseConnectionsIdx.push_back(i);
         i++;
       }
 

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -336,7 +336,6 @@ namespace TrRouting
               for (int connectionIndex = legConnectionStartIdx; connectionIndex <= legConnectionEndIdx; connectionIndex++)
               {
                 connectionDepartureTimeSeconds = *tripConnectionDepartureTimes[legTripIdx][connectionIndex];
-                *tripConnectionDemands[legTripIdx][connectionIndex] += correctedExpansionFactor;
                 connectionDepartureTimeHour    = connectionDepartureTimeSeconds / 3600;
 
                 pathProfiles[legPath.uuid][connectionIndex][connectionDepartureTimeHour] += correctedExpansionFactor;

--- a/connection_scan_algorithm/src/od_trips_routing.cpp
+++ b/connection_scan_algorithm/src/od_trips_routing.cpp
@@ -156,7 +156,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, std::vector<float>> pathTotalProfiles; // key: path uuid, value: [index: segment index, value: totalDemand]
     std::vector<float> demandByHourOfDay;
 
-    int    legTripIdx;
     int    legConnectionStartIdx;
     int    legConnectionEndIdx;
     int    connectionDepartureTimeSeconds;
@@ -317,7 +316,7 @@ namespace TrRouting
             totalTravelTimeSeconds += correctedExpansionFactor * visitor.getTotalTravelTime();
             for (auto & leg : visitor.getLegs())
             {
-              legTripIdx            = std::get<0>(leg);
+              const Trip &legTrip   = std::get<0>(leg);
               //std::reference_wrapper<const Line> lineref =  std::get<1>(leg);
               const Line &legLine   = std::get<1>(leg).get();
               //const Line &legLine = lineref.get();
@@ -335,7 +334,7 @@ namespace TrRouting
               }
               for (int connectionIndex = legConnectionStartIdx; connectionIndex <= legConnectionEndIdx; connectionIndex++)
               {
-                connectionDepartureTimeSeconds = *tripConnectionDepartureTimes[legTripIdx][connectionIndex];
+                connectionDepartureTimeSeconds = legTrip.connectionDepartureTimes[connectionIndex];
                 connectionDepartureTimeHour    = connectionDepartureTimeSeconds / 3600;
 
                 pathProfiles[legPath.uuid][connectionIndex][connectionDepartureTimeHour] += correctedExpansionFactor;

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -70,9 +70,7 @@ namespace TrRouting
       trips,
       lines,
       paths,
-      tripIndexesByUuid,
       services,
-      tripConnectionDepartureTimes,
       connections,
       customPath
     );

--- a/connection_scan_algorithm/src/preparations.cpp
+++ b/connection_scan_algorithm/src/preparations.cpp
@@ -73,7 +73,6 @@ namespace TrRouting
       tripIndexesByUuid,
       services,
       tripConnectionDepartureTimes,
-      tripConnectionDemands,
       connections,
       customPath
     );

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -240,15 +240,6 @@ namespace TrRouting
 
       spdlog::debug("  resetting filters");
 
-      if (params.calculateAllOdTrips)
-      {
-        // reset connections demand:
-        for (auto & tripConnectionDemand : tripConnectionDemands)
-        {
-          std::generate(tripConnectionDemand.begin(), tripConnectionDemand.end(), []() { return std::make_unique<float>(0.0); });
-        }
-      }
-
       int i {0};
       for (auto & trip : trips)
       {

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -120,12 +120,10 @@ namespace TrRouting
     );
 
     virtual int getSchedules(
-      std::vector<std::unique_ptr<Trip>>& trips,
+      std::map<boost::uuids::uuid, Trip>& trips,
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
-      std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = ""
     );

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -126,7 +126,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
-      std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = ""
     );

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -4,9 +4,10 @@
 namespace TrRouting
 {
   class Node;
+  class Trip;
   
-  // tuple representing a connection: departureNode, arrivalNode, departureTimeSeconds, arrivalTimeSeconds, tripIndex, canBoard, canUnboard, sequence in trip, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
-  using ConnectionTuple = std::tuple<std::reference_wrapper<const Node>,std::reference_wrapper<const Node>,int,int,int,short,short,int,short,short>;
+  // tuple representing a connection: departureNode, arrivalNode, departureTimeSeconds, arrivalTimeSeconds, trip, canBoard, canUnboard, sequence in trip, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
+  using ConnectionTuple = std::tuple<std::reference_wrapper<const Node>,std::reference_wrapper<const Node>,int,int,std::reference_wrapper<Trip>,short,short,int,short,short>;
 
   enum connectionIndexes : short { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, CAN_TRANSFER_SAME_LINE = 8, MIN_WAITING_TIME_SECONDS = 9 };
 

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -220,7 +220,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
-      std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = "") = 0;
 

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -214,12 +214,10 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getSchedules(
-      std::vector<std::unique_ptr<Trip>>& trips,
+      std::map<boost::uuids::uuid, Trip>& trips,
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
-      std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = "") = 0;
 

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -118,7 +118,6 @@ namespace TrRouting
       std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
       std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
-      std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
       std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = "") {return 0;}
 

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -112,12 +112,10 @@ namespace TrRouting
      * -(error codes from the open system call)
      */
     virtual int getSchedules(
-      std::vector<std::unique_ptr<Trip>>& trips,
+      std::map<boost::uuids::uuid, Trip>& trips,
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
-      std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
       std::vector<std::shared_ptr<ConnectionTuple>>& connections,
       std::string customPath = "") {return 0;}
 

--- a/include/path.hpp
+++ b/include/path.hpp
@@ -9,6 +9,7 @@
 namespace TrRouting
 {
   class Line;
+  class Trip;
   
   class Path {
   
@@ -18,7 +19,7 @@ namespace TrRouting
          const std::string &adirection,
          const std::string &ainternalId,
          const std::vector<std::reference_wrapper<const Node>> &anodesRef,
-         const std::vector<int> &atripsIdx,
+         const std::vector<std::reference_wrapper<const Trip>> &atripsRef,
          const std::vector<int> &asegmentsTravelTimeSeconds,
          const std::vector<int> &asegmentsDistanceMeters):
       uuid(auuid),
@@ -26,7 +27,7 @@ namespace TrRouting
       direction(adirection),
       internalId(ainternalId),
       nodesRef(anodesRef),
-      tripsIdx(atripsIdx),
+      tripsRef(atripsRef),
       segmentsTravelTimeSeconds(asegmentsTravelTimeSeconds),
       segmentsDistanceMeters(asegmentsDistanceMeters) {}
 
@@ -37,12 +38,12 @@ namespace TrRouting
          const std::string &adirection,
          const std::string &ainternalId,
          const std::vector<NodeTimeDistance> &anodesTimeDistance,
-         const std::vector<int> &atripsIdx):
+         const std::vector<std::reference_wrapper<const Trip>> &atripsRef):
       uuid(auuid),
       line(aline),
       direction(adirection),
       internalId(ainternalId),
-      tripsIdx(atripsIdx)
+      tripsRef(atripsRef)
       {
         for (const NodeTimeDistance & ntd: anodesTimeDistance) {
           nodesRef.push_back(ntd.node);
@@ -56,7 +57,7 @@ namespace TrRouting
     std::string direction;
     std::string internalId;
     std::vector<std::reference_wrapper<const Node>> nodesRef;
-    std::vector<int> tripsIdx;
+    std::vector<std::reference_wrapper<const Trip>> tripsRef;
     //TODO Should probably be integrated with nodes as a NodeTimeDistance object. Need
     // to validate their usage
     std::vector<int> segmentsTravelTimeSeconds;

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -13,6 +13,7 @@ namespace TrRouting
 {
   class Line;
   class Path;
+  class Trip;
 
   // TODO These enums are used temporarily, while we need the class hierarchy to be able to determine which type is returned when dynamic cast is necessary
   enum result_type { SINGLE_CALCULATION, ALTERNATIVES, ALL_NODES };
@@ -230,7 +231,7 @@ namespace TrRouting
    * 
    */
    // tuple: tripIdx, line, path, start connection index, end connection index
-  typedef std::tuple<int, std::reference_wrapper<const Line>, std::reference_wrapper<const Path>, int, int> Leg;
+  typedef std::tuple<std::reference_wrapper<const Trip>, std::reference_wrapper<const Line>, std::reference_wrapper<const Path>, int, int> Leg;
 
   class SingleCalculationResult : public RoutingResult {
   public:

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -3,16 +3,20 @@
 
 #include <boost/uuid/uuid.hpp>
 #include <vector>
+#include "toolbox.hpp" //MAX_INT
 
 namespace TrRouting
 {
   class Mode;
   class Agency;
   class Service;
+  class Path;
   
-  struct Trip {
+  class Trip {
   
   public:
+    typedef int uid_t; //Type for a local temporary ID
+
     Trip( boost::uuids::uuid auuid,
           const Agency &aagency,
           const Line &aline,
@@ -29,7 +33,8 @@ namespace TrRouting
                                          service(aservice),
                                          totalCapacity(atotalCapacity),
                                          seatedCapacity(aseatedCapacity),
-                                         allowSameLineTransfers(aallowSameLineTransfers) {}
+                                     allowSameLineTransfers(aallowSameLineTransfers),
+                                     uid(++global_uid) {}
    
     boost::uuids::uuid uuid;
     const Agency &agency; //TODO Agency is part of line, we could merge them
@@ -42,9 +47,38 @@ namespace TrRouting
     int seatedCapacity; //Unused
     std::vector<int> forwardConnectionsIdx;
     std::vector<int> reverseConnectionsIdx;
+    std::vector<int>   connectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
 
+    uid_t uid; //Local, temporary unique id, used to speed up lookups
+
+    inline bool operator==(const Trip& other ) const { return uuid == other.uuid; }
+  private:
+    //TODO, this could probably be an unsigned long, but current MAX_INT is good enough for our needs
+    inline static uid_t global_uid = 0;    
+  };
+  inline bool operator==(const std::reference_wrapper<const TrRouting::Trip>& lhs, const std::reference_wrapper<const Trip>& rhs)
+  {
+    return lhs.get() == rhs.get();
+  }
+  // Scratch data used by the calculation of each query
+  class TripQueryData {
+  public:
+
+    TripQueryData()
+      : usable(false),
+        enterConnection(-1),
+        enterConnectionTransferTravelTime(MAX_INT),
+        exitConnection(-1),
+        exitConnectionTransferTravelTime(MAX_INT)
+    {
+
+    }
+    bool usable; // after forward calculation, keep a list of usable trips in time range for reverse calculation
+    int enterConnection; // index of the entering connection
+    int enterConnectionTransferTravelTime;
+    int exitConnection; // index of the exiting connection
+    int exitConnectionTransferTravelTime;
   };
 
 }
-
 #endif // TR_TRIP

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -66,7 +66,7 @@ namespace TrRouting
         std::string uuid     {capnpT.getUuid()};
         std::string lineUuid {capnpT.getLineUuid()};
         std::vector<std::reference_wrapper<const Node>> nodesRef;
-        std::vector<int> tripsIdx;
+        std::vector<std::reference_wrapper<const Trip>> tripsRef;
         std::vector<int> distancesMeters;
         std::vector<int> travelTimesSeconds;
         boost::uuids::uuid nodeUuid;
@@ -96,7 +96,7 @@ namespace TrRouting
                                capnpT.getDirection(),
                                capnpT.getInternalId(),
                                nodesRef,
-                               tripsIdx, //TODO This is empty
+                               tripsRef, //TODO This is empty
                                travelTimesSeconds,
                                distancesMeters));
       }

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -27,7 +27,6 @@ namespace TrRouting
     std::map<boost::uuids::uuid, int>& tripIndexesByUuid,
     const std::map<boost::uuids::uuid, Service>& services,
     std::vector<std::vector<std::unique_ptr<int>>>&   tripConnectionDepartureTimes,
-    std::vector<std::vector<std::unique_ptr<float>>>& tripConnectionDemands,
     std::vector<std::shared_ptr<ConnectionTuple>>& connections,
     std::string customPath
   )
@@ -37,8 +36,6 @@ namespace TrRouting
     tripIndexesByUuid.clear();
     tripConnectionDepartureTimes.clear();
     tripConnectionDepartureTimes.shrink_to_fit();
-    tripConnectionDemands.clear();
-    tripConnectionDemands.shrink_to_fit();
     connections.clear();
     connections.shrink_to_fit();
 
@@ -111,7 +108,6 @@ namespace TrRouting
               auto canUnboards           = capnpTrip.getNodesCanUnboard();
               
               std::vector<std::unique_ptr<int>>   connectionDepartureTimes = std::vector<std::unique_ptr<int>>(nodeTimesCount);
-              std::vector<std::unique_ptr<float>> connectionDemands        = std::vector<std::unique_ptr<float>>(nodeTimesCount);
 
               // nodeTimesCount - 1, since we process node pairs, we have to stop and the second from last
               for (int nodeTimeI = 0; nodeTimeI < nodeTimesCount - 1; nodeTimeI++)
@@ -132,13 +128,11 @@ namespace TrRouting
                   connections.push_back(std::move(forwardConnection));
 
                   connectionDepartureTimes[nodeTimeI] = std::make_unique<int>(departureTimesSeconds[nodeTimeI]);
-                  connectionDemands[nodeTimeI]        = std::make_unique<float>(0.0);
 
               }
               trips.push_back(std::move(trip));
 
               tripConnectionDepartureTimes.push_back(std::move(connectionDepartureTimes));
-              tripConnectionDemands.push_back(std::move(connectionDemands));
 
             }
           }

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -14,13 +14,12 @@ namespace fs = std::filesystem;
 class ScheduleCacheFetcherFixtureTests : public BaseCacheFetcherFixtureTests
 {
 protected:
-    std::vector<std::unique_ptr<TrRouting::Trip>> trips;
+    std::map<boost::uuids::uuid, TrRouting::Trip> trips;
     std::map<boost::uuids::uuid, TrRouting::Line> lines;
     std::map<boost::uuids::uuid, TrRouting::Path> paths;
     std::map<boost::uuids::uuid, TrRouting::Node> nodes;
     std::map<boost::uuids::uuid, int> tripIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
-    std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
     std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> connections;
 
 public:
@@ -57,9 +56,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       trips,
       lines,
       paths,
-      tripIndexesByUuid,
       services,
-      tripConnectionDepartureTimes,
       connections,
       INVALID_CUSTOM_PATH
     );
@@ -74,9 +71,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       trips,
       lines,
       paths,
-      tripIndexesByUuid,
       services,
-      tripConnectionDepartureTimes,
       connections,
       INVALID_CUSTOM_PATH
     );
@@ -90,9 +85,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       trips,
       lines,
       paths,
-      tripIndexesByUuid,
       services,
-      tripConnectionDepartureTimes,
       connections,
       VALID_CUSTOM_PATH
     );

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -21,7 +21,6 @@ protected:
     std::map<boost::uuids::uuid, int> tripIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
     std::vector<std::vector<std::unique_ptr<int>>> tripConnectionDepartureTimes;
-    std::vector<std::vector<std::unique_ptr<float>>> tripConnectionDemands;
     std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> connections;
 
 public:
@@ -61,7 +60,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
       tripIndexesByUuid,
       services,
       tripConnectionDepartureTimes,
-      tripConnectionDemands,
       connections,
       INVALID_CUSTOM_PATH
     );
@@ -79,7 +77,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
       tripIndexesByUuid,
       services,
       tripConnectionDepartureTimes,
-      tripConnectionDemands,
       connections,
       INVALID_CUSTOM_PATH
     );
@@ -96,7 +93,6 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
       tripIndexesByUuid,
       services,
       tripConnectionDepartureTimes,
-      tripConnectionDemands,
       connections,
       VALID_CUSTOM_PATH
     );

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -280,7 +280,6 @@ void addTripData(TrRouting::Calculator& calculator, TrRouting::Trip *trip, TrRou
     path.tripsIdx.push_back(tripIdx);
 
     std::vector<std::unique_ptr<int>> connectionDepartureTimes = std::vector<std::unique_ptr<int>>(arraySize);
-    std::vector<std::unique_ptr<float>> connectionDemands = std::vector<std::unique_ptr<float>>(arraySize);
 
     for (int nodeTimeI = 0; nodeTimeI < arraySize - 1; nodeTimeI++) {
         std::shared_ptr<TrRouting::ConnectionTuple> forwardConnection(std::make_shared<TrRouting::ConnectionTuple>(TrRouting::ConnectionTuple(
@@ -299,12 +298,10 @@ void addTripData(TrRouting::Calculator& calculator, TrRouting::Trip *trip, TrRou
         connections.push_back(std::move(forwardConnection));
 
         connectionDepartureTimes[nodeTimeI] = std::make_unique<int>(departureTimes[nodeTimeI]);
-        connectionDemands[nodeTimeI] = std::make_unique<float>(0.0);
 
     }
 
     calculator.tripConnectionDepartureTimes.push_back(std::move(connectionDepartureTimes));
-    calculator.tripConnectionDemands.push_back(std::move(connectionDemands));
 
 }
 


### PR DESCRIPTION

    Migrate Trip vector and index map to a single UUID:Trip map
    
    Introduce a TripQueryData to contains the additional info related to Trips that is computed for
    each query.
    Added a local uid_t like Node to speed up lookup during query processing.
    
    There's still a 2x slow down. Hoping we can reduce that when we remove all the global variable
    used during the queries processing

In first commit: 
    Remove unused tripConnectionDemands
    
    Might be an interesting statistics to give users, but currently it's not reported.
    Remove until we have a use case for it
