### PR TITLE
Cleanup and optimization after the scenario cache PR

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -115,7 +115,9 @@ namespace TrRouting
     std::unordered_map<Node::uid_t, NodeTimeDistance> nodesAccess; // travel time/distance from origin to accessible nodes
     std::unordered_map<Node::uid_t, NodeTimeDistance> nodesEgress; // travel time/distance to reach destination;
 
-    std::unordered_map<Trip::uid_t, bool> tripsEnabled;
+    // Field used at the time of the query, mostly for alternatives, which deactivate some of the scenario trips. Typically, there are less disabled trips and enabled ones, so we keep only those
+    std::unordered_map<Trip::uid_t, bool> tripsDisabled;
+    bool isTripDisabled(Trip::uid_t uid) const { return tripsDisabled.find(uid) != tripsDisabled.end(); }
     std::unordered_map<Trip::uid_t, TripQueryData> tripsQueryOverlay; // Store addition trip info during a query processing
     // A subset of the connections that are used for the current query.
     std::shared_ptr<ConnectionSet> connectionSet;

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -50,7 +50,7 @@ namespace TrRouting
         auto & currentTripQueryOverlay = tripsQueryOverlay[trip.uid];
 
         // enabled trips only here:
-        if (tripsEnabled[trip.uid])
+        if (!isTripDisabled(trip.uid))
         {
           connectionDepartureTime         = (*connection).get().getDepartureTime();
           connectionMinWaitingTimeSeconds = (*connection).get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
@@ -250,7 +250,7 @@ namespace TrRouting
         auto & currentTripQueryOverlay = tripsQueryOverlay[trip.uid];
 
         // enabled trips only here:
-        if (tripsEnabled[trip.uid])
+        if (!isTripDisabled(trip.uid))
         {
           connectionDepartureTime         = (*connection).get().getDepartureTime();
           connectionMinWaitingTimeSeconds = (*connection).get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -50,7 +50,7 @@ namespace TrRouting
     tripsEnabled.clear();
     tripsQueryOverlay.clear();
 
-    spdlog::info("{} connections", transitData.getForwardConnections().size());;
+    spdlog::info("{} connections", transitData.getConnectionCount());;
 
     //int benchmarkingStart = algorithmCalculationTime.getEpoch();
 

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -47,7 +47,7 @@ namespace TrRouting
     forwardJourneysSteps.clear();
     reverseJourneysSteps.clear();
 
-    tripsEnabled.clear();
+    tripsDisabled.clear();
     tripsQueryOverlay.clear();
 
     spdlog::info("{} connections", transitData.getConnectionCount());;

--- a/connection_scan_algorithm/src/optimize_journey.cpp
+++ b/connection_scan_algorithm/src/optimize_journey.cpp
@@ -89,10 +89,10 @@ namespace TrRouting
           // get in-between nodes for the journet step trip segment (boarding and unboarding excluded):
           for(int sequenceIdx = sequenceStartIdx + 1; sequenceIdx <= sequenceEndIdx; ++sequenceIdx)
           {
-            const Node & nodeDep = trip.forwardConnections[sequenceIdx]->getDepartureNode();
+            const Node & nodeDep = trip.forwardConnections[sequenceIdx].get().getDepartureNode();
             if (nodeDep.uuid != firstNodeByJourneyStep.uuid && nodeDep.uuid != lastNodeByJourneyStepIdx.at(journeyStepIdx).value().get().uuid) // ignore repeated nodes at beginning or end
             {
-              inBetweenNodesByJourneyStepIdx[journeyStepIdx].push_back( trip.forwardConnections[sequenceIdx]->getDepartureNode() );
+              inBetweenNodesByJourneyStepIdx[journeyStepIdx].push_back( trip.forwardConnections[sequenceIdx].get().getDepartureNode() );
             }
           }
           
@@ -199,9 +199,9 @@ namespace TrRouting
         {
           auto connection = trip.reverseConnections[sequenceIdx];
           
-          if (optimizationNode.value() == connection->getArrivalNode())
+          if (optimizationNode.value() == connection.get().getArrivalNode())
           {
-            if (!connection->canUnboard())
+            if (!connection.get().canUnboard())
             {
               ignoreOptimizationNodes.push_back(optimizationNode.value());
               break;
@@ -217,7 +217,7 @@ namespace TrRouting
               {
                 journey.erase(journey.begin() + fromJourneyStepIdx + 1, journey.begin() + toJourneyStepIdx);
               }
-              journey[fromJourneyStepIdx].setFinalExitConnection(*connection);
+              journey[fromJourneyStepIdx].setFinalExitConnection(connection);
 
               break;
             }
@@ -235,9 +235,9 @@ namespace TrRouting
         for(size_t sequenceIdx = trip.reverseConnections.size() - 1 - sequenceEndIdx; sequenceIdx <= trip.reverseConnections.size() - 1 - sequenceStartIdx; ++sequenceIdx)
         {
           auto connection = trip.reverseConnections[sequenceIdx];
-          if (optimizationNode.value() == connection->getDepartureNode())
+          if (optimizationNode.value() == connection.get().getDepartureNode())
           {
-            if (!connection->canBoard())
+            if (!connection.get().canBoard())
             {
               ignoreOptimizationNodes.push_back(optimizationNode.value());
               break;
@@ -245,7 +245,7 @@ namespace TrRouting
             else
             {
               usedOptimizationCases.push_back(2);
-              journey[toJourneyStepIdx].setFinalEnterConnection(*connection);
+              journey[toJourneyStepIdx].setFinalEnterConnection(connection);
               journey[toJourneyStepIdx].setTransferTimeDistance(0,0);
               break;
             }
@@ -264,9 +264,9 @@ namespace TrRouting
         {
           auto connection = trip.reverseConnections[sequenceIdx];
           
-          if (optimizationNode.value() == connection->getArrivalNode())
+          if (optimizationNode.value() == connection.get().getArrivalNode())
           {
-            if (!connection->canUnboard())
+            if (!connection.get().canUnboard())
             {
               ignoreOptimizationNodes.push_back(optimizationNode.value());
               break;
@@ -274,7 +274,7 @@ namespace TrRouting
             else
             {
               usedOptimizationCases.push_back(3);
-              journey[fromJourneyStepIdx].setFinalExitConnection(*connection);
+              journey[fromJourneyStepIdx].setFinalExitConnection(connection);
               journey[toJourneyStepIdx].setTransferTimeDistance(0,0);
               break;
             }
@@ -292,17 +292,17 @@ namespace TrRouting
         int departureJourneyStepSequenceStartIdx = journey[toJourneyStepIdx].getFinalEnterConnection().value().get().getSequenceInTrip() - 1;
         int departureJourneyStepSequenceEndIdx   = journey[toJourneyStepIdx].getFinalExitConnection().value().get().getSequenceInTrip() - 1;
 
-        std::optional<std::reference_wrapper<Connection>> exitConnection;
+        std::optional<std::reference_wrapper<const Connection>> exitConnection;
 
         {
           for(size_t sequenceIdx = arrivalJourneyStepTrip.reverseConnections.size() - 1 - arrivalJourneyStepSequenceEndIdx; sequenceIdx <= arrivalJourneyStepTrip.reverseConnections.size() - 1 - arrivalJourneyStepSequenceStartIdx; ++sequenceIdx)
           {
             auto connection = arrivalJourneyStepTrip.reverseConnections[sequenceIdx];
-            if (optimizationNode.value() == connection->getArrivalNode())
+            if (optimizationNode.value() == connection.get().getArrivalNode())
             {
-              if (connection->canUnboard())
+              if (connection.get().canUnboard())
               {
-                exitConnection = *connection;
+                exitConnection = connection;
               }
               else
               {
@@ -314,13 +314,13 @@ namespace TrRouting
           for(size_t sequenceIdx = departureJourneyStepTrip.reverseConnections.size() - 1 - departureJourneyStepSequenceEndIdx; sequenceIdx <= departureJourneyStepTrip.reverseConnections.size() - 1 - departureJourneyStepSequenceStartIdx; ++sequenceIdx)
           {
             auto connection = departureJourneyStepTrip.reverseConnections[sequenceIdx];
-            if (optimizationNode.value() == connection->getDepartureNode())
+            if (optimizationNode.value() == connection.get().getDepartureNode())
             {
-              if (exitConnection.has_value() && connection->canBoard())
+              if (exitConnection.has_value() && connection.get().canBoard())
               {
                 usedOptimizationCases.push_back(4);
                 journey[fromJourneyStepIdx].setFinalExitConnection(exitConnection.value());
-                journey[toJourneyStepIdx].setFinalEnterConnection(*connection);
+                journey[toJourneyStepIdx].setFinalEnterConnection(connection);
               }
               else
               {

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -258,6 +258,7 @@ namespace TrRouting
     // exclusions than the scenario (the combinations of lines). It is not
     // redundant with the one in the connection cache generator
     // TODO: This code is very similar to the one in getConnectionsForScenario, extract it
+    tripsDisabled.clear();
     for (auto & tripIte : connectionSet.get()->getTrips())
     {
       const Trip & trip = tripIte.get();
@@ -346,7 +347,9 @@ namespace TrRouting
           enabled = false;
         }
       }
-      tripsEnabled[trip.uid] = enabled;
+      if (!enabled) {
+        tripsDisabled[trip.uid] = true;
+      }
     }
 
   }

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -54,7 +54,7 @@ namespace TrRouting
         
         // enabled trips only here:
         auto & currentTripQueryOverlay = tripsQueryOverlay[trip.uid];
-        if (currentTripQueryOverlay.usable && tripsEnabled[trip.uid])
+        if (currentTripQueryOverlay.usable && !isTripDisabled(trip.uid))
         {
 
           connectionArrivalTime           = (*connection).get().getArrivalTime();
@@ -270,7 +270,8 @@ namespace TrRouting
 
         // enabled trips only here:
         auto & currentTripQueryOverlay = tripsQueryOverlay[trip.uid];
-        if (currentTripQueryOverlay.usable) // && tripsEnabled[trip.uid])
+        // FIXME Determine with the new connection cache if a trip could be disabled in the all nodes path
+        if ((currentTripQueryOverlay.usable) && !isTripDisabled(trip.uid))
         {
           connectionArrivalTime           = (*connection).get().getArrivalTime();
 

--- a/include/cache_fetcher.hpp
+++ b/include/cache_fetcher.hpp
@@ -125,7 +125,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::shared_ptr<Connection>>& connections,
+      std::vector<Connection>& connections,
       std::string customPath = ""
     );
         

--- a/include/connection_set.hpp
+++ b/include/connection_set.hpp
@@ -19,25 +19,25 @@ class ConnectionSet {
     
     ConnectionSet(
         const std::vector<std::reference_wrapper<const Trip>> _trips,
-        const std::vector<std::reference_wrapper<Connection>> _forwardConnections,
-        const std::vector<std::reference_wrapper<Connection>> _reverseConnections
+        const std::vector<std::reference_wrapper<const Connection>> _forwardConnections,
+        const std::vector<std::reference_wrapper<const Connection>> _reverseConnections
     );
     const std::vector<std::reference_wrapper<const Trip>> & getTrips() const {return trips;}
-    const std::vector<std::reference_wrapper<Connection>> & getForwardConnections() const {return forwardConnections;}
-    const std::vector<std::reference_wrapper<Connection>> & getReverseConnections() const {return reverseConnections;}
+    const std::vector<std::reference_wrapper<const Connection>> & getForwardConnections() const {return forwardConnections;}
+    const std::vector<std::reference_wrapper<const Connection>> & getReverseConnections() const {return reverseConnections;}
 
-    std::vector<std::reference_wrapper<Connection>>::const_iterator getForwardConnectionsBeginAtDepartureHour(int hour) const;
-    std::vector<std::reference_wrapper<Connection>>::const_iterator getReverseConnectionsBeginAtArrivalHour(int hour) const;
+    std::vector<std::reference_wrapper<const Connection>>::const_iterator getForwardConnectionsBeginAtDepartureHour(int hour) const;
+    std::vector<std::reference_wrapper<const Connection>>::const_iterator getReverseConnectionsBeginAtArrivalHour(int hour) const;
 
   private:
     std::vector<std::reference_wrapper<const Trip>> trips;
-    std::vector<std::reference_wrapper<Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
-    std::vector<std::reference_wrapper<Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
+    std::vector<std::reference_wrapper<const Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
+    std::vector<std::reference_wrapper<const Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
 
     // Contains iterator matching each hour of the day from the corresponding connections container.
     // Used to speed up iterating the connections by skipping the connections that are too early or too late
-    std::vector<std::vector<std::reference_wrapper<Connection>>::const_iterator> forwardConnectionsBeginIteratorCache;
-    std::vector<std::vector<std::reference_wrapper<Connection>>::const_iterator> reverseConnectionsBeginIteratorCache;
+    std::vector<std::vector<std::reference_wrapper<const Connection>>::const_iterator> forwardConnectionsBeginIteratorCache;
+    std::vector<std::vector<std::reference_wrapper<const Connection>>::const_iterator> reverseConnectionsBeginIteratorCache;
 
     void generateConnectionsIteratorCache();
 };

--- a/include/data_fetcher.hpp
+++ b/include/data_fetcher.hpp
@@ -219,7 +219,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Line>& lines,
       std::map<boost::uuids::uuid, Path>& paths,
       const std::map<boost::uuids::uuid, Service>& services,
-      std::vector<std::shared_ptr<Connection>>& connections,
+      std::vector<Connection>& connections,
       std::string customPath = "") = 0;
 
   };    

--- a/include/dummy_data_fetcher.hpp
+++ b/include/dummy_data_fetcher.hpp
@@ -116,7 +116,7 @@ namespace TrRouting
       const std::map<boost::uuids::uuid, Line>& ,
       std::map<boost::uuids::uuid, Path>& ,
       const std::map<boost::uuids::uuid, Service>& ,
-      std::vector<std::shared_ptr<Connection>>& ,
+      std::vector<Connection>& ,
       std::string = "") {return 0;}
 
   };    

--- a/include/transit_data.hpp
+++ b/include/transit_data.hpp
@@ -67,7 +67,7 @@ namespace TrRouting {
     const std::map<boost::uuids::uuid, Path> & getPaths() const {return paths;}
     const std::map<boost::uuids::uuid, Scenario> & getScenarios() const {return scenarios;}
     const std::map<boost::uuids::uuid, Trip> & getTrips() const {return trips;}
-    unsigned int getConnectionCount() const {return forwardConnections.size();}
+    unsigned int getConnectionCount() const {return connections.size();}
 
     std::shared_ptr<ConnectionSet> getConnectionsForScenario(const Scenario & scenario) const;
 
@@ -99,7 +99,7 @@ namespace TrRouting {
     
   protected:
     DataStatus loadAllData();
-    int generateForwardAndReverseConnections(const std::vector<std::shared_ptr<Connection>> &connections);
+    int generateForwardAndReverseConnections();
 
     DataFetcher &dataFetcher;
 
@@ -115,8 +115,9 @@ namespace TrRouting {
     std::map<boost::uuids::uuid, Scenario>   scenarios;
     std::map<boost::uuids::uuid, Trip>       trips;
 
-    std::vector<std::shared_ptr<Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
-    std::vector<std::shared_ptr<Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
+    std::vector<Connection> connections;
+    std::vector<std::reference_wrapper<const Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
+    std::vector<std::reference_wrapper<const Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
 
     mutable ScenarioConnectionCache scenarioConnectionCache = ScenarioConnectionCache();
   };

--- a/include/transit_data.hpp
+++ b/include/transit_data.hpp
@@ -67,14 +67,10 @@ namespace TrRouting {
     const std::map<boost::uuids::uuid, Path> & getPaths() const {return paths;}
     const std::map<boost::uuids::uuid, Scenario> & getScenarios() const {return scenarios;}
     const std::map<boost::uuids::uuid, Trip> & getTrips() const {return trips;}
+    unsigned int getConnectionCount() const {return forwardConnections.size();}
 
     std::shared_ptr<ConnectionSet> getConnectionsForScenario(const Scenario & scenario) const;
 
-    const std::vector<std::shared_ptr<Connection>> & getForwardConnections() const {return forwardConnections;}
-    const std::vector<std::shared_ptr<Connection>> & getReverseConnections() const {return reverseConnections;}
-
-    std::vector<std::shared_ptr<Connection>>::const_iterator getForwardConnectionsBeginAtDepartureHour(int hour) const;
-    std::vector<std::shared_ptr<Connection>>::const_iterator getReverseConnectionsBeginAtArrivalHour(int hour) const;
     /**
      * The update* methods get the data from the data fetcher
      *
@@ -103,7 +99,6 @@ namespace TrRouting {
     
   protected:
     DataStatus loadAllData();
-    void generateConnectionsIteratorCache();
     int generateForwardAndReverseConnections(const std::vector<std::shared_ptr<Connection>> &connections);
 
     DataFetcher &dataFetcher;
@@ -122,11 +117,6 @@ namespace TrRouting {
 
     std::vector<std::shared_ptr<Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
     std::vector<std::shared_ptr<Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
-
-    // Contains iterator matching each hour of the day from the corresponding connections container.
-    // Used to speed up iterating the connections by skipping the connections that are too early or too late
-    std::vector<std::vector<std::shared_ptr<Connection>>::const_iterator> forwardConnectionsBeginIteratorCache;
-    std::vector<std::vector<std::shared_ptr<Connection>>::const_iterator> reverseConnectionsBeginIteratorCache;
 
     mutable ScenarioConnectionCache scenarioConnectionCache = ScenarioConnectionCache();
   };

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -46,8 +46,8 @@ namespace TrRouting
     short allowSameLineTransfers;
     int totalCapacity; //Unused
     int seatedCapacity; //Unused
-    std::vector<std::shared_ptr<Connection>> forwardConnections;
-    std::vector<std::shared_ptr<Connection>> reverseConnections;
+    std::vector<std::reference_wrapper<const Connection>> forwardConnections;
+    std::vector<std::reference_wrapper<const Connection>> reverseConnections;
     std::vector<int>   connectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
 
     uid_t uid; //Local, temporary unique id, used to speed up lookups

--- a/src/connection_set.cpp
+++ b/src/connection_set.cpp
@@ -8,7 +8,7 @@ namespace TrRouting {
   const int CONNECTION_ITERATOR_CACHE_BEGIN_HOUR = 0;
   const int CONNECTION_ITERATOR_CACHE_END_HOUR = 32;
 
-  std::vector<std::reference_wrapper<Connection>>::const_iterator ConnectionSet::getForwardConnectionsBeginAtDepartureHour(int hour) const
+  std::vector<std::reference_wrapper<const Connection>>::const_iterator ConnectionSet::getForwardConnectionsBeginAtDepartureHour(int hour) const
   {
     if (hour > CONNECTION_ITERATOR_CACHE_END_HOUR || hour  < CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
       return forwardConnections.cend();
@@ -17,7 +17,7 @@ namespace TrRouting {
     return forwardConnectionsBeginIteratorCache[hour];
   };
 
-  std::vector<std::reference_wrapper<Connection>>::const_iterator ConnectionSet::getReverseConnectionsBeginAtArrivalHour(int hour) const
+  std::vector<std::reference_wrapper<const Connection>>::const_iterator ConnectionSet::getReverseConnectionsBeginAtArrivalHour(int hour) const
   {
     if (hour < CONNECTION_ITERATOR_CACHE_BEGIN_HOUR) {
       return reverseConnections.cend();
@@ -35,7 +35,7 @@ namespace TrRouting {
     // Create first part of the forward cache
     // For each hour, we save the iterator matching the connection which as a departure time bigger
     // than this hour
-    for (std::vector<std::reference_wrapper<Connection>>::const_iterator ite = forwardConnections.cbegin();
+    for (std::vector<std::reference_wrapper<const Connection>>::const_iterator ite = forwardConnections.cbegin();
          ite != forwardConnections.cend();
          ite++) {
       // We can have a gap of multiple hours between 2 connections, so the current iterator
@@ -55,7 +55,7 @@ namespace TrRouting {
 
     // Create the reverse cache
     currentHour = CONNECTION_ITERATOR_CACHE_END_HOUR - 1;
-    for (std::vector<std::reference_wrapper<Connection>>::const_iterator ite = reverseConnections.cbegin();
+    for (std::vector<std::reference_wrapper<const Connection>>::const_iterator ite = reverseConnections.cbegin();
          ite != reverseConnections.cend();
          ite++) {
       // Fill cache with same iterator if we have multi hour gap between connection
@@ -75,8 +75,8 @@ namespace TrRouting {
 
   ConnectionSet::ConnectionSet(
     const std::vector<std::reference_wrapper<const Trip>> _trips,
-    const std::vector<std::reference_wrapper<Connection>> _forwardConnections,
-    const std::vector<std::reference_wrapper<Connection>> _reverseConnections
+    const std::vector<std::reference_wrapper<const Connection>> _forwardConnections,
+    const std::vector<std::reference_wrapper<const Connection>> _reverseConnections
   ): trips(_trips), forwardConnections(_forwardConnections), reverseConnections(_reverseConnections) {
     generateConnectionsIteratorCache();
   }

--- a/src/connection_set.cpp
+++ b/src/connection_set.cpp
@@ -29,7 +29,6 @@ namespace TrRouting {
   };
 
   // Create a cache with a begin iterator which match the connection closest to the specified hour
-  // TODO Copy-pasted from transit_data, remove it from there if not required anymore
   void ConnectionSet::generateConnectionsIteratorCache() {
     int currentHour = CONNECTION_ITERATOR_CACHE_BEGIN_HOUR;
 

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -25,7 +25,7 @@ namespace TrRouting
     const std::map<boost::uuids::uuid, Line>& lines,
     std::map<boost::uuids::uuid, Path>& paths,
     const std::map<boost::uuids::uuid, Service>& services,
-    std::vector<std::shared_ptr<Connection>>& connections,
+    std::vector<Connection>& connections,
     std::string customPath
   )
   {
@@ -101,7 +101,8 @@ namespace TrRouting
               // nodeTimesCount - 1, since we process node pairs, we have to stop and the second from last
               for (unsigned long nodeTimeI = 0; nodeTimeI < nodeTimesCount - 1; nodeTimeI++)
               {
-                  std::shared_ptr<Connection> forwardConnection(std::make_shared<Connection>(Connection(
+
+                  connections.push_back(Connection(
                     path.nodesRef[nodeTimeI].get(),
                     path.nodesRef[nodeTimeI + 1].get(),
                     departureTimesSeconds[nodeTimeI],
@@ -112,9 +113,7 @@ namespace TrRouting
                     nodeTimeI + 1,
                     trip.allowSameLineTransfers,
                     line.mode.isTransferable() ? 0 : -1
-                  )));
-
-                  connections.push_back(std::move(forwardConnection));
+                  ));
 
                   trip.connectionDepartureTimes[nodeTimeI] = departureTimesSeconds[nodeTimeI];
 

--- a/tests/cache_fetch/schedules_cache_fetcher_test.cpp
+++ b/tests/cache_fetch/schedules_cache_fetcher_test.cpp
@@ -20,7 +20,7 @@ protected:
     std::map<boost::uuids::uuid, TrRouting::Node> nodes;
     std::map<boost::uuids::uuid, int> tripIndexesByUuid;
     std::map<boost::uuids::uuid, TrRouting::Service> services;
-    std::vector<std::shared_ptr<TrRouting::Connection>> connections;
+    std::vector<TrRouting::Connection> connections;
 
 public:
     void SetUp( ) override
@@ -63,6 +63,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesInvalidLineFile)
     // TODO: Since a file was invalid, should this return -EBADMSG?
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0u, trips.size());
+    ASSERT_EQ(0u, connections.size());
 }
 
 TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
@@ -77,6 +78,7 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetUnexistingLineFiles)
     );
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(0u, trips.size());
+    ASSERT_EQ(0u, connections.size());
 }
 
 TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
@@ -91,4 +93,5 @@ TEST_F(ScheduleCacheFetcherFixtureTests, TestGetSchedulesValid)
     );
     ASSERT_EQ(0, retVal);
     ASSERT_EQ(50u, trips.size());
+    ASSERT_EQ(275u, connections.size());
 }

--- a/tests/connection_scan_algorithm/connection_set_test.cpp
+++ b/tests/connection_scan_algorithm/connection_set_test.cpp
@@ -20,8 +20,8 @@ class ReverseConnectionIteratorTestSuite : public ConnectionSetFixtureTests,
 
 // Create a connection set object with all connections
 std::shared_ptr<ConnectionSet> getConnectionSet(TransitData transitData) {
-    std::vector<std::reference_wrapper<Connection>> forwardConnections;
-    std::vector<std::reference_wrapper<Connection>> reverseConnections;
+    std::vector<std::reference_wrapper<const Connection>> forwardConnections;
+    std::vector<std::reference_wrapper<const Connection>> reverseConnections;
 
     auto forwardLastConnection = getForwardConnections().end(); // cache last connection for loop
     for(auto connection = getForwardConnections().begin(); connection != forwardLastConnection; ++connection)

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
@@ -322,14 +322,14 @@ int TestDataFetcher::getScenarios(
 
 
 
-void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<std::shared_ptr<TrRouting::Connection>>& connections, int arrivalTimes[], int departureTimes[], int arraySize)
+void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<TrRouting::Connection>& connections, int arrivalTimes[], int departureTimes[], int arraySize)
 {
     path.tripsRef.push_back(trip);
 
     trip.connectionDepartureTimes.resize(arraySize);
 
     for (int nodeTimeI = 0; nodeTimeI < arraySize - 1; nodeTimeI++) {
-      std::shared_ptr<TrRouting::Connection> forwardConnection(std::make_shared<TrRouting::Connection>(TrRouting::Connection(
+        connections.push_back(TrRouting::Connection(
             path.nodesRef[nodeTimeI],
             path.nodesRef[nodeTimeI + 1],
             departureTimes[nodeTimeI],
@@ -340,9 +340,7 @@ void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<std
             nodeTimeI + 1,
             trip.allowSameLineTransfers,
             -1
-        )));
-
-        connections.push_back(std::move(forwardConnection));
+        ));
 
         trip.connectionDepartureTimes[nodeTimeI] = departureTimes[nodeTimeI];
 
@@ -359,7 +357,7 @@ int TestDataFetcher::getSchedules(
                                   const std::map<boost::uuids::uuid, TrRouting::Line>& lines,
                                   std::map<boost::uuids::uuid, TrRouting::Path>& paths,
                                   const std::map<boost::uuids::uuid, TrRouting::Service>& services,
-                                  std::vector<std::shared_ptr<TrRouting::Connection>>& connections,
+                                  std::vector<TrRouting::Connection>& connections,
                                   std::string
                                   ) {
 

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.hpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.hpp
@@ -139,7 +139,7 @@ class TestDataFetcher : public TrRouting::DataFetcher
       const std::map<boost::uuids::uuid, TrRouting::Line>& lines,
       std::map<boost::uuids::uuid, TrRouting::Path>& paths,
       const std::map<boost::uuids::uuid, TrRouting::Service>& services,
-      std::vector<std::shared_ptr<TrRouting::Connection>>& connections,
+      std::vector<TrRouting::Connection>& connections,
       std::string customPath = ""
     );
         


### PR DESCRIPTION
* Removed unused code
* Keep only disabled trips for each calculation instead of a boolean value for all trips all the time
* Let TransitData manage a vector of the Connection objects and forward and reverse connections can now use reference_wrapper to const Connection instead of shared_ptr.

Here are some benchmark results of this PR (in rough average, showing the performance gain), vs the preCache and the scenario cache PR, with various capnp cache data
|    | vs preCache, single | vs preCache, alternatives | vs scenario cache, single | vs scenario cache, alternatives
|----|----|----|----|----|
|benchmark cache| 16 to 50% | 15 to 50% | 20 to 50% | 15 to 45% |
| large cache (eod) | 65 to 95% | precache alternatives did not work | 17 to 30% | 15 to 30% |

For memory, if I take the data I mentioned in https://github.com/chairemobilite/trRouting/pull/238#issuecomment-1437458333
|    | preCache | PR #238 | This PR
|---|---|---|---
| benchmark data | 173 | 192 | 121 |
| Small instance | 203 | 242 | 140 | 
| Large instance (eod) | 1946 | 1993 | 1000 |
