### PR TITLE
Replace struct class definition with class tag

### DIFF
--- a/include/agency.hpp
+++ b/include/agency.hpp
@@ -8,7 +8,7 @@
 namespace TrRouting
 {
   
-  struct Agency {
+  class Agency {
     
   public:
 

--- a/include/household.hpp
+++ b/include/household.hpp
@@ -10,7 +10,7 @@
 namespace TrRouting
 {
   
-  struct Household {
+  class Household {
   
   public:
    

--- a/include/mode.hpp
+++ b/include/mode.hpp
@@ -6,7 +6,7 @@
 namespace TrRouting
 {
   
-  struct Mode {
+  class Mode {
   
   public:
     inline static const std::string TRANSFERABLE {"transferable"}; 

--- a/include/place.hpp
+++ b/include/place.hpp
@@ -10,7 +10,7 @@
 namespace TrRouting
 {
   
-  struct Place {
+  class Place {
   
   public:
    

--- a/include/point.hpp
+++ b/include/point.hpp
@@ -6,7 +6,7 @@
 namespace TrRouting
 {
   
-  struct Point {
+  class Point {
   
   public:
     

--- a/include/service.hpp
+++ b/include/service.hpp
@@ -9,7 +9,7 @@
 namespace TrRouting
 {
   
-  struct Service {
+  class Service {
   
   public:
    


### PR DESCRIPTION
Avoid mismatch between struct and class. We use class everywhere