### PR TITLE
Add missing spdlog install instruction for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://chairemobilite.github.io/trRouting/
 ```
 brew install boost
 brew install capnp
+brew install spdlog
 ```
 
 ## Ubuntu 16.04 Install


### PR DESCRIPTION
I had the following error when compiling on macOS:

```
....
checking pkg-config is at least version 0.9.0... yes
checking for capnp... yes
checking for capnp... /usr/local/bin/capnp
checking for spdlog... no
configure: error: Package requirements (spdlog) were not met:

No package 'spdlog' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables SPDLOG_CFLAGS
and SPDLOG_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```

Had to be fixed using `brew install spdlog`. This PR adds this command to the README.md file.