### PR TITLE
Replace the nodesTentativeTime from a map to a vector

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -113,7 +113,7 @@ namespace TrRouting
     int              minEgressTravelTime;
     long long        calculationTime;
 
-    std::unordered_map<Node::uid_t, int> nodesTentativeTime; // arrival time at node
+    std::vector<int> nodesTentativeTime; // arrival time at node, using the Node::id as index
     std::unordered_map<Node::uid_t, int> nodesReverseTentativeTime; // departure time at node
     std::unordered_map<Node::uid_t, NodeTimeDistance> nodesAccess; // travel time/distance from origin to accessible nodes
     std::unordered_map<Node::uid_t, NodeTimeDistance> nodesEgress; // travel time/distance to reach destination;

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -68,13 +68,8 @@ namespace TrRouting
           std::optional<std::reference_wrapper<const Connection>> tripEnterConnection = currentTripQueryOverlay.enterConnection;
           const Node &nodeDeparture = (*connection).get().getDepartureNode();
 
-          // Extract node departure time if we have a result or set a default value
-          auto ite = nodesTentativeTime.find(nodeDeparture.uid);
-          if (ite != nodesTentativeTime.end()) {
-            nodeDepartureTentativeTime = ite->second;
-          } else{
-            nodeDepartureTentativeTime = MAX_INT;
-          }
+          // Extract node departure time if we have a result or use default value
+          nodeDepartureTentativeTime = nodesTentativeTime.at(nodeDeparture.uid);
 
           // TODO Do we need to make sure the departure node exists in the forwardJourneySteps map? For the reverse calculation, we had to in order to fix issue https://github.com/chairemobilite/trRouting/issues/250 The issue may apply to forward too, but we have no example
           auto nodesAccessIte = nodesAccess.find(nodeDeparture.uid);          
@@ -123,14 +118,8 @@ namespace TrRouting
               for (const NodeTimeDistance & transferableNode : nodeArrival.transferableNodes)
               {
                 // Extract tentative time for current transferable node if found
-                int currentTransferablenNodesTentativeTime = 0;
-                auto nodesIte = nodesTentativeTime.find(transferableNode.node.uid);
-                if (nodesIte != nodesTentativeTime.end()) {
-                  currentTransferablenNodesTentativeTime = nodesIte->second;
-                } else {
-                  currentTransferablenNodesTentativeTime = MAX_INT;
-                }
-                
+                int currentTransferablenNodesTentativeTime = nodesTentativeTime.at(transferableNode.node.uid);
+
                 if (nodeArrival != transferableNode.node &&
                     currentTransferablenNodesTentativeTime < connectionArrivalTime)
                 {
@@ -266,13 +255,8 @@ namespace TrRouting
           std::optional<std::reference_wrapper<const Connection>> tripEnterConnection = currentTripQueryOverlay.enterConnection;
           const Node &nodeDeparture = (*connection).get().getDepartureNode();
 
-          // Extract node departure time if we have a result or set a default value
-          auto ite = nodesTentativeTime.find(nodeDeparture.uid);
-          if (ite != nodesTentativeTime.end()) {
-            nodeDepartureTentativeTime = ite->second;
-          } else{
-            nodeDepartureTentativeTime = MAX_INT;
-          }
+          // Extract node departure time if we have a result or use default value
+          nodeDepartureTentativeTime = nodesTentativeTime.at(nodeDeparture.uid);
 
           auto nodesAccessIte = nodesAccess.find(nodeDeparture.uid);
           nodeWasAccessedFromOrigin  = parameters.getMaxFirstWaitingTimeSeconds() > 0 &&
@@ -313,13 +297,7 @@ namespace TrRouting
               for (const NodeTimeDistance & transferableNode : nodeArrival.transferableNodes)
               {
                 // Extract tentative time for current transferable node if found
-                int currentTransferablenNodesTentativeTime = 0;
-                auto nodesIte = nodesTentativeTime.find(transferableNode.node.uid);
-                if (nodesIte != nodesTentativeTime.end()) {
-                  currentTransferablenNodesTentativeTime = nodesIte->second;
-                } else {
-                  currentTransferablenNodesTentativeTime = MAX_INT;
-                }
+                int currentTransferablenNodesTentativeTime = nodesTentativeTime.at(transferableNode.node.uid);
 
                 if (nodeArrival != transferableNode.node &&
                     currentTransferablenNodesTentativeTime < connectionArrivalTime)

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -80,7 +80,8 @@ namespace TrRouting
       int footpathDistanceMeters;
       nodesAccess.clear();
       forwardJourneysSteps.clear();
-      nodesTentativeTime.clear();
+      nodesTentativeTime.assign(Node::getMaxUid() + 1, MAX_INT); //Assign default values to all indexes
+      
       for (auto & accessFootpath : accessFootpaths)
       {
         footpathTravelTimeSeconds = (int)ceil((float)(accessFootpath.time) / params.walkingSpeedFactor);

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -52,6 +52,8 @@ namespace TrRouting
     inline bool operator<(const Node& other ) const { return uid < other.uid; }
     inline bool operator!=(const Node& other ) const { return uid != other.uid; }
 
+    static uid_t getMaxUid() { return global_uid; }
+
   private:
     //TODO, this could probably be an unsigned long, but current MAX_INT is good enough for our needs
     inline static uid_t global_uid = 0;


### PR DESCRIPTION
We used the node global as a max entry to size the vector.

Fetching the temporary data from a map in the calculation loop is too intensive. Using a vector with a constant access is more efficient. We just need to be careful in match the UID of the Nodes