### PR TITLE
Add a workaround to have github actions build work on MacOS

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,6 +26,8 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: |
           brew update
+          # Temporary Workaround for conflict with multiple python in brew
+          brew install --overwrite python@3.11 python@3.10
           brew install autoconf automake libtool
           brew install boost
           brew install capnp


### PR DESCRIPTION
There's a conflict in Homebrew with multiple python trying to install the same symlink. This workaround force install both python and it ignore the symlink error. (The error was for 2to3, so now important in our use case)