### PR TITLE
performance: Cache connections by scenario

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -39,6 +39,7 @@ namespace TrRouting
   class AllNodesResult;
   class AlternativesResult;
   class TransitData;
+  class ConnectionSet;
   class Point;
 
   class Calculator {
@@ -116,6 +117,8 @@ namespace TrRouting
 
     std::unordered_map<Trip::uid_t, bool> tripsEnabled;
     std::unordered_map<Trip::uid_t, TripQueryData> tripsQueryOverlay; // Store addition trip info during a query processing
+    // A subset of the connections that are used for the current query.
+    std::shared_ptr<ConnectionSet> connectionSet;
 
     std::vector<NodeTimeDistance> accessFootpaths; // pair: accessNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters
     std::vector<NodeTimeDistance> egressFootpaths; // pair: egressNodeIndex, walkingTravelTimeSeconds, walkingDistanceMeters

--- a/connection_scan_algorithm/include/journey_step.hpp
+++ b/connection_scan_algorithm/include/journey_step.hpp
@@ -10,8 +10,8 @@ namespace TrRouting {
   //each of the step types. See issue #209
   class JourneyStep {
   public:
-    JourneyStep(std::optional<std::shared_ptr<Connection>> _finalEnterConnection,
-                std::optional<std::shared_ptr<Connection>> _finalExitConnection,
+    JourneyStep(std::optional<std::reference_wrapper<const Connection>> _finalEnterConnection,
+                std::optional<std::reference_wrapper<const Connection>> _finalExitConnection,
                 std::optional<std::reference_wrapper<const Trip>> _finalTrip,
                 int _transferTravelTime,
                 bool _sameNodeTransfer,
@@ -23,8 +23,8 @@ namespace TrRouting {
                                          transferDistance(_transferDistance) { }
 
     //TODO Why is there Final in the function name. Is that appropriate?
-    std::optional<std::shared_ptr<Connection>> getFinalEnterConnection() const {return finalEnterConnection;}
-    std::optional<std::shared_ptr<Connection>> getFinalExitConnection() const {return finalExitConnection;}
+    std::optional<std::reference_wrapper<const Connection>> getFinalEnterConnection() const {return finalEnterConnection;}
+    std::optional<std::reference_wrapper<const Connection>> getFinalExitConnection() const {return finalExitConnection;}
     std::optional<std::reference_wrapper<const Trip>> getFinalTrip() const {return finalTrip;}
     //TODO: Comment from @tahini.
     // So walking is tranferring in a transfer step, but walking is just walking in an access/egress step.
@@ -38,10 +38,10 @@ namespace TrRouting {
 
     //TODO Setting connections midway should also affected other parameters automatically
     // Their usage in the optimise function should be reviewed (Maybe in conjunction with #209)
-    void setFinalEnterConnection(std::shared_ptr<Connection> _connection) {
+    void setFinalEnterConnection(const Connection&  _connection) {
       finalEnterConnection = _connection;
     }
-    void setFinalExitConnection(std::shared_ptr<Connection> _connection) {
+    void setFinalExitConnection(const Connection& _connection) {
       finalExitConnection = _connection;
     }
 
@@ -61,8 +61,8 @@ namespace TrRouting {
     // If we have type of each step type, maybe this would be needed. #209
     bool hasConnections() const {return finalEnterConnection.has_value() && finalExitConnection.has_value();}
   private:
-    std::optional<std::shared_ptr<Connection>> finalEnterConnection;
-    std::optional<std::shared_ptr<Connection>> finalExitConnection;
+    std::optional<std::reference_wrapper<const Connection>> finalEnterConnection;
+    std::optional<std::reference_wrapper<const Connection>> finalExitConnection;
     std::optional<std::reference_wrapper<const Trip>> finalTrip;
     int transferTravelTime;
     bool sameNodeTransfer;

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -64,7 +64,7 @@ namespace TrRouting
           {
             break;
           }
-          std::optional<std::shared_ptr<Connection>> tripEnterConnection = currentTripQueryOverlay.enterConnection;
+          std::optional<std::reference_wrapper<const Connection>> tripEnterConnection = currentTripQueryOverlay.enterConnection;
           const Node &nodeDeparture = (**connection).getDepartureNode();
 
           // Extract node departure time if we have a result or set a default value
@@ -100,7 +100,7 @@ namespace TrRouting
             if ((**connection).canBoard() && (!tripEnterConnection.has_value()) )
             {
               currentTripQueryOverlay.usable = true;
-              currentTripQueryOverlay.enterConnection = *connection;
+              currentTripQueryOverlay.enterConnection = **connection;
               currentTripQueryOverlay.enterConnectionTransferTravelTime = forwardJourneysSteps.at(nodeDeparture.uid).getTransferTravelTime();
             }
             
@@ -146,7 +146,7 @@ namespace TrRouting
                     nodesTentativeTime[transferableNode.node.uid] = footpathTravelTime + connectionArrivalTime;
 
                     //TODO DO we need a make_optional here??
-                    forwardJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, *connection, std::cref(trip), footpathTravelTime, (nodeArrival == transferableNode.node), footpathDistance));
+                    forwardJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, **connection, std::cref(trip), footpathTravelTime, (nodeArrival == transferableNode.node), footpathDistance));
                   }
 
                   if (
@@ -156,12 +156,12 @@ namespace TrRouting
                      //TODO Not fully sure this is equivalent to the ancient code
                      forwardEgressJourneysSteps.count(transferableNode.node.uid) == 0
                       ||
-                     forwardEgressJourneysSteps.at(transferableNode.node.uid).getFinalExitConnection().value()->getArrivalTime() > connectionArrivalTime
+                     forwardEgressJourneysSteps.at(transferableNode.node.uid).getFinalExitConnection().value().get().getArrivalTime() > connectionArrivalTime
                     )
                   )
                   {
                     footpathDistance = nodeArrival.transferableNodes[footpathIndex].distance;
-                    forwardEgressJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, *connection, std::cref(trip), footpathTravelTime, true, footpathDistance));
+                    forwardEgressJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, **connection, std::cref(trip), footpathTravelTime, true, footpathDistance));
                   }
                 }
                 footpathIndex++;
@@ -180,7 +180,7 @@ namespace TrRouting
     }
 
     int egressNodeArrivalTime {-1};
-    std::optional<std::shared_ptr<Connection>> egressExitConnection;
+    std::optional<std::reference_wrapper<const Connection>> egressExitConnection;
     // find best egress node:
 
     std::optional<std::reference_wrapper<const NodeTimeDistance>> bestEgress;
@@ -193,7 +193,7 @@ namespace TrRouting
         if (egressExitConnection.has_value())
         {
           const NodeTimeDistance &egress = nodesEgress.at(egressFootpath.node.uid);
-          egressNodeArrivalTime = egressExitConnection.value()->getArrivalTime() + egress.time;
+          egressNodeArrivalTime = egressExitConnection.value().get().getArrivalTime() + egress.time;
 
           if (egressNodeArrivalTime >= 0 && egressNodeArrivalTime - departureTimeSeconds <= parameters.getMaxTotalTravelTimeSeconds() && egressNodeArrivalTime < bestArrivalTime && egressNodeArrivalTime < MAX_INT)
           {
@@ -261,7 +261,7 @@ namespace TrRouting
           {
             break;
           }
-          std::optional<std::shared_ptr<Connection>> tripEnterConnection = currentTripQueryOverlay.enterConnection;
+          std::optional<std::reference_wrapper<const Connection>> tripEnterConnection = currentTripQueryOverlay.enterConnection;
           const Node &nodeDeparture = (**connection).getDepartureNode();
 
           // Extract node departure time if we have a result or set a default value
@@ -297,7 +297,7 @@ namespace TrRouting
             if ((**connection).canBoard() && ( !tripEnterConnection.has_value()))
             {
               currentTripQueryOverlay.usable = true;
-              currentTripQueryOverlay.enterConnection = *connection;
+              currentTripQueryOverlay.enterConnection = **connection;
               currentTripQueryOverlay.enterConnectionTransferTravelTime = forwardJourneysSteps.at(nodeDeparture.uid).getTransferTravelTime();
             }
 
@@ -336,7 +336,7 @@ namespace TrRouting
                     nodesTentativeTime[transferableNode.node.uid] = footpathTravelTime + connectionArrivalTime;
 
                     //TODO DO we need a make_optional here??
-                    forwardJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, *connection, std::cref(trip), footpathTravelTime, (nodeArrival == transferableNode.node), footpathDistance));
+                    forwardJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, **connection, std::cref(trip), footpathTravelTime, (nodeArrival == transferableNode.node), footpathDistance));
                   }
 
                   if (
@@ -346,12 +346,12 @@ namespace TrRouting
                      //TODO Not fully sure this is equivalent to the ancient code
                      forwardEgressJourneysSteps.count(transferableNode.node.uid) == 0
                       ||
-                     forwardEgressJourneysSteps.at(transferableNode.node.uid).getFinalExitConnection().value()->getArrivalTime() > connectionArrivalTime
+                     forwardEgressJourneysSteps.at(transferableNode.node.uid).getFinalExitConnection().value().get().getArrivalTime() > connectionArrivalTime
                     )
                   )
                   {
                     footpathDistance = nodeArrival.transferableNodes[footpathIndex].distance;
-                    forwardEgressJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, *connection, std::cref(trip), footpathTravelTime, true, footpathDistance));
+                    forwardEgressJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(currentTripQueryOverlay.enterConnection, **connection, std::cref(trip), footpathTravelTime, true, footpathDistance));
                   }
                 }
                 footpathIndex++;

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -15,6 +15,7 @@
 #include "place.hpp"
 #include "household.hpp"
 #include "person.hpp"
+#include "connection_cache.hpp"
 #include "transit_data.hpp"
 
 namespace TrRouting

--- a/connection_scan_algorithm/src/optimize_journey.cpp
+++ b/connection_scan_algorithm/src/optimize_journey.cpp
@@ -71,19 +71,19 @@ namespace TrRouting
         )
         {
           const Trip & trip  = journeyStep.getFinalTrip().value().get();
-          int sequenceStartIdx = journeyStep.getFinalEnterConnection().value()->getSequenceInTrip() - 1;
-          int sequenceEndIdx   = journeyStep.getFinalExitConnection().value()->getSequenceInTrip() - 1;
+          int sequenceStartIdx = journeyStep.getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
+          int sequenceEndIdx   = journeyStep.getFinalExitConnection().value().get().getSequenceInTrip() - 1;
 
           // get first and last nodes for the journey step trip segment (boarding and unboarding nodes):
-          auto enterConnect = journeyStep.getFinalEnterConnection().value();
+          auto enterConnect = journeyStep.getFinalEnterConnection().value().get();
 
           //TODO Double check this, unsure what type is enterConnect
-          const Node & firstNodeByJourneyStep  =  enterConnect->getDepartureNode();
+          const Node & firstNodeByJourneyStep  =  enterConnect.getDepartureNode();
 
-          auto exitConnect = journeyStep.getFinalExitConnection().value();
+          auto exitConnect = journeyStep.getFinalExitConnection().value().get();
 
           //TODO Double check this, unsure what type is exitConnect
-          lastNodeByJourneyStepIdx.push_back(exitConnect->getArrivalNode());
+          lastNodeByJourneyStepIdx.push_back(exitConnect.getArrivalNode());
           inBetweenNodesByJourneyStepIdx.resize(journeyStepIdx+1); // Resize outer vector so we can push_back in it later
 
           // get in-between nodes for the journet step trip segment (boarding and unboarding excluded):
@@ -190,8 +190,8 @@ namespace TrRouting
       {
         //TODO We might need to check if the optional have a value
         const Trip & trip = journey[fromJourneyStepIdx].getFinalTrip().value().get();
-        int sequenceStartIdx = journey[fromJourneyStepIdx].getFinalEnterConnection().value()->getSequenceInTrip() - 1;
-        int sequenceEndIdx   = journey[fromJourneyStepIdx].getFinalExitConnection().value()->getSequenceInTrip() - 1;
+        int sequenceStartIdx = journey[fromJourneyStepIdx].getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
+        int sequenceEndIdx   = journey[fromJourneyStepIdx].getFinalExitConnection().value().get().getSequenceInTrip() - 1;
 
         // Editorial comment: There's lot of +1/-1 in this code. This suggest that we have an array index that start at 1 instead of zero. This need confirmation
         assert(trip.reverseConnections.size() >= 1 + sequenceEndIdx); // make sure sequenceIdx will be valid
@@ -217,7 +217,7 @@ namespace TrRouting
               {
                 journey.erase(journey.begin() + fromJourneyStepIdx + 1, journey.begin() + toJourneyStepIdx);
               }
-              journey[fromJourneyStepIdx].setFinalExitConnection(connection);
+              journey[fromJourneyStepIdx].setFinalExitConnection(*connection);
 
               break;
             }
@@ -230,8 +230,8 @@ namespace TrRouting
       {
 
         const Trip & trip = journey[toJourneyStepIdx].getFinalTrip().value().get();
-        int sequenceStartIdx = journey[toJourneyStepIdx].getFinalEnterConnection().value()->getSequenceInTrip() - 1;
-        int sequenceEndIdx   = journey[toJourneyStepIdx].getFinalExitConnection().value()->getSequenceInTrip() - 1;
+        int sequenceStartIdx = journey[toJourneyStepIdx].getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
+        int sequenceEndIdx   = journey[toJourneyStepIdx].getFinalExitConnection().value().get().getSequenceInTrip() - 1;
         for(size_t sequenceIdx = trip.reverseConnections.size() - 1 - sequenceEndIdx; sequenceIdx <= trip.reverseConnections.size() - 1 - sequenceStartIdx; ++sequenceIdx)
         {
           auto connection = trip.reverseConnections[sequenceIdx];
@@ -245,7 +245,7 @@ namespace TrRouting
             else
             {
               usedOptimizationCases.push_back(2);
-              journey[toJourneyStepIdx].setFinalEnterConnection(connection);
+              journey[toJourneyStepIdx].setFinalEnterConnection(*connection);
               journey[toJourneyStepIdx].setTransferTimeDistance(0,0);
               break;
             }
@@ -257,8 +257,8 @@ namespace TrRouting
       else if (optimizationCase == 3) // GTF // untested
       {
         const Trip & trip = journey[fromJourneyStepIdx].getFinalTrip().value().get();
-        int sequenceStartIdx = journey[fromJourneyStepIdx].getFinalEnterConnection().value()->getSequenceInTrip() - 1;
-        int sequenceEndIdx   = journey[fromJourneyStepIdx].getFinalExitConnection().value()->getSequenceInTrip() - 1;
+        int sequenceStartIdx = journey[fromJourneyStepIdx].getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
+        int sequenceEndIdx   = journey[fromJourneyStepIdx].getFinalExitConnection().value().get().getSequenceInTrip() - 1;
 
         for(size_t sequenceIdx = trip.reverseConnections.size() - 1 - sequenceEndIdx; sequenceIdx <= trip.reverseConnections.size() - 1 - sequenceStartIdx; ++sequenceIdx)
         {
@@ -274,7 +274,7 @@ namespace TrRouting
             else
             {
               usedOptimizationCases.push_back(3);
-              journey[fromJourneyStepIdx].setFinalExitConnection(connection);
+              journey[fromJourneyStepIdx].setFinalExitConnection(*connection);
               journey[toJourneyStepIdx].setTransferTimeDistance(0,0);
               break;
             }
@@ -285,14 +285,14 @@ namespace TrRouting
       else if (optimizationCase == 4) // CSS
       {
         const Trip & arrivalJourneyStepTrip          = journey[fromJourneyStepIdx].getFinalTrip().value().get();
-        int arrivalJourneyStepSequenceStartIdx = journey[fromJourneyStepIdx].getFinalEnterConnection().value()->getSequenceInTrip() - 1;
-        int arrivalJourneyStepSequenceEndIdx   = journey[fromJourneyStepIdx].getFinalExitConnection().value()->getSequenceInTrip() - 1;
+        int arrivalJourneyStepSequenceStartIdx = journey[fromJourneyStepIdx].getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
+        int arrivalJourneyStepSequenceEndIdx   = journey[fromJourneyStepIdx].getFinalExitConnection().value().get().getSequenceInTrip() - 1;
 
         const Trip & departureJourneyStepTrip          = journey[toJourneyStepIdx].getFinalTrip().value().get();
-        int departureJourneyStepSequenceStartIdx = journey[toJourneyStepIdx].getFinalEnterConnection().value()->getSequenceInTrip() - 1;
-        int departureJourneyStepSequenceEndIdx   = journey[toJourneyStepIdx].getFinalExitConnection().value()->getSequenceInTrip() - 1;
+        int departureJourneyStepSequenceStartIdx = journey[toJourneyStepIdx].getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
+        int departureJourneyStepSequenceEndIdx   = journey[toJourneyStepIdx].getFinalExitConnection().value().get().getSequenceInTrip() - 1;
 
-        std::optional<std::shared_ptr<Connection>> exitConnection;
+        std::optional<std::reference_wrapper<Connection>> exitConnection;
 
         {
           for(size_t sequenceIdx = arrivalJourneyStepTrip.reverseConnections.size() - 1 - arrivalJourneyStepSequenceEndIdx; sequenceIdx <= arrivalJourneyStepTrip.reverseConnections.size() - 1 - arrivalJourneyStepSequenceStartIdx; ++sequenceIdx)
@@ -302,7 +302,7 @@ namespace TrRouting
             {
               if (connection->canUnboard())
               {
-                exitConnection = connection;
+                exitConnection = *connection;
               }
               else
               {
@@ -320,7 +320,7 @@ namespace TrRouting
               {
                 usedOptimizationCases.push_back(4);
                 journey[fromJourneyStepIdx].setFinalExitConnection(exitConnection.value());
-                journey[toJourneyStepIdx].setFinalEnterConnection(connection);
+                journey[toJourneyStepIdx].setFinalEnterConnection(*connection);
               }
               else
               {

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -19,7 +19,7 @@ namespace TrRouting
     int benchmarkingStart = algorithmCalculationTime.getEpoch();
 
     int  reachableConnectionsCount        {0};
-    std::optional<std::shared_ptr<Connection>> tripExitConnection;
+    std::optional<std::reference_wrapper<const Connection>> tripExitConnection;
     int  connectionDepartureTime          {-1};
     int  connectionArrivalTime            {-1};
     short connectionMinWaitingTimeSeconds {-1};
@@ -91,7 +91,7 @@ namespace TrRouting
               const JourneyStep & reverseStepAtArrival = reverseJourneysSteps.at(nodeArrival.uid);
               if (!tripExitConnection.has_value()) // <= to make sure we get the same result as forward calculation, which uses >
               {
-                currentTripQueryOverlay.exitConnection = *connection;
+                currentTripQueryOverlay.exitConnection = **connection;
                 currentTripQueryOverlay.exitConnectionTransferTravelTime = reverseStepAtArrival.getTransferTravelTime();
               }
               else if (
@@ -103,11 +103,11 @@ namespace TrRouting
                        reverseStepAtArrival.getTransferTravelTime() < currentTripQueryOverlay.exitConnectionTransferTravelTime
                        )
               {
-                journeyConnectionMinWaitingTimeSeconds = reverseStepAtArrival.getFinalEnterConnection().value()->getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
+                journeyConnectionMinWaitingTimeSeconds = reverseStepAtArrival.getFinalEnterConnection().value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
 
                 if (connectionArrivalTime + journeyConnectionMinWaitingTimeSeconds <= nodeArrivalTentativeTime)
                 {
-                  currentTripQueryOverlay.exitConnection = *connection;
+                  currentTripQueryOverlay.exitConnection = **connection;
                   currentTripQueryOverlay.exitConnectionTransferTravelTime = reverseStepAtArrival.getTransferTravelTime();
                 }
               }
@@ -150,7 +150,7 @@ namespace TrRouting
                     footpathDistance = nodeDeparture.reverseTransferableNodes.at(footpathIndex).distance;
                     nodesReverseTentativeTime[transferableNode.node.uid] = connectionDepartureTime - footpathTravelTime - connectionMinWaitingTimeSeconds;
                     //TODO Do we need a make_optional<...>(connection) ??
-                    reverseJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(*connection, currentTripQueryOverlay.exitConnection, std::cref(trip), footpathTravelTime, (nodeDeparture == transferableNode.node), footpathDistance));
+                    reverseJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(**connection, currentTripQueryOverlay.exitConnection, std::cref(trip), footpathTravelTime, (nodeDeparture == transferableNode.node), footpathDistance));
                   }
                   if (
                     nodeDeparture == transferableNode.node
@@ -159,7 +159,7 @@ namespace TrRouting
                      //TODO Really not sure this is equivalent
                      reverseAccessJourneysSteps.count(transferableNode.node.uid) == 0
                      || 
-                     reverseAccessJourneysSteps.at(transferableNode.node.uid).getFinalEnterConnection().value()->getDepartureTime() <= connectionDepartureTime - connectionMinWaitingTimeSeconds
+                     reverseAccessJourneysSteps.at(transferableNode.node.uid).getFinalEnterConnection().value().get().getDepartureTime() <= connectionDepartureTime - connectionMinWaitingTimeSeconds
                     )
                   )
                   {                    
@@ -178,7 +178,7 @@ namespace TrRouting
                         connectionDepartureTime - departureTimeSeconds - nodeDepartureInNodesAccessIte->second.time <= parameters.getMaxFirstWaitingTimeSeconds()
                       )
                       {
-                        reverseAccessJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(*connection, currentTripQueryOverlay.exitConnection, std::cref(trip), 0, true, 0));
+                        reverseAccessJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(**connection, currentTripQueryOverlay.exitConnection, std::cref(trip), 0, true, 0));
                       }
                     }
                   }
@@ -204,13 +204,13 @@ namespace TrRouting
     for (auto & accessFootpath : accessFootpaths)
     {
       if (reverseAccessJourneysSteps.count(accessFootpath.node.uid)) {
-        std::optional<std::shared_ptr<Connection>> accessEnterConnection  = reverseAccessJourneysSteps.at(accessFootpath.node.uid).getFinalEnterConnection();
+        std::optional<std::reference_wrapper<const Connection>> accessEnterConnection  = reverseAccessJourneysSteps.at(accessFootpath.node.uid).getFinalEnterConnection();
         if (accessEnterConnection.has_value()) //TODO is this check required with the previous if(count()) added ?
         {
           const NodeTimeDistance & access = nodesAccess.at(accessFootpath.node.uid);
-          int accessEnterConnectionMinWaitingTimeSeconds = accessEnterConnection.value()->getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
+          int accessEnterConnectionMinWaitingTimeSeconds = accessEnterConnection.value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
 
-          int accessNodeDepartureTime                    = accessEnterConnection.value()->getDepartureTime() - access.time - accessEnterConnectionMinWaitingTimeSeconds;
+          int accessNodeDepartureTime                    = accessEnterConnection.value().get().getDepartureTime() - access.time - accessEnterConnectionMinWaitingTimeSeconds;
           if ((accessNodeDepartureTime >= 0) &&
               (arrivalTimeSeconds - accessNodeDepartureTime <= parameters.getMaxTotalTravelTimeSeconds()) &&
               (accessNodeDepartureTime > bestDepartureTime) &&
@@ -239,7 +239,7 @@ namespace TrRouting
     int benchmarkingStart = algorithmCalculationTime.getEpoch();
 
     int  reachableConnectionsCount        {0};
-    std::optional<std::shared_ptr<Connection>> tripExitConnection;
+    std::optional<std::reference_wrapper<const Connection>> tripExitConnection;
     int  connectionDepartureTime          {-1};
     int  connectionArrivalTime            {-1};
     short connectionMinWaitingTimeSeconds {-1};
@@ -305,7 +305,7 @@ namespace TrRouting
               const JourneyStep & reverseStepAtArrival = reverseJourneysSteps.at(nodeArrival.uid);
               if (!tripExitConnection.has_value()) // <= to make sure we get the same result as forward calculation, which uses >
               {
-                currentTripQueryOverlay.exitConnection = *connection;
+                currentTripQueryOverlay.exitConnection = **connection;
                 currentTripQueryOverlay.exitConnectionTransferTravelTime = reverseStepAtArrival.getTransferTravelTime();
               }
               else if (
@@ -317,11 +317,11 @@ namespace TrRouting
                        reverseStepAtArrival.getTransferTravelTime() < currentTripQueryOverlay.exitConnectionTransferTravelTime
                        )
               {
-                journeyConnectionMinWaitingTimeSeconds = reverseStepAtArrival.getFinalEnterConnection().value()->getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
+                journeyConnectionMinWaitingTimeSeconds = reverseStepAtArrival.getFinalEnterConnection().value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
 
                 if (connectionArrivalTime + journeyConnectionMinWaitingTimeSeconds <= nodeArrivalTentativeTime)
                 {
-                  currentTripQueryOverlay.exitConnection = *connection;
+                  currentTripQueryOverlay.exitConnection = **connection;
                   currentTripQueryOverlay.exitConnectionTransferTravelTime = reverseStepAtArrival.getTransferTravelTime();
                 }
               }
@@ -358,7 +358,7 @@ namespace TrRouting
                     footpathDistance = nodeDeparture.reverseTransferableNodes.at(footpathIndex).distance;
                     nodesReverseTentativeTime[transferableNode.node.uid] = connectionDepartureTime - footpathTravelTime - connectionMinWaitingTimeSeconds;
                     //TODO Do we need a make_optional<...>(connection) ??
-                    reverseJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(*connection, currentTripQueryOverlay.exitConnection, std::cref(trip), footpathTravelTime, (nodeDeparture == transferableNode.node), footpathDistance));
+                    reverseJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(**connection, currentTripQueryOverlay.exitConnection, std::cref(trip), footpathTravelTime, (nodeDeparture == transferableNode.node), footpathDistance));
                   }
                   if (
                     nodeDeparture == transferableNode.node
@@ -367,7 +367,7 @@ namespace TrRouting
                      //TODO Really not sure this is equivalent
                      reverseAccessJourneysSteps.count(transferableNode.node.uid) == 0
                      ||
-                     reverseAccessJourneysSteps.at(transferableNode.node.uid).getFinalEnterConnection().value()->getDepartureTime() <= connectionDepartureTime - connectionMinWaitingTimeSeconds
+                     reverseAccessJourneysSteps.at(transferableNode.node.uid).getFinalEnterConnection().value().get().getDepartureTime() <= connectionDepartureTime - connectionMinWaitingTimeSeconds
                     )
                   )
                   {
@@ -386,7 +386,7 @@ namespace TrRouting
                         connectionDepartureTime - departureTimeSeconds - nodeDepartureInNodesAccessIte->second.time <= parameters.getMaxFirstWaitingTimeSeconds()
                       )
                       {
-                        reverseAccessJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(*connection, currentTripQueryOverlay.exitConnection, std::cref(trip), 0, true, 0));
+                        reverseAccessJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(**connection, currentTripQueryOverlay.exitConnection, std::cref(trip), 0, true, 0));
                       }
                     }
                   }

--- a/connection_scan_algorithm/src/reverse_journey.cpp
+++ b/connection_scan_algorithm/src/reverse_journey.cpp
@@ -24,8 +24,6 @@ namespace TrRouting
       throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
     }
 
-    std::shared_ptr<Connection> journeyStepEnterConnection;
-    std::shared_ptr<Connection> journeyStepExitConnection;
     std::vector<Leg> legs;
 
     int totalInVehicleTime       { 0}; int transferArrivalTime    {-1};
@@ -57,7 +55,7 @@ namespace TrRouting
               journey[journey.size()-1].copyTransferTimeDistance(resultingNodeJourneyStep);
             }
           journey.push_back(resultingNodeJourneyStep);
-          bestEgressNode = resultingNodeJourneyStep.getFinalExitConnection().value()->getArrivalNode();
+          bestEgressNode = resultingNodeJourneyStep.getFinalExitConnection().value().get().getArrivalNode();
           resultingNodeJourneyStep = reverseJourneysSteps.at(bestEgressNode.value().get().uid);
         }
 
@@ -88,18 +86,18 @@ namespace TrRouting
           if (journeyStep.hasConnections())
             {
               // journey tuple: final enter connection, final exit connection, final footpath
-              journeyStepEnterConnection  = journeyStep.getFinalEnterConnection().value();
-              journeyStepExitConnection   = journeyStep.getFinalExitConnection().value();
-              const Node &journeyStepNodeDeparture    = journeyStepEnterConnection->getDepartureNode();
-              const Node &journeyStepNodeArrival      = journeyStepExitConnection->getArrivalNode();
+              const Connection &journeyStepEnterConnection  = journeyStep.getFinalEnterConnection().value().get();
+              const Connection &journeyStepExitConnection   = journeyStep.getFinalExitConnection().value().get();
+              const Node &journeyStepNodeDeparture    = journeyStepEnterConnection.getDepartureNode();
+              const Node &journeyStepNodeArrival      = journeyStepExitConnection.getArrivalNode();
               const Trip &journeyStepTrip             = journeyStep.getFinalTrip().value().get();
               transferTime                = journeyStep.getTransferTravelTime();
               distance                    = journeyStep.getTransferDistance();
               inVehicleDistance           = 0;
-              departureTime               = journeyStepEnterConnection->getDepartureTime();
-              arrivalTime                 = journeyStepExitConnection->getArrivalTime();
-              boardingSequence            = journeyStepEnterConnection->getSequenceInTrip();
-              unboardingSequence          = journeyStepExitConnection->getSequenceInTrip();
+              departureTime               = journeyStepEnterConnection.getDepartureTime();
+              arrivalTime                 = journeyStepExitConnection.getArrivalTime();
+              boardingSequence            = journeyStepEnterConnection.getSequenceInTrip();
+              unboardingSequence          = journeyStepExitConnection.getSequenceInTrip();
               inVehicleTime               = arrivalTime   - departureTime;
               waitingTime                 = departureTime - transferArrivalTime;
               transferArrivalTime         = arrivalTime   + transferTime;
@@ -107,7 +105,7 @@ namespace TrRouting
 
               if (journey.size() > i + 1 && journey[i+1].getFinalEnterConnection().has_value())
                 {
-                  transferReadyTime += journey[i+1].getFinalEnterConnection().value()->getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
+                  transferReadyTime += journey[i+1].getFinalEnterConnection().value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
                 }
 
               totalInVehicleTime         += inVehicleTime;
@@ -210,7 +208,7 @@ namespace TrRouting
 
                   if (journey.size() > i + 1 && journey[i+1].getFinalEnterConnection().has_value())
                     {
-                      transferReadyTime += journey[i+1].getFinalEnterConnection().value()->getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
+                      transferReadyTime += journey[i+1].getFinalEnterConnection().value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
                     }
 
                   totalWalkingTime    += transferTime;
@@ -296,7 +294,7 @@ namespace TrRouting
           journey[journey.size()-1].copyTransferTimeDistance(resultingNodeJourneyStep);
         }
         journey.push_back(resultingNodeJourneyStep);
-        bestEgressNode = resultingNodeJourneyStep.getFinalExitConnection().value()->getArrivalNode();
+        bestEgressNode = resultingNodeJourneyStep.getFinalExitConnection().value().get().getArrivalNode();
         resultingNodeJourneyStep = reverseJourneysSteps.at(bestEgressNode.value().get().uid);
       }
 
@@ -328,7 +326,7 @@ namespace TrRouting
       if (reverseAccessJourneysSteps.at(resultingNode.uid).getFinalEnterConnection().has_value()) {
         //TODO Should check taht MinWaiting is not -1 or use OrDefault(0)
         //TODO Could move this operation into a function of class Connection
-        int departureTimeD = reverseAccessJourneysSteps.at(resultingNode.uid).getFinalEnterConnection().value()->getDepartureTime() - reverseAccessJourneysSteps.at(resultingNode.uid).getFinalEnterConnection().value()->getMinWaitingTime();
+        int departureTimeD = reverseAccessJourneysSteps.at(resultingNode.uid).getFinalEnterConnection().value().get().getDepartureTime() - reverseAccessJourneysSteps.at(resultingNode.uid).getFinalEnterConnection().value().get().getMinWaitingTime();
         if (arrivalTimeSeconds - departureTimeD <=  parameters.getMaxTotalTravelTimeSeconds()) {
           reachableNodesCount++;
 

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -30,19 +30,19 @@ namespace TrRouting
       canTransferSameLineValue(_canTransferSameLine),
       minWaitingTimeSeconds(_minWaitingTimeSeconds) {}
 
-    const Node & getDepartureNode() {return departureNode;}
-    const Node & getArrivalNode() {return arrivalNode;}
-    int getDepartureTime() {return departureTimeSeconds;}
-    int getArrivalTime() {return arrivalTimeSeconds;}
-    const Trip & getTrip() {return trip;}
+    const Node & getDepartureNode() const {return departureNode;}
+    const Node & getArrivalNode() const {return arrivalNode;}
+    int getDepartureTime() const {return departureTimeSeconds;}
+    int getArrivalTime() const {return arrivalTimeSeconds;}
+    const Trip & getTrip() const {return trip;}
     //TODO Revisit how we create Trip and Connection to not require a mutable trip here (issue #201
-    Trip & getTripMutable() {return trip;}
-    bool canBoard() {return canBoardValue;}
-    bool canUnboard() {return canUnboardValue;}
-    int getSequenceInTrip() {return sequenceInTrip;}
-    bool canTransferSameLine() {return canTransferSameLineValue;}
-    short getMinWaitingTime() {return minWaitingTimeSeconds;}
-    short getMinWaitingTimeOrDefault(short defaultMinWaitingTime) {
+    Trip & getTripMutable() const {return trip;}
+    bool canBoard() const {return canBoardValue;}
+    bool canUnboard() const {return canUnboardValue;}
+    int getSequenceInTrip() const {return sequenceInTrip;}
+    bool canTransferSameLine() const {return canTransferSameLineValue;}
+    short getMinWaitingTime() const {return minWaitingTimeSeconds;}
+    short getMinWaitingTimeOrDefault(short defaultMinWaitingTime) const {
       if (minWaitingTimeSeconds >= 0) {
         return minWaitingTimeSeconds;
       } else {

--- a/include/connection_cache.hpp
+++ b/include/connection_cache.hpp
@@ -1,0 +1,42 @@
+#ifndef TR_CONNECTION_CACHE
+#define TR_CONNECTION_CACHE
+
+#include <vector>
+#include <optional>
+#include <boost/uuid/uuid.hpp>
+#include <memory>
+
+
+namespace TrRouting {
+
+class Connection;
+class ConnectionSet;
+
+
+/**
+ * @brief Caches the connection sets used by different transit scenarios.
+ *
+ * // TODO Currently caches only the last queried scenario. We could make this a
+ * real lru cache eventually, or not, if we find a better way to handle scenario
+ * query data.
+ */
+class ScenarioConnectionCache {
+
+  public:
+    ScenarioConnectionCache()
+    {
+       
+    };
+    virtual ~ScenarioConnectionCache() {}
+    
+    std::optional<std::shared_ptr<ConnectionSet>> get(boost::uuids::uuid uuid) const;
+    void set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache);
+
+  private:
+    std::optional<boost::uuids::uuid> lastUuid;
+    std::shared_ptr<ConnectionSet> lastConnection;
+};
+
+}
+
+#endif // TR_CONNECTION_CACHE

--- a/include/connection_set.hpp
+++ b/include/connection_set.hpp
@@ -1,0 +1,47 @@
+#ifndef TR_CONNECTION_SET
+#define TR_CONNECTION_SET
+
+#include <vector>
+
+
+namespace TrRouting {
+
+class Connection;
+class Trip;
+
+/**
+ * @brief Encapsulates a subset of the whole connection set, ie the connections
+ * that are used by the trips
+ */
+class ConnectionSet {
+
+  public:
+    
+    ConnectionSet(
+        const std::vector<std::reference_wrapper<const Trip>> _trips,
+        const std::vector<std::reference_wrapper<Connection>> _forwardConnections,
+        const std::vector<std::reference_wrapper<Connection>> _reverseConnections
+    );
+    const std::vector<std::reference_wrapper<const Trip>> & getTrips() const {return trips;}
+    const std::vector<std::reference_wrapper<Connection>> & getForwardConnections() const {return forwardConnections;}
+    const std::vector<std::reference_wrapper<Connection>> & getReverseConnections() const {return reverseConnections;}
+
+    std::vector<std::reference_wrapper<Connection>>::const_iterator getForwardConnectionsBeginAtDepartureHour(int hour) const;
+    std::vector<std::reference_wrapper<Connection>>::const_iterator getReverseConnectionsBeginAtArrivalHour(int hour) const;
+
+  private:
+    std::vector<std::reference_wrapper<const Trip>> trips;
+    std::vector<std::reference_wrapper<Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
+    std::vector<std::reference_wrapper<Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
+
+    // Contains iterator matching each hour of the day from the corresponding connections container.
+    // Used to speed up iterating the connections by skipping the connections that are too early or too late
+    std::vector<std::vector<std::reference_wrapper<Connection>>::const_iterator> forwardConnectionsBeginIteratorCache;
+    std::vector<std::vector<std::reference_wrapper<Connection>>::const_iterator> reverseConnectionsBeginIteratorCache;
+
+    void generateConnectionsIteratorCache();
+};
+
+}
+
+#endif // TR_CONNECTION_SET

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -115,7 +115,7 @@ namespace TrRouting
       );
       virtual ~CommonParameters() {}
       // FIXME Temporary method, will be removed once calculation specific parameters are implemented. Try not to use.
-      const Scenario& getScenario() { return scenario; }
+      const Scenario& getScenario() const { return scenario; }
       int getTimeOfTrip() const { return timeOfTrip; }
       int getMinWaitingTimeSeconds() const { return minWaitingTimeSeconds; }
       int getMaxTotalTravelTimeSeconds() const { return maxTotalTravelTimeSeconds; }

--- a/include/transit_data.hpp
+++ b/include/transit_data.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/uuid/uuid.hpp>
 #include "connection.hpp"
+#include "connection_cache.hpp"
 
 
 namespace TrRouting {
@@ -67,6 +68,8 @@ namespace TrRouting {
     const std::map<boost::uuids::uuid, Scenario> & getScenarios() const {return scenarios;}
     const std::map<boost::uuids::uuid, Trip> & getTrips() const {return trips;}
 
+    std::shared_ptr<ConnectionSet> getConnectionsForScenario(const Scenario & scenario) const;
+
     const std::vector<std::shared_ptr<Connection>> & getForwardConnections() const {return forwardConnections;}
     const std::vector<std::shared_ptr<Connection>> & getReverseConnections() const {return reverseConnections;}
 
@@ -124,6 +127,8 @@ namespace TrRouting {
     // Used to speed up iterating the connections by skipping the connections that are too early or too late
     std::vector<std::vector<std::shared_ptr<Connection>>::const_iterator> forwardConnectionsBeginIteratorCache;
     std::vector<std::vector<std::shared_ptr<Connection>>::const_iterator> reverseConnectionsBeginIteratorCache;
+
+    mutable ScenarioConnectionCache scenarioConnectionCache = ScenarioConnectionCache();
   };
 
 }

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -75,9 +75,9 @@ namespace TrRouting
 
     }
     bool usable; // after forward calculation, keep a list of usable trips in time range for reverse calculation
-    std::optional<std::shared_ptr<Connection>> enterConnection; // index of the entering connection
+    std::optional<std::reference_wrapper<const Connection>> enterConnection; // index of the entering connection
     int enterConnectionTransferTravelTime;
-    std::optional<std::shared_ptr<Connection>> exitConnection; // index of the exiting connection
+    std::optional<std::reference_wrapper<const Connection>> exitConnection; // index of the exiting connection
     int exitConnectionTransferTravelTime;
   };
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,8 @@ persons_cache_fetcher.cpp \
 scenarios_cache_fetcher.cpp \
 services_cache_fetcher.cpp \
 trips_and_connections_cache_fetcher.cpp \
+connection_set.cpp \
+connection_cache.cpp \
 transit_data.cpp
 #TODO #167 Place/Household removed while refactoring
 #places_cache_fetcher.cpp \

--- a/src/connection_cache.cpp
+++ b/src/connection_cache.cpp
@@ -1,0 +1,21 @@
+#include "connection_cache.hpp"
+#include "connection_set.hpp"
+#include "spdlog/spdlog.h"
+#include "connection.hpp"
+
+
+namespace TrRouting {
+
+  std::optional<std::shared_ptr<ConnectionSet>> ScenarioConnectionCache::get(boost::uuids::uuid uuid) const {
+    if (uuid == lastUuid) {
+      return std::optional(lastConnection);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  void ScenarioConnectionCache::set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache) {
+    lastUuid = uuid;
+    lastConnection = cache;
+  }
+}

--- a/src/connection_set.cpp
+++ b/src/connection_set.cpp
@@ -1,0 +1,85 @@
+#include "connection_set.hpp"
+#include "spdlog/spdlog.h"
+#include "connection.hpp"
+
+
+namespace TrRouting {
+
+  const int CONNECTION_ITERATOR_CACHE_BEGIN_HOUR = 0;
+  const int CONNECTION_ITERATOR_CACHE_END_HOUR = 32;
+
+  std::vector<std::reference_wrapper<Connection>>::const_iterator ConnectionSet::getForwardConnectionsBeginAtDepartureHour(int hour) const
+  {
+    if (hour > CONNECTION_ITERATOR_CACHE_END_HOUR || hour  < CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
+      return forwardConnections.cend();
+    }
+
+    return forwardConnectionsBeginIteratorCache[hour];
+  };
+
+  std::vector<std::reference_wrapper<Connection>>::const_iterator ConnectionSet::getReverseConnectionsBeginAtArrivalHour(int hour) const
+  {
+    if (hour < CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
+      return reverseConnections.cend();
+    } else if (hour > CONNECTION_ITERATOR_CACHE_END_HOUR - 1) {
+      return reverseConnections.begin();
+    }
+
+    return reverseConnectionsBeginIteratorCache[hour];
+  };
+
+  // Create a cache with a begin iterator which match the connection closest to the specified hour
+  // TODO Copy-pasted from transit_data, remove it from there if not required anymore
+  void ConnectionSet::generateConnectionsIteratorCache() {
+    int currentHour = CONNECTION_ITERATOR_CACHE_BEGIN_HOUR;
+
+    // Create first part of the forward cache
+    // For each hour, we save the iterator matching the connection which as a departure time bigger
+    // than this hour
+    for (std::vector<std::reference_wrapper<Connection>>::const_iterator ite = forwardConnections.cbegin();
+         ite != forwardConnections.cend();
+         ite++) {
+      // We can have a gap of multiple hours between 2 connections, so the current iterator
+      // can be valid for multiple hour slots
+      while ((*ite).get().getDepartureTime() >= currentHour * 3600) {
+        forwardConnectionsBeginIteratorCache.push_back(ite);
+        currentHour++;
+      }
+    }
+
+    //Finish filling forward cache
+    //We reached the end of the forwardConnections in the previous loop, so here we
+    //fill the rest of the forward cache with end iterator
+    for (;currentHour < CONNECTION_ITERATOR_CACHE_END_HOUR; currentHour++) {
+      forwardConnectionsBeginIteratorCache.push_back(forwardConnections.cend());
+    }
+
+    // Create the reverse cache
+    currentHour = CONNECTION_ITERATOR_CACHE_END_HOUR - 1;
+    for (std::vector<std::reference_wrapper<Connection>>::const_iterator ite = reverseConnections.cbegin();
+         ite != reverseConnections.cend();
+         ite++) {
+      // Fill cache with same iterator if we have multi hour gap between connection
+      while ((*ite).get().getArrivalTime() <= currentHour * 3600 && currentHour > CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
+        reverseConnectionsBeginIteratorCache.insert(reverseConnectionsBeginIteratorCache.begin(),ite);
+        currentHour--;
+      }
+    }
+
+    //Finish filling reverse cache
+    //We reached the end of the reverse connections in the previous loop, so here we
+    //fill the rest of the reverse cache with end iterator
+    for (;currentHour >= CONNECTION_ITERATOR_CACHE_BEGIN_HOUR; currentHour--) {
+      reverseConnectionsBeginIteratorCache.insert(reverseConnectionsBeginIteratorCache.begin(), reverseConnections.cend());
+    }
+  }
+
+  ConnectionSet::ConnectionSet(
+    const std::vector<std::reference_wrapper<const Trip>> _trips,
+    const std::vector<std::reference_wrapper<Connection>> _forwardConnections,
+    const std::vector<std::reference_wrapper<Connection>> _reverseConnections
+  ): trips(_trips), forwardConnections(_forwardConnections), reverseConnections(_reverseConnections) {
+    generateConnectionsIteratorCache();
+  }
+
+}

--- a/tests/benchmark_csa/Makefile.am
+++ b/tests/benchmark_csa/Makefile.am
@@ -15,6 +15,8 @@ gtest_SOURCES = gtest.cpp \
     ../../src/persons_cache_fetcher.cpp \
     ../../src/modes_initialization.cpp \
     ../../src/od_trips_cache_fetcher.cpp \
+    ../../src/connection_set.cpp \
+    ../../src/connection_cache.cpp \
     ../../src/transit_data.cpp \
     ../../src/osrm_fetcher.cpp
 

--- a/tests/connection_scan_algorithm/Makefile.am
+++ b/tests/connection_scan_algorithm/Makefile.am
@@ -4,9 +4,12 @@ check_PROGRAMS = csa_test
 csa_test_SOURCES = gtest.cpp \
     ../../src/calculation_time.cpp \
     ../../src/osrm_fetcher.cpp \
+    ../../src/connection_set.cpp \
+    ../../src/connection_cache.cpp \
     ../../src/transit_data.cpp \
     csa_test_base.cpp \
     csa_test_data_fetcher.cpp \
+    connection_cache_test.cpp \
     csa_v1_simple_calculation_test.cpp \
     csa_v1_transfer_and_alternatives_test.cpp \
     csa_v1_access_map_test.cpp \

--- a/tests/connection_scan_algorithm/connection_cache_test.cpp
+++ b/tests/connection_scan_algorithm/connection_cache_test.cpp
@@ -1,0 +1,43 @@
+#include <errno.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "gtest/gtest.h"
+#include "calculator.hpp"
+#include "connection_set_test.hpp"
+#include "connection_set.hpp"
+#include "connection_cache.hpp"
+#include "spdlog/spdlog.h"
+#include "scenario.hpp"
+
+// Test that the TransitData gets and create the connection cache correctly for various scenarios
+TEST_F(ConnectionSetFixtureTests, TestCacheAssignation)
+{
+    const TrRouting::Scenario & scenario = transitData.getScenarios().at(TestDataFetcher::scenarioUuid);
+    const TrRouting::Scenario & scenario2 = transitData.getScenarios().at(TestDataFetcher::scenario2Uuid);
+
+    // Get the cache a first time for a given scenario
+    std::shared_ptr<TrRouting::ConnectionSet> cache = transitData.getConnectionsForScenario(scenario);
+
+    ASSERT_EQ(17, cache->getForwardConnections().size());
+    ASSERT_EQ(17, cache->getReverseConnections().size());
+
+    // Get the cache a second time for the same scenario
+    cache = transitData.getConnectionsForScenario(scenario);
+
+    ASSERT_EQ(17, cache->getForwardConnections().size());
+    ASSERT_EQ(17, cache->getReverseConnections().size());
+
+    // Get the cache for a second scenario
+    cache = transitData.getConnectionsForScenario(scenario2);
+
+    ASSERT_EQ(9, cache->getForwardConnections().size());
+    ASSERT_EQ(9, cache->getReverseConnections().size());
+
+    // Get the cache for a first scenario again
+    cache = transitData.getConnectionsForScenario(scenario);
+
+    ASSERT_EQ(17, cache->getForwardConnections().size());
+    ASSERT_EQ(17, cache->getReverseConnections().size());
+
+}

--- a/tests/connection_scan_algorithm/connection_set_test.cpp
+++ b/tests/connection_scan_algorithm/connection_set_test.cpp
@@ -1,0 +1,119 @@
+#include <errno.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "gtest/gtest.h"
+#include "calculator.hpp"
+#include "connection_set_test.hpp"
+#include "connection_set.hpp"
+#include "spdlog/spdlog.h"
+#include "scenario.hpp"
+
+
+class ForwardConnectionIteratorTestSuite : public ConnectionSetFixtureTests,
+                              public testing::WithParamInterface<std::tuple<int, int>> {
+};
+
+class ReverseConnectionIteratorTestSuite : public ConnectionSetFixtureTests,
+                              public testing::WithParamInterface<std::tuple<int, int>> {
+};
+
+// Create a connection set object with all connections
+std::shared_ptr<ConnectionSet> getConnectionSet(TransitData transitData) {
+    std::vector<std::reference_wrapper<Connection>> forwardConnections;
+    std::vector<std::reference_wrapper<Connection>> reverseConnections;
+
+    auto forwardLastConnection = getForwardConnections().end(); // cache last connection for loop
+    for(auto connection = getForwardConnections().begin(); connection != forwardLastConnection; ++connection)
+    {
+        forwardConnections.push_back((**connection));
+    }
+
+    auto reverseLastConnection = getReverseConnections().end(); // cache last connection for loop
+    for(auto connection = getReverseConnections().begin(); connection != reverseLastConnection; ++connection)
+    {
+        reverseConnections.push_back((**connection));
+    }
+
+    return std::make_shared<ConnectionSet>(trips, forwardConnections, reverseConnections);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ForwardConnectionIteratorValues, ForwardConnectionIteratorTestSuite,
+    testing::Values(
+        // First trip, should include all connections
+        std::make_tuple(9, 17),
+        // Before all connections, should include all
+        std::make_tuple(0, 17),
+        // Should not include 9am trip
+        std::make_tuple(10, 13),
+        // Should only include the 11am trip
+        std::make_tuple(11, 4),
+        // The following should not include any connections
+        std::make_tuple(15, 0),
+        std::make_tuple(31, 0),
+        // out of range, but still no connection
+        std::make_tuple(100, 0)
+    )
+);
+
+// Test the forward connection iterator by hour
+TEST_P(ForwardConnectionIteratorTestSuite, TestForwardIterator)
+{
+    std::tuple<int, int> param = GetParam();
+    int startHour = std::get<0>(param);
+    int expected = std::get<1>(param);
+
+    std::shared_ptr<TrRouting::ConnectionSet> cache = getConnectionSet();
+
+    // cache last connection
+    auto lastConnection = cache.get()->getForwardConnections().end(); // cache last connection for loop
+
+    int connectionCount = 0;
+    for(auto connection = cache.get()->getForwardConnectionsBeginAtDepartureHour(startHour); connection != lastConnection; ++connection)
+    {
+        connectionCount++;
+    }
+    ASSERT_EQ(expected, connectionCount);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ReverseConnectionIteratorValues, ReverseConnectionIteratorTestSuite,
+    testing::Values(
+        // After all trips, should include all
+        std::make_tuple(12, 17),
+        // Before all connections, should include all
+        std::make_tuple(15, 17),
+        // Test from 11, which should not include the 11 am trip
+        std::make_tuple(11, 13),
+        // Test from 10, which should include the first east west trip
+        std::make_tuple(10, 4),
+        // Test from 8, which should not include any connection
+        std::make_tuple(8, 0),
+        std::make_tuple(0, 0),
+        // out of range, but should include all connections
+        std::make_tuple(100, 17)
+    )
+);
+
+// Test the forward connection iterator by hour
+TEST_P(ReverseConnectionIteratorTestSuite, TestReverseIterator)
+{
+    std::tuple<int, int> param = GetParam();
+    int startHour = std::get<0>(param);
+    int expected = std::get<1>(param);
+
+    std::shared_ptr<TrRouting::ConnectionSet> cache = getConnectionSet();
+
+    // cache last connection
+    auto lastConnection = cache.get()->getReverseConnections().end(); // cache last connection for loop
+
+    int connectionCount = 0;
+    for(auto connection = cache.get()->getReverseConnectionsBeginAtArrivalHour(startHour); connection != lastConnection; ++connection)
+    {
+        connectionCount++;
+    }
+    ASSERT_EQ(expected, connectionCount);
+}
+
+

--- a/tests/connection_scan_algorithm/connection_set_test.hpp
+++ b/tests/connection_scan_algorithm/connection_set_test.hpp
@@ -1,0 +1,24 @@
+#ifndef _CONNECTION_SET_TEST_H
+#define _CONNECTION_SET_TEST_H
+
+#include <boost/uuid/string_generator.hpp>
+
+#include "gtest/gtest.h"
+#include "csa_test_data_fetcher.hpp"
+#include "transit_data.hpp"
+
+
+class ConnectionSetFixtureTests : public ::testing::Test
+{
+
+protected:
+    // A DataFetcher is required to initialize the calculator
+    TestDataFetcher dataFetcher;
+    TrRouting::TransitData transitData;
+
+public:
+    ConnectionSetFixtureTests() : dataFetcher(TestDataFetcher()), transitData(TrRouting::TransitData(dataFetcher)) {}
+
+};
+
+#endif // _CONNECTION_SET_TEST_H

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -76,6 +76,53 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithTransfer)
         0);
 }
 
+// Test from OD which includes a transfer to the same node, origin is further
+// south of South2, in the line axis, destination is very close to west2
+// But use the second scenario, where ease-west line is disabled
+TEST_F(SingleTAndACalculationFixtureTests, TripWithTransferButLineNotEnabled)
+{
+    int departureTime = getTimeInSeconds(9, 45);
+    int minWaitingTime = 90;
+    int travelTimeInVehicle = 420;
+    // This is where mocking would be interesting. Those were taken from the first run of the test
+    int accessTime = 469;
+    int egressTime = 884;
+    int expectedTransitDepartureTime = getTimeInSeconds(10);
+    int expectedTransferWaitingTime = 0;
+
+    // Make sure scenario2Uuid is not accidentally equal to scenarioUuid
+    ASSERT_NE(boost::uuids::to_string(TestDataFetcher::scenario2Uuid), boost::uuids::to_string(TestDataFetcher::scenarioUuid));
+
+    TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
+        std::make_unique<TrRouting::Point>(45.5242, -73.5817),
+        std::make_unique<TrRouting::Point>(45.5295, -73.624),
+        transitData.getScenarios().at(TestDataFetcher::scenario2Uuid),
+        departureTime,
+        minWaitingTime,
+        DEFAULT_MAX_TOTAL_TIME,
+        DEFAULT_MAX_ACCESS_TRAVEL_TIME,
+        DEFAULT_MAX_EGRESS_TRAVEL_TIME,
+        DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
+        DEFAULT_FIRST_WAITING_TIME,
+        false,
+        true
+    );
+
+    // Exit at midpoint, no transfer
+    std::unique_ptr<TrRouting::RoutingResult> result = calculateOd(testParameters);
+    assertSuccessResults(*result.get(),
+        departureTime,
+        expectedTransitDepartureTime,
+        travelTimeInVehicle,
+        accessTime,
+        egressTime,
+        0,
+        minWaitingTime,
+        minWaitingTime + expectedTransferWaitingTime,
+        expectedTransferWaitingTime,
+        0);
+}
+
 // Same as TripWithTransfer but with a minimal transfer time higher than
 // available, the result is a walk from midpoint instead of another bus trip
 TEST_F(SingleTAndACalculationFixtureTests, NoTransferMinTransferTime)

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
@@ -302,7 +302,7 @@ int TestDataFetcher::getPaths(
 int TestDataFetcher::getScenarios(
                                   std::map<boost::uuids::uuid, TrRouting::Scenario>& array,
                                   const std::map<boost::uuids::uuid, TrRouting::Service>& services,
-                                  const std::map<boost::uuids::uuid, TrRouting::Line>&,
+                                  const std::map<boost::uuids::uuid, TrRouting::Line>& lines,
                                   const std::map<boost::uuids::uuid, TrRouting::Agency>&,
                                   const std::map<boost::uuids::uuid, TrRouting::Node>&,
                                   const std::map<std::string, TrRouting::Mode>&,
@@ -311,6 +311,11 @@ int TestDataFetcher::getScenarios(
   array[scenarioUuid].uuid = scenarioUuid;
   array[scenarioUuid].name = "Test valid scenario";
   array[scenarioUuid].servicesList.push_back(services.at(serviceUuid));
+
+  array[scenario2Uuid].uuid = scenario2Uuid;
+  array[scenario2Uuid].name = "Test valid without one line";
+  array[scenario2Uuid].servicesList.push_back(services.at(serviceUuid));
+  array[scenario2Uuid].exceptLines.push_back(lines.at(lineEWUuid));
   
   return 0;
 }

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.hpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.hpp
@@ -58,6 +58,7 @@ class TestDataFetcher : public TrRouting::DataFetcher
     inline static const boost::uuids::uuid serviceUuid = uuidGenerator("11111111-2222-3333-4444-555555666666");
 
     inline static const boost::uuids::uuid scenarioUuid = uuidGenerator("11111111-2222-2345-789a-555555666666");
+    inline static const boost::uuids::uuid scenario2Uuid = uuidGenerator("11111111-2222-2345-789a-555555666667");
 
     inline static const boost::uuids::uuid pathSNUuid = uuidGenerator("2f31893e-b2fb-4ebe-bf1b-2ee77fe1f96b");
     inline static const boost::uuids::uuid pathEWUuid = uuidGenerator("50f8e656-99b5-4ddd-b41f-b4804fe599f3");


### PR DESCRIPTION
Fixes #237

This caches the connections for the queried scenario. Only the last queried scenario is kept to avoid having to manage cache eviction and memory usage.

At the beginning of the calculation, in the resetFilters step, the connection cache object is retrieved, and computed if a new scenario is requested. This object contains only the forward and reverse connections for this scenario. All others are ignored.

For instances with a lot of services this improves performance. For example, calculations are 75% faster for an instance that contained the complete Montreal area data for fall 2018 and 2019.