### PR TITLE
Check for index in path node list when parsing connection

### DIFF
--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -102,9 +102,10 @@ namespace TrRouting
               for (unsigned long nodeTimeI = 0; nodeTimeI < nodeTimesCount - 1; nodeTimeI++)
               {
 
+                try {
                   connections.push_back(Connection(
-                    path.nodesRef[nodeTimeI].get(),
-                    path.nodesRef[nodeTimeI + 1].get(),
+                    path.nodesRef.at(nodeTimeI).get(),
+                    path.nodesRef.at(nodeTimeI + 1).get(),
                     departureTimesSeconds[nodeTimeI],
                     arrivalTimesSeconds[nodeTimeI + 1],
                     trip,
@@ -116,7 +117,10 @@ namespace TrRouting
                   ));
 
                   trip.connectionDepartureTimes[nodeTimeI] = departureTimesSeconds[nodeTimeI];
-
+                } catch (std::out_of_range const& exc) {
+                  spdlog::error("Index out of range while parsing connection for trip on line ({})", path.line.longname);
+                  return -1;
+                }
               }
             }
           }


### PR DESCRIPTION
We had an issue when the data got corrupted and the number of entry in the path was not the same as in the schedule. This was corrupting the memory. We use the at() instead of [] when accessing the vector in the parsing loop in getSchedules() and we display a meaningful error message if we get the exceptiono