### PR TITLE
result: Keep the Node object in the AccessibleNode result

### DIFF
--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -311,7 +311,7 @@ namespace TrRouting
           reachableNodesCount++;
 
           AccessibleNodes node = AccessibleNodes(
-                                                 resultingNode.uuid,
+                                                 resultingNode,
                                                  arrivalTime,
                                                  arrivalTime - departureTimeSeconds,
                                                  numberOfTransfers
@@ -324,8 +324,7 @@ namespace TrRouting
     spdlog::debug("-- forward result: allNodes ");
 
     allNodesResult.get()->numberOfReachableNodes = reachableNodesCount;
-    // Get a number with 2 decimals. FIXME: Let the formatting be done at another level?
-    allNodesResult.get()->percentOfReachableNodes = round(10000 * (float)reachableNodesCount / (float)(nodesCount))/100.0;
+    allNodesResult.get()->totalNodeCount = nodesCount;
     return allNodesResult;
   }
 }

--- a/connection_scan_algorithm/src/result_to_v1.cpp
+++ b/connection_scan_algorithm/src/result_to_v1.cpp
@@ -201,7 +201,7 @@ namespace TrRouting
     json["nodes"] = nlohmann::json::array();
     for (auto &node : result.nodes) {
       nlohmann::json nodeJson;
-      nodeJson["id"]                     = boost::uuids::to_string(node.nodeUuid);
+      nodeJson["id"]                     = boost::uuids::to_string(node.node.uuid);
       nodeJson["arrivalTime"]            = Toolbox::convertSecondsToFormattedTime(node.arrivalTime);
       nodeJson["arrivalTimeSeconds"]     = node.arrivalTime;
       nodeJson["totalTravelTimeSeconds"] = node.totalTravelTime;
@@ -209,7 +209,8 @@ namespace TrRouting
       json["nodes"].push_back(nodeJson);
     }
     json["numberOfReachableNodes"] = result.numberOfReachableNodes;
-    json["percentOfReachableNodes"] = result.percentOfReachableNodes;
+    // Get a number with 2 decimals.
+    json["percentOfReachableNodes"] = round(10000 * (float)(result.numberOfReachableNodes) / (float)(result.totalNodeCount))/100.0;
     response = json;
   }
 

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -335,7 +335,7 @@ namespace TrRouting
           reachableNodesCount++;
 
           AccessibleNodes node = AccessibleNodes(
-                                                 resultingNode.uuid,
+                                                 resultingNode,
                                                  arrivalTimeSeconds,
                                                  arrivalTimeSeconds - departureTimeD,
                                                  numberOfTransfers
@@ -346,8 +346,7 @@ namespace TrRouting
     }
 
     allNodesResult.get()->numberOfReachableNodes = reachableNodesCount;
-    // Get a number with 2 decimals. FIXME: Let the formatting be done at another level?
-    allNodesResult.get()->percentOfReachableNodes = round(10000 * (float)reachableNodesCount / (float)(nodesCount))/100.0;
+    allNodesResult.get()->totalNodeCount = nodesCount;
     return allNodesResult;
   }
 }

--- a/include/routing_result.hpp
+++ b/include/routing_result.hpp
@@ -224,15 +224,15 @@ namespace TrRouting
    */
   class AccessibleNodes {
   public:
-    boost::uuids::uuid nodeUuid;
+    const Node & node;
     int arrivalTime;
     int totalTravelTime;
     int numberOfTransfers;
-    AccessibleNodes(boost::uuids::uuid _uuid,
+    AccessibleNodes(const Node & _node,
       int _arrivalTime,
       int _totalTravelTime,
       int _numberOfTransfers
-    ): nodeUuid(_uuid),
+    ): node(_node),
       arrivalTime(_arrivalTime),
       totalTravelTime(_totalTravelTime),
       numberOfTransfers(_numberOfTransfers)
@@ -247,7 +247,7 @@ namespace TrRouting
   public:
     std::vector<AccessibleNodes> nodes;
     int numberOfReachableNodes;
-    float percentOfReachableNodes;
+    int totalNodeCount;
     AllNodesResult(): RoutingResult(result_type::ALL_NODES) {}
     void do_accept(ResultVisitorBase &visitor) const override {
       return visitor.visitAllNodesResult(*this);

--- a/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
@@ -129,21 +129,18 @@ TEST_F(ResultToV1FixtureTest, TestAlternativesResult)
 
 TEST_F(ResultToV1FixtureTest, TestAllNodesResult)
 {
-    std::string node1Uuid = "aaaaaaaa-5555-cccc-dddd-eeeeeeffffff";
-    std::string node2Uuid = "aaaaaaaa-6666-cccc-dddd-eeeeeeffffff";
-
     // Prepare the result, we test the conversion, the result doesn't have to make sense
     TrRouting::AllNodesResult result = TrRouting::AllNodesResult();
     result.numberOfReachableNodes = 2;
-    result.percentOfReachableNodes = 0.3;
+    result.totalNodeCount = 4;
     TrRouting::AccessibleNodes node1Result = TrRouting::AccessibleNodes(
-        uuidGenerator(node1Uuid),
+        *boardingNode,
         9 * 60 * 60,
         2000,
         2
     );
     TrRouting::AccessibleNodes node2Result = TrRouting::AccessibleNodes(
-        uuidGenerator(node2Uuid),
+        *unboardingNode,
         9 * 60 * 60 + 5 * 60,
         2100,
         1
@@ -156,17 +153,17 @@ TEST_F(ResultToV1FixtureTest, TestAllNodesResult)
 
     ASSERT_EQ(STATUS_SUCCESS, jsonResponse["status"]);
     ASSERT_EQ(result.numberOfReachableNodes, jsonResponse["numberOfReachableNodes"]);
-    ASSERT_EQ(result.percentOfReachableNodes, jsonResponse["percentOfReachableNodes"]);
+    ASSERT_EQ(50.0, jsonResponse["percentOfReachableNodes"]);
     ASSERT_EQ(result.numberOfReachableNodes, jsonResponse["nodes"].size());
 
     // Test the individual nodes
-    ASSERT_EQ(node1Uuid, jsonResponse["nodes"][0]["id"]);
+    ASSERT_EQ(boardingNodeUuid, jsonResponse["nodes"][0]["id"]);
     ASSERT_EQ(TrRouting::Toolbox::convertSecondsToFormattedTime(node1Result.arrivalTime), jsonResponse["nodes"][0]["arrivalTime"]);
     ASSERT_EQ(node1Result.arrivalTime, jsonResponse["nodes"][0]["arrivalTimeSeconds"]);
     ASSERT_EQ(node1Result.totalTravelTime, jsonResponse["nodes"][0]["totalTravelTimeSeconds"]);
     ASSERT_EQ(node1Result.numberOfTransfers, jsonResponse["nodes"][0]["numberOfTransfers"]);
 
-    ASSERT_EQ(node2Uuid, jsonResponse["nodes"][1]["id"]);
+    ASSERT_EQ(unboardingNodeUuid, jsonResponse["nodes"][1]["id"]);
     ASSERT_EQ(TrRouting::Toolbox::convertSecondsToFormattedTime(node2Result.arrivalTime), jsonResponse["nodes"][1]["arrivalTime"]);
     ASSERT_EQ(node2Result.arrivalTime, jsonResponse["nodes"][1]["arrivalTimeSeconds"]);
     ASSERT_EQ(node2Result.totalTravelTime, jsonResponse["nodes"][1]["totalTravelTimeSeconds"]);


### PR DESCRIPTION
Instead of only the uuid, the whole Node object is kept, so the name and code can also be part of the returned values.

Also, format the accessible node percentage at the result generation level instead of in the calculation.