### PR TITLE
Fix the cache being fetched twice

### DIFF
--- a/src/transit_data.cpp
+++ b/src/transit_data.cpp
@@ -20,9 +20,8 @@ namespace TrRouting {
   TransitData::TransitData(DataFetcher& fetcher) :
     dataFetcher(fetcher)
   {
-    
-    loadAllData();
-    if(loadAllData() != DataStatus::READY ) {
+    DataStatus loadStatus = loadAllData();
+    if (loadStatus != DataStatus::READY) {
       //TODO For now, don't throw on error because Transit server expect to get the dataStatus
       //throw std::exception("Incomplete transit data");
       spdlog::error("TransitData loading had error, object will not be valid");


### PR DESCRIPTION
Fixes #239

The `loadAllData` function should be called only once in the TransitData constructor.