### PR TITLE
csaTest: Remove the assertResultConversion from base class

### DIFF
--- a/tests/connection_scan_algorithm/csa_result_to_response_test.hpp
+++ b/tests/connection_scan_algorithm/csa_result_to_response_test.hpp
@@ -50,9 +50,7 @@ protected:
     std::unique_ptr<TrRouting::Node> boardingNode;
     std::unique_ptr<TrRouting::Node> unboardingNode;
 
-
     std::unique_ptr<TrRouting::SingleCalculationResult> getSingleResult();
-    virtual void assertResultConversion(nlohmann::json jsonResponse, TrRouting::SingleCalculationResult &result, TrRouting::RouteParameters &params) = 0;
 
 public:
     void SetUp();

--- a/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v1_test.cpp
@@ -17,7 +17,7 @@
 class ResultToV1FixtureTest : public ResultToResponseFixtureTest
 {
 protected:
-    void assertResultConversion(nlohmann::json jsonResponse, TrRouting::SingleCalculationResult &result, TrRouting::RouteParameters &params) override;
+    void assertResultConversion(nlohmann::json jsonResponse, TrRouting::SingleCalculationResult &result, TrRouting::RouteParameters &params);
 
 public:
 };

--- a/tests/connection_scan_algorithm/csa_result_to_v2_summary_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v2_summary_test.cpp
@@ -10,7 +10,6 @@
 class ResultToV2SummaryFixtureTest : public ResultToResponseFixtureTest
 {
 protected:
-    void assertResultConversion(nlohmann::json jsonResponse, TrRouting::SingleCalculationResult &result, TrRouting::RouteParameters &params) override;
     void assertResultConversion(nlohmann::json jsonResponse, TrRouting::BoardingStep& boardingStep, int count, TrRouting::RouteParameters &params);
 
 public:
@@ -87,8 +86,3 @@ void ResultToV2SummaryFixtureTest::assertResultConversion(nlohmann::json jsonRes
     ASSERT_EQ(lineUuid, jsonResponse["result"]["lines"][0]["lineUuid"]);
    
 }
-
-void ResultToV2SummaryFixtureTest::assertResultConversion(nlohmann::json , TrRouting::SingleCalculationResult &, TrRouting::RouteParameters &) {
-    // Not called by this test
-}
-

--- a/tests/connection_scan_algorithm/csa_result_to_v2_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v2_test.cpp
@@ -10,7 +10,7 @@
 class ResultToV2FixtureTest : public ResultToResponseFixtureTest
 {
 protected:
-    void assertResultConversion(nlohmann::json jsonResponse, TrRouting::SingleCalculationResult &result, TrRouting::RouteParameters &params) override;
+    void assertResultConversion(nlohmann::json jsonResponse, TrRouting::SingleCalculationResult &result, TrRouting::RouteParameters &params);
 
 public:
 


### PR DESCRIPTION
This function is implemented for each test and the result class of the parameter is not the same for each case. The `summary` test was already implementing an empty function for this one and adding its own local implementation. Each test class should just implement what it needs instead.