### PR TITLE
csa: Make sure the connection arrival node is a candidate

### DIFF
--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -76,6 +76,7 @@ namespace TrRouting
             nodeDepartureTentativeTime = MAX_INT;
           }
 
+          // TODO Do we need to make sure the departure node exists in the forwardJourneySteps map? For the reverse calculation, we had to in order to fix issue https://github.com/chairemobilite/trRouting/issues/250 The issue may apply to forward too, but we have no example
           auto nodesAccessIte = nodesAccess.find(nodeDeparture.uid);          
           nodeWasAccessedFromOrigin  = parameters.getMaxFirstWaitingTimeSeconds() > 0 &&
             nodesAccessIte != nodesAccess.end() &&

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -86,10 +86,12 @@ namespace TrRouting
           )
           {
             
-            if ((*connection).get().canUnboard())
+            // Make sure the arrival of the connection can unboard and is a candidate for the journey. Nodes are candidate if they can either reach the destination by foot, or a connection that can reach the destination within the specified parameters.
+            auto rjsIte = reverseJourneysSteps.find(nodeArrival.uid);
+            if ((*connection).get().canUnboard() && rjsIte != reverseJourneysSteps.end())
             {
               // Extract journeyStep once from map
-              const JourneyStep & reverseStepAtArrival = reverseJourneysSteps.at(nodeArrival.uid);
+              const JourneyStep & reverseStepAtArrival = rjsIte->second;
               if (!tripExitConnection.has_value()) // <= to make sure we get the same result as forward calculation, which uses >
               {
                 currentTripQueryOverlay.exitConnection = *connection;


### PR DESCRIPTION
fixes #250

Lookup the arrival node in the reverse journey steps map to make sure the arrival node of the connection is a candidate for the journey.

Otherwise, it throws an exception when calling the `at`, making the whole query fail.