### PR TITLE
Don't copie the scenario filter into the commonparameters

### DIFF
--- a/connection_scan_algorithm/src/parameters/common_parameters.cpp
+++ b/connection_scan_algorithm/src/parameters/common_parameters.cpp
@@ -27,16 +27,7 @@ namespace TrRouting
         maxFirstWaitingTimeSeconds(maxFirstWaitingTime),
         forwardCalculation(forward)
   {
-    scenarioUuid = scenario.uuid;
-    onlyServices = scenario.servicesList;
-    onlyLines = scenario.onlyLines;
-    onlyAgencies = scenario.onlyAgencies;
-    onlyNodes = scenario.onlyNodes;
-    onlyModes = scenario.onlyModes;
-    exceptLines = scenario.exceptLines;
-    exceptAgencies = scenario.exceptAgencies;
-    exceptNodes = scenario.exceptNodes;
-    exceptModes = scenario.exceptModes;
+    scenarioUuid = scenario.uuid; //TODO Check if this is used somewhere
   }
 
   CommonParameters::CommonParameters(const CommonParameters& baseParams):


### PR DESCRIPTION
When creating the initial ConnectionSet, we fetch the filters directly from the scenario object. With the current code copying the filter data, we would reapply the same filters to the trips list in the reset functions, spending time for no use.