### PR TITLE
Add index.html page for redoc page documenting the v2 API

### DIFF
--- a/docs/APIv2/index.html
+++ b/docs/APIv2/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TrRouting API v2</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='https://raw.githubusercontent.com/chairemobilite/trRouting/v2c/docs/APIv2/API.yml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TrRouting Documentation documentation</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="APIv2/index.html">API v2 documentation</a>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #222

This will create a formatted web page for the v2 API documentation.