### PR TITLE
Add an option to cache all connectionSets from all scenarios

### DIFF
--- a/connection_scan_algorithm/include/program_options.hpp
+++ b/connection_scan_algorithm/include/program_options.hpp
@@ -16,6 +16,7 @@ namespace TrRouting
     std::string cachePath;
     int         port;
     bool        debug;
+    bool        cacheAllConnectionSets;
     std::string algorithm;
     std::string dataFetcherShortname;
     std::string osrmWalkingPort;

--- a/connection_scan_algorithm/src/program_options.cpp
+++ b/connection_scan_algorithm/src/program_options.cpp
@@ -16,6 +16,8 @@ namespace TrRouting {
       ("dataFetcher,data",                                  boost::program_options::value<std::string>()->default_value("cache"), "data fetcher (csv, gtfs or cache)"); // only cache implemented for now
     options.add_options()
       ("cachePath",                                         boost::program_options::value<std::string>()->default_value("cache"), "cache path");
+   options.add_options()
+      ("cacheAllConnectionSets",                            boost::program_options::value<bool>()       ->default_value(false), "cache all connections set instead of the ones from the last used scenario");
     options.add_options()
       ("osrmPort,osrmWalkPort,osrmWalkingPort",             boost::program_options::value<std::string>()->default_value("5000"), "osrm walking port");
     options.add_options()
@@ -40,6 +42,7 @@ namespace TrRouting {
     debug                = false;
     dataFetcherShortname = "cache";
     cachePath            = "cache";
+    cacheAllConnectionSets = false;
     osrmWalkingPort      = "5000";
     osrmCyclingPort      = "8000";
     osrmDrivingPort      = "7000";
@@ -70,6 +73,10 @@ namespace TrRouting {
     if(variablesMap.count("cachePath") == 1)
     {
       cachePath = variablesMap["cachePath"].as<std::string>();
+    }
+    if(variablesMap.count("cacheAllConnectionSets") == 1)
+    {
+      cacheAllConnectionSets = variablesMap["cacheAllConnectionSets"].as<bool>();
     }
 
     if(variablesMap.count("osrmWalkPort") == 1)

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
   }
 
   spdlog::info("preparing calculator...");
-  TransitData transitData(*fetcher);
+  TransitData transitData(*fetcher, programOptions.cacheAllConnectionSets);
   //TODO We wanted to handle error in the constructor, but later part of this code expect a dataStatus
   // leaving as a todo
   DataStatus dataStatus = transitData.getDataStatus();

--- a/include/connection_cache.hpp
+++ b/include/connection_cache.hpp
@@ -5,7 +5,7 @@
 #include <optional>
 #include <boost/uuid/uuid.hpp>
 #include <memory>
-
+#include <map>
 
 namespace TrRouting {
 
@@ -14,27 +14,61 @@ class ConnectionSet;
 
 
 /**
- * @brief Caches the connection sets used by different transit scenarios.
+ * @brief Interface for the caches of the connection sets used by different transit scenarios.
  *
- * // TODO Currently caches only the last queried scenario. We could make this a
+ * // TODO Currently caches only the last queried scenario or all of them. We could make this a
  * real lru cache eventually, or not, if we find a better way to handle scenario
  * query data.
  */
 class ScenarioConnectionCache {
 
   public:
-    ScenarioConnectionCache()
-    {
-       
-    };
     virtual ~ScenarioConnectionCache() {}
     
-    std::optional<std::shared_ptr<ConnectionSet>> get(boost::uuids::uuid uuid) const;
-    void set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache);
+    virtual std::optional<std::shared_ptr<ConnectionSet>> get(boost::uuids::uuid uuid) const = 0;
+    virtual void set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache) = 0;
+};
+
+/**
+ * @brief Caches the last connection sets used by different transit scenarios.
+ *
+ */
+class ScenarioConnectionCacheOne : public ScenarioConnectionCache {
+
+  public:
+    ScenarioConnectionCacheOne()
+    {
+
+    }
+    virtual ~ScenarioConnectionCacheOne() {}
+
+    virtual std::optional<std::shared_ptr<ConnectionSet>> get(boost::uuids::uuid uuid) const;
+    virtual void set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache);
 
   private:
     std::optional<boost::uuids::uuid> lastUuid;
     std::shared_ptr<ConnectionSet> lastConnection;
+};
+
+
+/**
+ * @brief Caches the all connection sets used by different transit scenarios.
+ *
+ */
+class ScenarioConnectionCacheAll : public ScenarioConnectionCache {
+
+  public:
+    ScenarioConnectionCacheAll()
+    {
+
+    }
+    virtual ~ScenarioConnectionCacheAll(){}
+
+    virtual std::optional<std::shared_ptr<ConnectionSet>> get(boost::uuids::uuid uuid) const;
+    virtual void set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache);
+
+  private:
+    std::map<boost::uuids::uuid, std::shared_ptr<ConnectionSet> > connectionSets;
 };
 
 }

--- a/include/transit_data.hpp
+++ b/include/transit_data.hpp
@@ -52,7 +52,8 @@ namespace TrRouting {
 
   class TransitData {
   public:
-    TransitData(DataFetcher& dataFetcher);
+    TransitData(DataFetcher& dataFetcher, bool cacheAllScenarios = false);
+    virtual ~TransitData();
     DataStatus getDataStatus() const;
     
     // const data access functions
@@ -119,7 +120,8 @@ namespace TrRouting {
     std::vector<std::reference_wrapper<const Connection>> forwardConnections; // Forward connections, sorted by departure time ascending
     std::vector<std::reference_wrapper<const Connection>> reverseConnections; // Reverse connections, sorted by arrival time descending
 
-    mutable ScenarioConnectionCache scenarioConnectionCache = ScenarioConnectionCache();
+    //TODO Consider using a reference instead, making sure the object is always valid
+    mutable ScenarioConnectionCache *scenarioConnectionCache;
   };
 
 }

--- a/src/connection_cache.cpp
+++ b/src/connection_cache.cpp
@@ -2,11 +2,12 @@
 #include "connection_set.hpp"
 #include "spdlog/spdlog.h"
 #include "connection.hpp"
+#include <boost/uuid/uuid_io.hpp>
 
 
 namespace TrRouting {
-
-  std::optional<std::shared_ptr<ConnectionSet>> ScenarioConnectionCache::get(boost::uuids::uuid uuid) const {
+  // ScenarioConnectionCacheOne
+  std::optional<std::shared_ptr<ConnectionSet>> ScenarioConnectionCacheOne::get(boost::uuids::uuid uuid) const {
     if (uuid == lastUuid) {
       return std::optional(lastConnection);
     } else {
@@ -14,8 +15,25 @@ namespace TrRouting {
     }
   }
 
-  void ScenarioConnectionCache::set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache) {
+  void ScenarioConnectionCacheOne::set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache) {
     lastUuid = uuid;
     lastConnection = cache;
+  }
+
+  // ScenarioConnectionCacheAll
+  std::optional<std::shared_ptr<ConnectionSet>> ScenarioConnectionCacheAll::get(boost::uuids::uuid uuid) const {
+    // Lookup the scenario uuid in the map. If found, returns it, if not, return a null_opt
+    auto connectionSetItr = connectionSets.find(uuid);
+    if (connectionSetItr != connectionSets.end()) {
+      return std::optional(connectionSetItr->second);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  void ScenarioConnectionCacheAll::set(boost::uuids::uuid uuid, std::shared_ptr<ConnectionSet> cache) {
+    spdlog::debug("Caching connection set for scenario {}", boost::uuids::to_string(uuid));
+
+    connectionSets[uuid] = cache;
   }
 }


### PR DESCRIPTION
In a situation where you have multiple scenario and where you often switch between them, having only one connection set in the cache does not offer lot of perf improvement.

This add a --cacheAllConnectionSets parameter, which when set to true will cache all connection cache.

This is implemented with a new ScenarioConnectionCacheAll class. (the old one renamed to ScenarioConnectionCacheOne) The flag define which one the TransitData class will instanciate.

Issue #252