### PR TITLE
Change log levels of endpoint entry/exit

### DIFF
--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -194,7 +194,7 @@ namespace TrRouting
           alternativeParameters.exceptLines.push_back(line);
         }
 
-        spdlog::info("calculating alternative {} from a total of {} ...", alternativeSequence, alternativesCalculatedCount);
+        spdlog::debug("calculating alternative {} from a total of {} ...", alternativeSequence, alternativesCalculatedCount);
         
         spdlog::debug("except lines: {}", LinesToString(combination));
 


### PR DESCRIPTION
Part of #248

The alternatives calculation statements are set to 'debug' instead of 'info'.

The log statement at the beginning and end of the v2/* routes are set to 'info' and parameters are removed, spdlog will associate a timestamp with the log, so no need to display the application's time.

If a catchall exception occurs, the log level is 'error'.

TODO
Cleanup the 'debug' statements and set a few as 'trace'