### PR TITLE
v2: Remove "Meters" suffix for distances in the route return types

### DIFF
--- a/connection_scan_algorithm/src/result_to_v2.cpp
+++ b/connection_scan_algorithm/src/result_to_v2.cpp
@@ -97,7 +97,7 @@ namespace TrRouting
     stepJson["nodeCoordinates"] = {step.node.point->longitude, step.node.point->latitude};
     stepJson["arrivalTime"] = step.arrivalTime;
     stepJson["inVehicleTime"] = step.inVehicleTime;
-    stepJson["inVehicleDistanceMeters"] = step.inVehicleDistanceMeters;
+    stepJson["inVehicleDistance"] = step.inVehicleDistanceMeters;
     response = stepJson;
   }
 
@@ -107,7 +107,7 @@ namespace TrRouting
     stepJson["action"] = "walking";
     stepJson["type"] = step.walkingType == walking_step_type::ACCESS ? "access" : step.walkingType == walking_step_type::EGRESS ? "egress" : "transfer";
     stepJson["travelTime"] = step.travelTime;
-    stepJson["distanceMeters"] = step.distanceMeters;
+    stepJson["distance"] = step.distanceMeters;
     stepJson["departureTime"] = step.departureTime;
     stepJson["arrivalTime"] = step.arrivalTime;
     if (step.walkingType != walking_step_type::EGRESS) {
@@ -127,19 +127,19 @@ namespace TrRouting
     json["departureTime"] = result.departureTime;
     json["arrivalTime"] = result.arrivalTime;
     json["totalTravelTime"] = result.totalTravelTime;
-    json["totalDistanceMeters"] = result.totalDistance;
+    json["totalDistance"] = result.totalDistance;
     json["totalInVehicleTime"] = result.totalInVehicleTime;
-    json["totalInVehicleDistanceMeters"] = result.totalInVehicleDistance;
+    json["totalInVehicleDistance"] = result.totalInVehicleDistance;
     json["totalNonTransitTravelTime"] = result.totalNonTransitTravelTime;
-    json["totalNonTransitDistanceMeters"] = result.totalNonTransitDistance;
+    json["totalNonTransitDistance"] = result.totalNonTransitDistance;
     json["numberOfBoardings"] = result.numberOfBoardings;
     json["numberOfTransfers"] = result.numberOfTransfers;
     json["transferWalkingTime"] = result.transferWalkingTime;
-    json["transferWalkingDistanceMeters"] = result.transferWalkingDistance;
+    json["transferWalkingDistance"] = result.transferWalkingDistance;
     json["accessTravelTime"] = result.accessTravelTime;
-    json["accessDistanceMeters"] = result.accessDistance;
+    json["accessDistance"] = result.accessDistance;
     json["egressTravelTime"] = result.egressTravelTime;
-    json["egressDistanceMeters"] = result.egressDistance;
+    json["egressDistance"] = result.egressDistance;
     json["transferWaitingTime"] = result.transferWaitingTime;
     json["firstWaitingTime"] = result.firstWaitingTime;
     json["totalWaitingTime"] = result.totalWaitingTime;

--- a/docs/APIv2/routeResponse.yml
+++ b/docs/APIv2/routeResponse.yml
@@ -83,19 +83,19 @@ routeResponse:
         totalTravelTime:
           type: number
           description: Total travel time, from the optimized departure time to the arrival time, in seconds
-        totalDistanceMeters:
+        totalDistance:
           type: number
           description: Total distance traveled, from departure to arrival
         totalInVehicleTime:
           type: number
           description: Total time spent in a transit vehicle, in seconds
-        totalInVehicleDistanceMeters:
+        totalInVehicleDistance:
           type: number
           description: Total distance traveled in a vehicle, in meters
         totalNonTransitTravelTime:
           type: number
           description: Total time spent traveling, but not in a transit vehicle. This excludes waiting time. In seconds
-        totalNonTransitDistanceMeters:
+        totalNonTransitDistance:
           type: number
           description: Total distance traveled not in a vehicle, in meters
         numberOfBoardings:
@@ -107,19 +107,19 @@ routeResponse:
         transferWalkingTime:
           type: number
           description: Time spent walking to transfer from a transit route to another transit route, in seconds
-        transferWalkingDistanceMeters:
+        transferWalkingDistance:
           type: number
           description: Distance traveled to transfer between transit trips, in meters
         accessTravelTime:
           type: number
           description: Time spent traveling to access the first transit stop of the trip, in seconds
-        accessDistanceMeters:
+        accessDistance:
           type: number
           description: Distance traveled to access the first transit stop of the trip, in meters
         egressTravelTime:
           type: number
           description: Time spent traveling from the last transit stop of the trip, to the destination, in seconds
-        egressDistanceMeters:
+        egressDistance:
           type: number
           description: Distance traveled from the last transit stop of the trip to the destination, in meters
         transferWaitingTime:
@@ -185,7 +185,7 @@ tripStepWalkingBase:
     travelTime:
       type: number
       description: Time spent walking in this step, in seconds
-    distanceMeters:
+    distance:
       type: number
       description: Distance traveled in this step, in meters
     departureTime:
@@ -309,6 +309,6 @@ tripStepUnboarding: # 'unboarding' is a value for the action (discriminator)
         inVehicleTime:
           type: number
           description: Time spent in the vehicle, in seconds
-        inVehicleDistanceMeters:
+        inVehicleDistance:
           type: number
           description: Distance covered in the vehicle, in meters

--- a/tests/connection_scan_algorithm/csa_result_to_v2_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v2_test.cpp
@@ -99,19 +99,19 @@ void ResultToV2FixtureTest::assertResultConversion(nlohmann::json jsonResponse, 
     ASSERT_EQ(result.departureTime, jsonResponse["departureTime"]);
     ASSERT_EQ(result.arrivalTime, jsonResponse["arrivalTime"]);
     ASSERT_EQ(result.totalTravelTime, jsonResponse["totalTravelTime"]);
-    ASSERT_EQ(result.totalDistance, jsonResponse["totalDistanceMeters"]);
+    ASSERT_EQ(result.totalDistance, jsonResponse["totalDistance"]);
     ASSERT_EQ(result.totalInVehicleTime, jsonResponse["totalInVehicleTime"]);
-    ASSERT_EQ(result.totalInVehicleDistance, jsonResponse["totalInVehicleDistanceMeters"]);
+    ASSERT_EQ(result.totalInVehicleDistance, jsonResponse["totalInVehicleDistance"]);
     ASSERT_EQ(result.totalNonTransitTravelTime, jsonResponse["totalNonTransitTravelTime"]);
-    ASSERT_EQ(result.totalNonTransitDistance, jsonResponse["totalNonTransitDistanceMeters"]);
+    ASSERT_EQ(result.totalNonTransitDistance, jsonResponse["totalNonTransitDistance"]);
     ASSERT_EQ(result.numberOfBoardings, jsonResponse["numberOfBoardings"]);
     ASSERT_EQ(result.numberOfTransfers, jsonResponse["numberOfTransfers"]);
     ASSERT_EQ(result.transferWalkingTime, jsonResponse["transferWalkingTime"]);
-    ASSERT_EQ(result.transferWalkingDistance, jsonResponse["transferWalkingDistanceMeters"]);
+    ASSERT_EQ(result.transferWalkingDistance, jsonResponse["transferWalkingDistance"]);
     ASSERT_EQ(result.accessTravelTime, jsonResponse["accessTravelTime"]);
-    ASSERT_EQ(result.accessDistance, jsonResponse["accessDistanceMeters"]);
+    ASSERT_EQ(result.accessDistance, jsonResponse["accessDistance"]);
     ASSERT_EQ(result.egressTravelTime, jsonResponse["egressTravelTime"]);
-    ASSERT_EQ(result.egressDistance, jsonResponse["egressDistanceMeters"]);
+    ASSERT_EQ(result.egressDistance, jsonResponse["egressDistance"]);
     ASSERT_EQ(result.transferWaitingTime, jsonResponse["transferWaitingTime"]);
     ASSERT_EQ(result.firstWaitingTime, jsonResponse["firstWaitingTime"]);
     ASSERT_EQ(result.totalWaitingTime, jsonResponse["totalWaitingTime"]);
@@ -121,7 +121,7 @@ void ResultToV2FixtureTest::assertResultConversion(nlohmann::json jsonResponse, 
     ASSERT_EQ("walking", jsonResponse["steps"][0]["action"]);
     ASSERT_EQ("access", jsonResponse["steps"][0]["type"]);
     ASSERT_EQ(walkingStep.travelTime, jsonResponse["steps"][0]["travelTime"]);
-    ASSERT_EQ(walkingStep.distanceMeters, jsonResponse["steps"][0]["distanceMeters"]);
+    ASSERT_EQ(walkingStep.distanceMeters, jsonResponse["steps"][0]["distance"]);
     ASSERT_EQ(walkingStep.departureTime, jsonResponse["steps"][0]["departureTime"]);
     ASSERT_EQ(walkingStep.arrivalTime, jsonResponse["steps"][0]["arrivalTime"]);
     ASSERT_EQ(walkingStep.readyToBoardAt, jsonResponse["steps"][0]["readyToBoardAt"]);
@@ -171,5 +171,5 @@ void ResultToV2FixtureTest::assertResultConversion(nlohmann::json jsonResponse, 
     ASSERT_EQ(unboardingNodePoint.latitude, jsonResponse["steps"][2]["nodeCoordinates"][1]);
     ASSERT_EQ(unboardingStep.arrivalTime, jsonResponse["steps"][2]["arrivalTime"]);
     ASSERT_EQ(unboardingStep.inVehicleTime, jsonResponse["steps"][2]["inVehicleTime"]);
-    ASSERT_EQ(unboardingStep.inVehicleDistanceMeters, jsonResponse["steps"][2]["inVehicleDistanceMeters"]);
+    ASSERT_EQ(unboardingStep.inVehicleDistanceMeters, jsonResponse["steps"][2]["inVehicleDistance"]);
 }


### PR DESCRIPTION
It is documented that the values are in meters. The "Seconds" suffix was already dropped from the time fields. For consistency, the Meters suffix is not necessary.

And do not repeat the success status and base parameters for each alternatives. This requires splitting the API return types for routes in smaller object types that can be reused in the alternatives.