### PR TITLE
Rework Connection management

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -37,7 +37,7 @@ namespace TrRouting
   class AlternativesResult;
   class TransitData;
 
-  using JourneyStep = std::tuple<int,int,std::optional<std::reference_wrapper<const Trip>>,int,short,int>; //final enter connection, final exit connection, final trip, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
+  using JourneyStep = std::tuple<std::optional<std::shared_ptr<Connection>>,std::optional<std::shared_ptr<Connection>>,std::optional<std::reference_wrapper<const Trip>>,int,short,int>; //final enter connection, final exit connection, final trip, transfer travel time, is same node transfer (first, second, third and fourth values = -1 for access and egress journeys)
 
   class Calculator {
 

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -100,8 +100,9 @@ namespace TrRouting
     long long        calculationTime;
     std::string      accessMode;
     std::string      egressMode;
-    std::vector<int> forwardConnectionsIndexPerDepartureTimeHour;
-    std::vector<int> reverseConnectionsIndexPerArrivalTimeHour;
+    //TODO
+    ////std::vector<int> forwardConnectionsIndexPerDepartureTimeHour;    
+    ////std::vector<int> reverseConnectionsIndexPerArrivalTimeHour;
 
     std::unordered_map<Node::uid_t, int> nodesTentativeTime; // arrival time at node
     std::unordered_map<Node::uid_t, int> nodesReverseTentativeTime; // departure time at node

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -100,9 +100,6 @@ namespace TrRouting
     long long        calculationTime;
     std::string      accessMode;
     std::string      egressMode;
-    //TODO
-    ////std::vector<int> forwardConnectionsIndexPerDepartureTimeHour;    
-    ////std::vector<int> reverseConnectionsIndexPerArrivalTimeHour;
 
     std::unordered_map<Node::uid_t, int> nodesTentativeTime; // arrival time at node
     std::unordered_map<Node::uid_t, int> nodesReverseTentativeTime; // departure time at node

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -34,12 +34,8 @@ namespace TrRouting
     int  departureTimeHour = departureTimeSeconds / 3600;
 
     // main loop:
-    ////int i = forwardConnectionsIndexPerDepartureTimeHour[departureTimeHour];
     auto lastConnection = transitData.getForwardConnections().end(); // cache last connection for loop
-    //TODO Let's ignore the forwardConnectionsIndexPerDepartureTimeHour, it's a small optimization which complexify the code
-    // We can replace it by a transitData.GetFCbeginItePerHour function which will cache the result internally 
-    ////for(auto connection = transitData.getForwardConnections().begin() + forwardConnectionsIndexPerDepartureTimeHour[departureTimeHour]; connection != lastConnection; ++connection)
-    for(auto connection = transitData.getForwardConnections().begin(); connection != lastConnection; ++connection)
+    for(auto connection = transitData.getForwardConnectionsBeginAtDepartureHour(departureTimeHour); connection != lastConnection; ++connection)
     {
       
       // ignore connections before departure time + minimum access travel time:

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -36,9 +36,13 @@ namespace TrRouting
 
     // main loop:
     //TODO Better identify this i variable
-    int i = forwardConnectionsIndexPerDepartureTimeHour[departureTimeHour];
+    ////int i = forwardConnectionsIndexPerDepartureTimeHour[departureTimeHour];
     auto lastConnection = transitData.getForwardConnections().end(); // cache last connection for loop
-    for(auto connection = transitData.getForwardConnections().begin() + forwardConnectionsIndexPerDepartureTimeHour[departureTimeHour]; connection != lastConnection; ++connection)
+    //TODO Let's ignore the forwardConnectionsIndexPerDepartureTimeHour, it's a small optimization which complexify the code
+    // We can replace it by a transitData.GetFCbeginItePerHour function which will cache the result internally 
+    ////for(auto connection = transitData.getForwardConnections().begin() + forwardConnectionsIndexPerDepartureTimeHour[departureTimeHour]; connection != lastConnection; ++connection)
+    int i = 0;
+    for(auto connection = transitData.getForwardConnections().begin(); connection != lastConnection; ++connection)
     {
       
       // ignore connections before departure time + minimum access travel time:

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -61,45 +61,6 @@ namespace TrRouting
 
     //int benchmarkingStart = algorithmCalculationTime.getEpoch();
 
-    //TODO See comments in forward_calculation about forwardConnectionsIndexPerDepartureTimeHour
-    /* 
-    int lastConnectionIndex = transitData.getForwardConnections().size() - 1;
-
-    forwardConnectionsIndexPerDepartureTimeHour = std::vector<int>(32, -1);
-    reverseConnectionsIndexPerArrivalTimeHour   = std::vector<int>(32, lastConnectionIndex);
-
-    int hour {0};
-    int i = 0;
-    for (auto & connection : transitData.getForwardConnections())
-    {
-      while (connection->getDepartureTime() >= hour * 3600 && forwardConnectionsIndexPerDepartureTimeHour[hour] == -1 && hour < 32)
-      {
-        forwardConnectionsIndexPerDepartureTimeHour[hour] = i;
-        hour++;
-      }
-      i++;
-    }
-
-    hour = 31;
-    i = 0;
-    for (auto & connection : transitData.getReverseConnections())
-    {
-      while (connection->getArrivalTime() <= hour * 3600 && reverseConnectionsIndexPerArrivalTimeHour[hour] == lastConnectionIndex && hour >= 0)
-      {
-        reverseConnectionsIndexPerArrivalTimeHour[hour] = i;
-        hour--;
-      }
-      i++;
-    }
-
-    for (int h = 0; h < 32; h++)
-    {
-      if (forwardConnectionsIndexPerDepartureTimeHour[h] == -1)
-      {
-        forwardConnectionsIndexPerDepartureTimeHour[h] = lastConnectionIndex;
-      }
-    }*/
-
   }
 
 }

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -61,6 +61,8 @@ namespace TrRouting
 
     //int benchmarkingStart = algorithmCalculationTime.getEpoch();
 
+    //TODO See comments in forward_calculation about forwardConnectionsIndexPerDepartureTimeHour
+    /* 
     int lastConnectionIndex = transitData.getForwardConnections().size() - 1;
 
     forwardConnectionsIndexPerDepartureTimeHour = std::vector<int>(32, -1);
@@ -96,7 +98,7 @@ namespace TrRouting
       {
         forwardConnectionsIndexPerDepartureTimeHour[h] = lastConnectionIndex;
       }
-    }
+    }*/
 
   }
 

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -70,7 +70,7 @@ namespace TrRouting
     int i = 0;
     for (auto & connection : transitData.getForwardConnections())
     {
-      while (std::get<connectionIndexes::TIME_DEP>(*connection) >= hour * 3600 && forwardConnectionsIndexPerDepartureTimeHour[hour] == -1 && hour < 32)
+      while (connection->getDepartureTime() >= hour * 3600 && forwardConnectionsIndexPerDepartureTimeHour[hour] == -1 && hour < 32)
       {
         forwardConnectionsIndexPerDepartureTimeHour[hour] = i;
         hour++;
@@ -82,7 +82,7 @@ namespace TrRouting
     i = 0;
     for (auto & connection : transitData.getReverseConnections())
     {
-      while (std::get<connectionIndexes::TIME_ARR>(*connection) <= hour * 3600 && reverseConnectionsIndexPerArrivalTimeHour[hour] == lastConnectionIndex && hour >= 0)
+      while (connection->getArrivalTime() <= hour * 3600 && reverseConnectionsIndexPerArrivalTimeHour[hour] == lastConnectionIndex && hour >= 0)
       {
         reverseConnectionsIndexPerArrivalTimeHour[hour] = i;
         hour--;

--- a/connection_scan_algorithm/src/optimize_journey.cpp
+++ b/connection_scan_algorithm/src/optimize_journey.cpp
@@ -176,7 +176,7 @@ namespace TrRouting
         {
           auto connection = trip.reverseConnections[sequenceIdx];
           
-          if (optimizationNode == connection->getArrivalNode())
+          if (optimizationNode.value() == connection->getArrivalNode())
           {
             if (!connection->canUnboard())
             {
@@ -211,7 +211,7 @@ namespace TrRouting
         for(size_t sequenceIdx = trip.reverseConnections.size() - 1 - sequenceEndIdx; sequenceIdx <= trip.reverseConnections.size() - 1 - sequenceStartIdx; ++sequenceIdx)
         {
           auto connection = trip.reverseConnections[sequenceIdx];
-          if (optimizationNode == connection->getDepartureNode())
+          if (optimizationNode.value() == connection->getDepartureNode())
           {
             if (!connection->canBoard())
             {
@@ -241,7 +241,7 @@ namespace TrRouting
         {
           auto connection = trip.reverseConnections[sequenceIdx];
           
-          if (optimizationNode == connection->getArrivalNode())
+          if (optimizationNode.value() == connection->getArrivalNode())
           {
             if (!connection->canUnboard())
             {
@@ -276,7 +276,7 @@ namespace TrRouting
           for(size_t sequenceIdx = arrivalJourneyStepTrip.reverseConnections.size() - 1 - arrivalJourneyStepSequenceEndIdx; sequenceIdx <= arrivalJourneyStepTrip.reverseConnections.size() - 1 - arrivalJourneyStepSequenceStartIdx; ++sequenceIdx)
           {
             auto connection = arrivalJourneyStepTrip.reverseConnections[sequenceIdx];
-            if (optimizationNode == connection->getArrivalNode())
+            if (optimizationNode.value() == connection->getArrivalNode())
             {
               if (connection->canUnboard())
               {
@@ -292,7 +292,7 @@ namespace TrRouting
           for(size_t sequenceIdx = departureJourneyStepTrip.reverseConnections.size() - 1 - departureJourneyStepSequenceEndIdx; sequenceIdx <= departureJourneyStepTrip.reverseConnections.size() - 1 - departureJourneyStepSequenceStartIdx; ++sequenceIdx)
           {
             auto connection = departureJourneyStepTrip.reverseConnections[sequenceIdx];
-            if (optimizationNode == connection->getDepartureNode())
+            if (optimizationNode.value() == connection->getDepartureNode())
             {
               if (exitConnection.has_value() && connection->canBoard())
               {

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -125,7 +125,7 @@ namespace TrRouting
         nodesAccess.emplace(accessFootpath.node.uid, NodeTimeDistance(accessFootpath.node,
                                                                       footpathTravelTimeSeconds,
                                                                       footpathDistanceMeters));
-        forwardJourneysSteps[accessFootpath.node.uid]  = std::make_tuple(-1, -1, std::nullopt, footpathTravelTimeSeconds, -1, footpathDistanceMeters);
+        forwardJourneysSteps[accessFootpath.node.uid]  = std::make_tuple(std::nullopt, std::nullopt, std::nullopt, footpathTravelTimeSeconds, -1, footpathDistanceMeters);
         nodesTentativeTime[accessFootpath.node.uid]    = departureTimeSeconds + footpathTravelTimeSeconds;
         if (footpathTravelTimeSeconds < minAccessTravelTime)
         {
@@ -195,7 +195,7 @@ namespace TrRouting
                                                                        footpathTravelTimeSeconds,
                                                                        footpathDistanceMeters));
 
-        reverseJourneysSteps[egressFootpath.node.uid] = std::make_tuple(-1, -1, std::nullopt, footpathTravelTimeSeconds, -1, footpathDistanceMeters);
+        reverseJourneysSteps[egressFootpath.node.uid] = std::make_tuple(std::nullopt, std::nullopt, std::nullopt, footpathTravelTimeSeconds, -1, footpathDistanceMeters);
         nodesReverseTentativeTime[egressFootpath.node.uid] = arrivalTimeSeconds - footpathTravelTimeSeconds;
         if (footpathTravelTimeSeconds > maxEgressTravelTime)
         {

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -40,12 +40,8 @@ namespace TrRouting
     // reverse calculation:
 
     // main loop for reverse connections:
-    ////i = (arrivalTimeHour + 1 >= reverseConnectionsIndexPerArrivalTimeHour.size()) ? 0 : reverseConnectionsIndexPerArrivalTimeHour[arrivalTimeHour + 1];
-    //i = 0;
     auto lastConnection = reverseConnections.end();
-    //TODO See comment in forward_calculation about forwardConnectionsIndexPerDepartureTimeHour
-    ////for(auto connection = reverseConnections.begin() + reverseConnectionsIndexPerArrivalTimeHour[arrivalTimeHour + 1]; connection != lastConnection; ++connection)
-    for(auto connection = reverseConnections.begin(); connection != lastConnection; ++connection)
+    for(auto connection = transitData.getReverseConnectionsBeginAtArrivalHour(arrivalTimeHour + 1); connection != lastConnection; ++connection)
     {
       // ignore connections after arrival time - minimum egress travel time:
       if ((**connection).getArrivalTime() <= arrivalTimeSeconds - (params.returnAllNodesResult ? 0 : minEgressTravelTime))

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -41,10 +41,12 @@ namespace TrRouting
     // reverse calculation:
 
     // main loop for reverse connections:
-    i = (arrivalTimeHour + 1 >= reverseConnectionsIndexPerArrivalTimeHour.size()) ? 0 : reverseConnectionsIndexPerArrivalTimeHour[arrivalTimeHour + 1];
-    
+    ////i = (arrivalTimeHour + 1 >= reverseConnectionsIndexPerArrivalTimeHour.size()) ? 0 : reverseConnectionsIndexPerArrivalTimeHour[arrivalTimeHour + 1];
+    i = 0;
     auto lastConnection = reverseConnections.end();
-    for(auto connection = reverseConnections.begin() + reverseConnectionsIndexPerArrivalTimeHour[arrivalTimeHour + 1]; connection != lastConnection; ++connection)
+    //TODO See comment in forward_calculation about forwardConnectionsIndexPerDepartureTimeHour
+    ////for(auto connection = reverseConnections.begin() + reverseConnectionsIndexPerArrivalTimeHour[arrivalTimeHour + 1]; connection != lastConnection; ++connection)
+    for(auto connection = reverseConnections.begin(); connection != lastConnection; ++connection)
     {
       // ignore connections after arrival time - minimum egress travel time:
       if ((**connection).getArrivalTime() <= arrivalTimeSeconds - (params.returnAllNodesResult ? 0 : minEgressTravelTime))

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -125,7 +125,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::shared_ptr<ConnectionTuple>>& connections,
+      std::vector<std::shared_ptr<Connection>>& connections,
       std::string customPath = ""
     );
         

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -6,11 +6,62 @@ namespace TrRouting
   class Node;
   class Trip;
   
-  // tuple representing a connection: departureNode, arrivalNode, departureTimeSeconds, arrivalTimeSeconds, trip, canBoard, canUnboard, sequence in trip, canTransferSameLine, minWaitingTimeSeconds (-1 to inherit from parameters)
-  using ConnectionTuple = std::tuple<std::reference_wrapper<const Node>,std::reference_wrapper<const Node>,int,int,std::reference_wrapper<Trip>,short,short,int,short,short>;
+  class Connection {
 
-  enum connectionIndexes : short { NODE_DEP = 0, NODE_ARR = 1, TIME_DEP = 2, TIME_ARR = 3, TRIP = 4, CAN_BOARD = 5, CAN_UNBOARD = 6, SEQUENCE = 7, CAN_TRANSFER_SAME_LINE = 8, MIN_WAITING_TIME_SECONDS = 9 };
+  public:
+    Connection(const Node & _departureNode,
+               const Node & _arrivalNode,
+               int _departureTimeSeconds,
+               int _arrivalTimeSeconds,
+               Trip & _trip,
+               bool _canBoard,
+               bool _canUnboard,
+               int _sequenceInTrip,
+               bool _canTransferSameLine,
+               short _minWaitingTimeSeconds) :
+      departureNode(_departureNode),
+      arrivalNode(_arrivalNode),
+      departureTimeSeconds(_departureTimeSeconds),
+      arrivalTimeSeconds(_arrivalTimeSeconds),
+      trip(_trip),
+      canBoardValue(_canBoard),
+      canUnboardValue(_canUnboard),
+      sequenceInTrip(_sequenceInTrip),
+      canTransferSameLineValue(_canTransferSameLine),
+      minWaitingTimeSeconds(_minWaitingTimeSeconds) {}
 
+    const Node & getDepartureNode() {return departureNode;}
+    const Node & getArrivalNode() {return arrivalNode;}
+    int getDepartureTime() {return departureTimeSeconds;}
+    int getArrivalTime() {return arrivalTimeSeconds;}
+    const Trip & getTrip() {return trip;}
+    //TODO Revisit how we create Trip and Connection to not require a mutable trip here (issue #201
+    Trip & getTripMutable() {return trip;}
+    bool canBoard() {return canBoardValue;}
+    bool canUnboard() {return canUnboardValue;}
+    int getSequenceInTrip() {return sequenceInTrip;}
+    bool canTransferSameLine() {return canTransferSameLineValue;}
+    short getMinWaitingTime() {return minWaitingTimeSeconds;}
+    short getMinWaitingTimeOrDefault(short defaultMinWaitingTime) {
+      if (minWaitingTimeSeconds >= 0) {
+        return minWaitingTimeSeconds;
+      } else {
+        return defaultMinWaitingTime;
+      }
+    }
+
+  private:
+    const Node & departureNode;
+    const Node & arrivalNode;
+    int departureTimeSeconds;
+    int arrivalTimeSeconds;
+    Trip & trip;
+    bool canBoardValue;
+    bool canUnboardValue;
+    int sequenceInTrip;
+    bool canTransferSameLineValue;
+    short minWaitingTimeSeconds; // (-1 to inherit from parameters)
+  };
 
 }
 

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -219,7 +219,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::shared_ptr<ConnectionTuple>>& connections,
+      std::vector<std::shared_ptr<Connection>>& connections,
       std::string customPath = "") = 0;
 
   };    

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -116,7 +116,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Line>& ,
       std::map<boost::uuids::uuid, Path>& ,
       const std::map<boost::uuids::uuid, Service>& ,
-      std::vector<std::shared_ptr<ConnectionTuple>>& ,
+      std::vector<std::shared_ptr<Connection>>& ,
       std::string = "") {return 0;}
 
   };    

--- a/include/transit_data.hpp
+++ b/include/transit_data.hpp
@@ -70,6 +70,8 @@ namespace TrRouting {
     const std::vector<std::shared_ptr<Connection>> & getForwardConnections() const {return forwardConnections;}
     const std::vector<std::shared_ptr<Connection>> & getReverseConnections() const {return reverseConnections;}
 
+    std::vector<std::shared_ptr<Connection>>::const_iterator getForwardConnectionsBeginAtDepartureHour(int hour) const;
+    std::vector<std::shared_ptr<Connection>>::const_iterator getReverseConnectionsBeginAtArrivalHour(int hour) const;
     /**
      * The update* methods get the data from the data fetcher
      *
@@ -98,6 +100,7 @@ namespace TrRouting {
     
   protected:
     DataStatus loadAllData();
+    void generateConnectionsIteratorCache();
     int generateForwardAndReverseConnections(const std::vector<std::shared_ptr<Connection>> &connections);
 
     DataFetcher &dataFetcher;
@@ -116,6 +119,11 @@ namespace TrRouting {
 
     std::vector<std::shared_ptr<Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
     std::vector<std::shared_ptr<Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
+
+    // Contains iterator matching each hour of the day from the corresponding connections container.
+    // Used to speed up iterating the connections by skipping the connections that are too early or too late
+    std::vector<std::vector<std::shared_ptr<Connection>>::const_iterator> forwardConnectionsBeginIteratorCache;
+    std::vector<std::vector<std::shared_ptr<Connection>>::const_iterator> reverseConnectionsBeginIteratorCache;
   };
 
 }

--- a/include/transit_data.hpp
+++ b/include/transit_data.hpp
@@ -67,8 +67,8 @@ namespace TrRouting {
     const std::map<boost::uuids::uuid, Scenario> & getScenarios() const {return scenarios;}
     const std::map<boost::uuids::uuid, Trip> & getTrips() const {return trips;}
 
-    const std::vector<std::shared_ptr<ConnectionTuple>> & getForwardConnections() const {return forwardConnections;}
-    const std::vector<std::shared_ptr<ConnectionTuple>> & getReverseConnections() const {return reverseConnections;}
+    const std::vector<std::shared_ptr<Connection>> & getForwardConnections() const {return forwardConnections;}
+    const std::vector<std::shared_ptr<Connection>> & getReverseConnections() const {return reverseConnections;}
 
     /**
      * The update* methods get the data from the data fetcher
@@ -98,7 +98,7 @@ namespace TrRouting {
     
   protected:
     DataStatus loadAllData();
-    int generateForwardAndReverseConnections(const std::vector<std::shared_ptr<ConnectionTuple>> &connections);
+    int generateForwardAndReverseConnections(const std::vector<std::shared_ptr<Connection>> &connections);
 
     DataFetcher &dataFetcher;
 
@@ -114,8 +114,8 @@ namespace TrRouting {
     std::map<boost::uuids::uuid, Scenario>   scenarios;
     std::map<boost::uuids::uuid, Trip>       trips;
 
-    std::vector<std::shared_ptr<ConnectionTuple>> forwardConnections; // Forward connections, sorted by departure time ascending
-    std::vector<std::shared_ptr<ConnectionTuple>> reverseConnections; // Reverse connections, sorted by arrival time descending
+    std::vector<std::shared_ptr<Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
+    std::vector<std::shared_ptr<Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
   };
 
 }

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -45,8 +45,8 @@ namespace TrRouting
     short allowSameLineTransfers;
     int totalCapacity; //Unused
     int seatedCapacity; //Unused
-    std::vector<int> forwardConnectionsIdx;
-    std::vector<int> reverseConnectionsIdx;
+    std::vector<std::shared_ptr<Connection>> forwardConnections;
+    std::vector<std::shared_ptr<Connection>> reverseConnections;
     std::vector<int>   connectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
 
     uid_t uid; //Local, temporary unique id, used to speed up lookups
@@ -66,17 +66,17 @@ namespace TrRouting
 
     TripQueryData()
       : usable(false),
-        enterConnection(-1),
+        enterConnection(std::nullopt),
         enterConnectionTransferTravelTime(MAX_INT),
-        exitConnection(-1),
+        exitConnection(std::nullopt),
         exitConnectionTransferTravelTime(MAX_INT)
     {
 
     }
     bool usable; // after forward calculation, keep a list of usable trips in time range for reverse calculation
-    int enterConnection; // index of the entering connection
+    std::optional<std::shared_ptr<Connection>> enterConnection; // index of the entering connection
     int enterConnectionTransferTravelTime;
-    int exitConnection; // index of the exiting connection
+    std::optional<std::shared_ptr<Connection>> exitConnection; // index of the exiting connection
     int exitConnectionTransferTravelTime;
   };
 

--- a/src/transit_data.cpp
+++ b/src/transit_data.cpp
@@ -221,22 +221,18 @@ namespace TrRouting {
       calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
 
       // assign connections to trips:
-      int i {0};
       for(auto & connection : forwardConnections)
       {
         //TODO This require a trip to be modified, we might want to revisit how to create Connection and Trip (#201)
         Trip & trip = connection->getTripMutable();
-        trip.forwardConnectionsIdx.push_back(i);
-        i++;
+        trip.forwardConnections.push_back(connection);
       }
 
-      i = 0;
       for(auto & connection : reverseConnections)
       {
         //TODO This require a trip to be modified, we might want to revisit how to create Connection and Trip (#201)
         Trip & trip = connection->getTripMutable();
-        trip.reverseConnectionsIdx.push_back(i);
-        i++;
+        trip.reverseConnections.push_back(connection);
       }
 
       spdlog::debug("-- assign connections to trips -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);

--- a/src/transit_data.cpp
+++ b/src/transit_data.cpp
@@ -135,9 +135,12 @@ namespace TrRouting {
     return generateForwardAndReverseConnections(connections);
   }
 
+  const int CONNECTION_ITERATOR_CACHE_BEGIN_HOUR = 0;
+  const int CONNECTION_ITERATOR_CACHE_END_HOUR = 32;
+
   std::vector<std::shared_ptr<Connection>>::const_iterator TransitData::getForwardConnectionsBeginAtDepartureHour(int hour) const
   {
-    if (hour > 32 || hour  < 0) {
+    if (hour > CONNECTION_ITERATOR_CACHE_END_HOUR || hour  < CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
       return forwardConnections.cend();
     }
 
@@ -146,7 +149,7 @@ namespace TrRouting {
 
   std::vector<std::shared_ptr<Connection>>::const_iterator TransitData::getReverseConnectionsBeginAtArrivalHour(int hour) const
   {
-    if (hour > 32 || hour  < 0) {
+    if (hour > CONNECTION_ITERATOR_CACHE_END_HOUR || hour  < CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
       return reverseConnections.cend();
     }
 
@@ -155,31 +158,40 @@ namespace TrRouting {
 
   // Create a cache with a begin iterator which match the connection closest to the specified hour
   void TransitData::generateConnectionsIteratorCache() {
-    int currentHour = 0;
+    int currentHour = CONNECTION_ITERATOR_CACHE_BEGIN_HOUR;
+
+    // Create first part of the forward cache
+    // For each hour, we save the iterator matching the connection which as a departure time bigger
+    // than this hour
     for (std::vector<std::shared_ptr<Connection>>::const_iterator ite = forwardConnections.cbegin();
          ite != forwardConnections.cend();
          ite++) {
+      // We can have a gap of multiple hours between 2 connections, so the current iterator
+      // can be valid for multiple hour slots
       while ((*ite)->getDepartureTime() >= currentHour * 3600) {
-        //forwardConnectionsBeginIteratorCache[currentHour] = ite;
         forwardConnectionsBeginIteratorCache.push_back(ite);
         currentHour++;
       }
     }
+
     //Finish filling forward cache
-    for (;currentHour < 32; currentHour++) {
+    //We reached the end of the forwardConnections in the previously, so here we
+    //fill the rest of the forward cache with end iterator
+    for (;currentHour < CONNECTION_ITERATOR_CACHE_END_HOUR; currentHour++) {
       forwardConnectionsBeginIteratorCache.push_back(forwardConnections.cend());
     }
 
-    currentHour = 31;
+    // Create the reverse cache
+    currentHour = CONNECTION_ITERATOR_CACHE_END_HOUR - 1;
     for (std::vector<std::shared_ptr<Connection>>::const_iterator ite = reverseConnections.cbegin();
          ite != reverseConnections.cend();
          ite++) {
-      while ((*ite)->getArrivalTime() <= currentHour * 3600 && currentHour > 0) {
-        //forwardConnectionsBeginIteratorCache[currentHour] = ite;
+      // Fill cache with same iterator if we have multi hour gap between connection
+      while ((*ite)->getArrivalTime() <= currentHour * 3600 && currentHour > CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
         reverseConnectionsBeginIteratorCache.insert(reverseConnectionsBeginIteratorCache.begin(),ite);
         currentHour--;
       }
-    }    
+    }
   }
 
   int TransitData::generateForwardAndReverseConnections(const std::vector<std::shared_ptr<Connection>> &connections)

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -25,7 +25,7 @@ namespace TrRouting
     const std::map<boost::uuids::uuid, Line>& lines,
     std::map<boost::uuids::uuid, Path>& paths,
     const std::map<boost::uuids::uuid, Service>& services,
-    std::vector<std::shared_ptr<ConnectionTuple>>& connections,
+    std::vector<std::shared_ptr<Connection>>& connections,
     std::string customPath
   )
   {
@@ -101,14 +101,14 @@ namespace TrRouting
               // nodeTimesCount - 1, since we process node pairs, we have to stop and the second from last
               for (unsigned long nodeTimeI = 0; nodeTimeI < nodeTimesCount - 1; nodeTimeI++)
               {
-                  std::shared_ptr<ConnectionTuple> forwardConnection(std::make_shared<ConnectionTuple>(ConnectionTuple(
-                    path.nodesRef[nodeTimeI],
-                    path.nodesRef[nodeTimeI + 1],
+                  std::shared_ptr<Connection> forwardConnection(std::make_shared<Connection>(Connection(
+                    path.nodesRef[nodeTimeI].get(),
+                    path.nodesRef[nodeTimeI + 1].get(),
                     departureTimesSeconds[nodeTimeI],
                     arrivalTimesSeconds[nodeTimeI + 1],
                     trip,
-                    canBoards[nodeTimeI],
-                    canUnboards[nodeTimeI + 1],
+                    canBoards[nodeTimeI] == 1,
+                    canUnboards[nodeTimeI + 1] == 1,
                     nodeTimeI + 1,
                     trip.allowSameLineTransfers,
                     line.mode.shortname == Mode::TRANSFERABLE ? 0 : -1

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -20,7 +20,7 @@ protected:
     std::map<boost::uuids::uuid, TrRouting::Node> nodes;
     std::map<boost::uuids::uuid, int> tripIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
-    std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> connections;
+    std::vector<std::shared_ptr<TrRouting::Connection>> connections;
 
 public:
     void SetUp( ) override

--- a/tests/connection_scan_algorithm/csa_test_base.cpp
+++ b/tests/connection_scan_algorithm/csa_test_base.cpp
@@ -48,8 +48,6 @@ void BaseCsaFixtureTests::SetUp() {
     // Enable full debug output in the test runs
     spdlog::set_level(spdlog::level::debug);
 
-    std::vector<std::shared_ptr<TrRouting::ConnectionTuple>> connections;
-
     calculator.initializeCalculationData();
 }
 
@@ -73,8 +71,7 @@ void BaseCsaFixtureTests::assertSuccessResults(TrRouting::RoutingResult& result,
     ASSERT_EQ(TrRouting::result_type::SINGLE_CALCULATION, result.resType);
     TrRouting::SingleCalculationResult& routingResult = dynamic_cast<TrRouting::SingleCalculationResult&>(result);
     ASSERT_LE(origDepartureTime, routingResult.departureTime);
-    ASSERT_EQ(expInVehicleTravelTime + expAccessTime + expEgressTime + expTotalWaitingTime + expTransferTravelTime, routingResult.totalTravelTime);
-    ASSERT_EQ(expTransitDepartureTime + expInVehicleTravelTime + expEgressTime + (expTotalWaitingTime - minWaitingTime) + expTransferTravelTime, routingResult.arrivalTime);
+
     ASSERT_EQ(expTransitDepartureTime - expAccessTime - minWaitingTime, routingResult.departureTime);
     ASSERT_EQ(expNbTransfers, routingResult.numberOfTransfers);
     ASSERT_EQ(expInVehicleTravelTime, routingResult.totalInVehicleTime);
@@ -84,5 +81,8 @@ void BaseCsaFixtureTests::assertSuccessResults(TrRouting::RoutingResult& result,
     ASSERT_EQ(expEgressTime, routingResult.egressTravelTime);
     ASSERT_EQ(expTransferWaitingTime, routingResult.transferWaitingTime);
     ASSERT_EQ(minWaitingTime, routingResult.firstWaitingTime);
+    // Test total at the end, so we assert individual value first. (To ease debugging)
     ASSERT_EQ(expAccessTime + expEgressTime + expTransferTravelTime, routingResult.totalNonTransitTravelTime);
+    ASSERT_EQ(expInVehicleTravelTime + expAccessTime + expEgressTime + expTotalWaitingTime + expTransferTravelTime, routingResult.totalTravelTime);
+    ASSERT_EQ(expTransitDepartureTime + expInVehicleTravelTime + expEgressTime + (expTotalWaitingTime - minWaitingTime) + expTransferTravelTime, routingResult.arrivalTime);
 }

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
@@ -317,21 +317,21 @@ int TestDataFetcher::getScenarios(
 
 
 
-void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<std::shared_ptr<TrRouting::ConnectionTuple>>& connections, int arrivalTimes[], int departureTimes[], int arraySize)
+void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<std::shared_ptr<TrRouting::Connection>>& connections, int arrivalTimes[], int departureTimes[], int arraySize)
 {
     path.tripsRef.push_back(trip);
 
     trip.connectionDepartureTimes.resize(arraySize);
 
     for (int nodeTimeI = 0; nodeTimeI < arraySize - 1; nodeTimeI++) {
-      std::shared_ptr<TrRouting::ConnectionTuple> forwardConnection(std::make_shared<TrRouting::ConnectionTuple>(TrRouting::ConnectionTuple(
+      std::shared_ptr<TrRouting::Connection> forwardConnection(std::make_shared<TrRouting::Connection>(TrRouting::Connection(
             path.nodesRef[nodeTimeI],
             path.nodesRef[nodeTimeI + 1],
             departureTimes[nodeTimeI],
             arrivalTimes[nodeTimeI + 1],
             trip,
-            1,
-            1,
+            true,
+            true,
             nodeTimeI + 1,
             trip.allowSameLineTransfers,
             -1
@@ -354,7 +354,7 @@ int TestDataFetcher::getSchedules(
                                   const std::map<boost::uuids::uuid, TrRouting::Line>& lines,
                                   std::map<boost::uuids::uuid, TrRouting::Path>& paths,
                                   const std::map<boost::uuids::uuid, TrRouting::Service>& services,
-                                  std::vector<std::shared_ptr<TrRouting::ConnectionTuple>>& connections,
+                                  std::vector<std::shared_ptr<TrRouting::Connection>>& connections,
                                   std::string
                                   ) {
 

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.hpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.hpp
@@ -138,7 +138,7 @@ class TestDataFetcher : public TrRouting::DataFetcher
       const std::map<boost::uuids::uuid, TrRouting::Line>& lines,
       std::map<boost::uuids::uuid, TrRouting::Path>& paths,
       const std::map<boost::uuids::uuid, TrRouting::Service>& services,
-      std::vector<std::shared_ptr<TrRouting::ConnectionTuple>>& connections,
+      std::vector<std::shared_ptr<TrRouting::Connection>>& connections,
       std::string customPath = ""
     );
         


### PR DESCRIPTION
We create an actual Connection class instead of relying on a tuple. We migrate some usage to use a reference instead of a vector index. 

For the moment we still use a shared_ptr for the Connection, but we could later migrate them directly to references. 