### PR TITLE
Reset global params object in calculator at beginning of V2 request.

### DIFF
--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -469,6 +469,7 @@ int main(int argc, char** argv) {
     calculator.benchmarking.clear();
 
     // prepare parameters:
+    calculator.params.setDefaultValues(); // Reset global params object (TODO only need while its global)
     std::vector<std::pair<std::string, std::string>> parametersWithValues;
     auto queryFields = request->parse_query_string();
     for(auto &field : queryFields)
@@ -540,6 +541,7 @@ int main(int argc, char** argv) {
     calculator.benchmarking.clear();
 
     // prepare parameters:
+    calculator.params.setDefaultValues(); // Reset global params object (TODO only need while its global)
     std::vector<std::pair<std::string, std::string>> parametersWithValues;
     auto queryFields = request->parse_query_string();
     for(auto &field : queryFields)
@@ -611,6 +613,7 @@ int main(int argc, char** argv) {
     calculator.benchmarking.clear();
 
     // prepare parameters:
+    calculator.params.setDefaultValues(); // Reset global params object (TODO only need while its global)
     std::vector<std::pair<std::string, std::string>> parametersWithValues;
     auto queryFields = request->parse_query_string();
     for(auto &field : queryFields)


### PR DESCRIPTION
If we were doing a request with the old V1 API, you could set some global flags that would not be reseted when then calling a V2 API.

We were hitting the assert in forward_calculation in the forwardCalculation() call