### PR TITLE
Add a new error code for invalid scenario

### DIFF
--- a/connection_scan_algorithm/src/parameters/common_parameters.cpp
+++ b/connection_scan_algorithm/src/parameters/common_parameters.cpp
@@ -105,12 +105,20 @@ namespace TrRouting
       // scenario:
       else if (parameterWithValue.first == "scenario_id")
       {
-        boost::uuids::uuid scenarioUuid  = uuidGenerator(parameterWithValue.second);
-
+        boost::uuids::uuid scenarioUuid;
+        try {
+          scenarioUuid  = uuidGenerator(parameterWithValue.second);
+        } catch (std::runtime_error const& exc) {
+          // If we cannot parse the parameter as a valid uuid, return an INVALID error
+          throw ParameterException(ParameterException::Type::INVALID_SCENARIO);
+        }
         auto scenarioIte = scenarios.find(scenarioUuid);
         if (scenarioIte != scenarios.end())
         {
           scenario = scenarioIte->second;
+        } else {
+          // If the scenario UUID is not in our DB return an INVALID error
+          throw ParameterException(ParameterException::Type::INVALID_SCENARIO);
         }
         continue;
       }

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -92,6 +92,7 @@ std::string getResponseCode(ParameterException::Type type)
     case ParameterException::Type::MISSING_ORIGIN: return "MISSING_PARAM_ORIGIN";
     case ParameterException::Type::MISSING_DESTINATION: return "MISSING_PARAM_DESTINATION";
     case ParameterException::Type::MISSING_TIME_OF_TRIP: return "MISSING_PARAM_TIME_OF_TRIP";
+    case ParameterException::Type::INVALID_SCENARIO: return "INVALID_SCENARIO";
     case ParameterException::Type::INVALID_ORIGIN: return "INVALID_ORIGIN";
     case ParameterException::Type::INVALID_DESTINATION: return "INVALID_DESTINATION";
     case ParameterException::Type::INVALID_NUMERICAL_DATA: return "INVALID_NUMERICAL_DATA";

--- a/docs/APIv2/accessibilityResponse.yml
+++ b/docs/APIv2/accessibilityResponse.yml
@@ -13,6 +13,7 @@ access_query_error: # 'query_error' is a value for the status (discriminator)
         - 'MISSING_PARAM_SCENARIO'
         - 'MISSING_PARAM_PLACE'
         - 'MISSING_PARAM_TIME_OF_TRIP'
+        - 'INVALID_SCENARIO'
         - 'INVALID_PLACE'
         - 'INVALID_NUMERICAL_DATA'
         - 'PARAM_ERROR_UNKNOWN'

--- a/docs/APIv2/commonResponse.yml
+++ b/docs/APIv2/commonResponse.yml
@@ -34,6 +34,7 @@ query_error: # 'query_error' is a value for the status (discriminator)
         - 'MISSING_PARAM_ORIGIN'
         - 'MISSING_PARAM_DESTINATION'
         - 'MISSING_PARAM_TIME_OF_TRIP'
+        - 'INVALID_SCENARIO'
         - 'INVALID_ORIGIN'
         - 'INVALID_DESTINATION'
         - 'INVALID_NUMERICAL_DATA'

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -47,6 +47,8 @@ namespace TrRouting
         MISSING_PLACE,
         // The selected scenario does not contain any trips
         EMPTY_SCENARIO,
+        // The specified scenario id is invalid
+        INVALID_SCENARIO,
         // Origin data received is invalid. Expected comma-separated lon/lat
         INVALID_ORIGIN,
         // Destination data received is invalid. Expected comma-separated lon/lat

--- a/tests/connection_scan_algorithm/parameters/accessibility_param_test.cpp
+++ b/tests/connection_scan_algorithm/parameters/accessibility_param_test.cpp
@@ -13,6 +13,7 @@
 
 const std::string EMPTY_SCENARIO_UUID = "acdcef12-1111-2222-3333-444455558888";
 const std::string TEST_SCENARIO_UUID = "12345678-9999-0000-1111-ababbabaabab";
+const std::string INVALID_SCENARIO_UUID = "11111111-0000-0000-1111-ababbabaabab";
 
 class AccessibilityParametersFixtureTests : public BaseParametersFixtureTests
 {
@@ -56,6 +57,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("time_of_trip", "", TrRouting::ParameterException::Type::MISSING_TIME_OF_TRIP),
         std::make_tuple("time_of_trip", "-3", TrRouting::ParameterException::Type::MISSING_TIME_OF_TRIP),
         std::make_tuple("scenario_id", EMPTY_SCENARIO_UUID, TrRouting::ParameterException::Type::EMPTY_SCENARIO),
+        std::make_tuple("scenario_id", "SOMEGARBAGE", TrRouting::ParameterException::Type::INVALID_SCENARIO),
+        std::make_tuple("scenario_id", INVALID_SCENARIO_UUID, TrRouting::ParameterException::Type::INVALID_SCENARIO),
         std::make_tuple("place", "45", TrRouting::ParameterException::Type::INVALID_PLACE),
         std::make_tuple("place", "foo,bar", TrRouting::ParameterException::Type::INVALID_PLACE),
         std::make_tuple("min_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),

--- a/tests/connection_scan_algorithm/parameters/route_param_test.cpp
+++ b/tests/connection_scan_algorithm/parameters/route_param_test.cpp
@@ -13,6 +13,7 @@
 
 const std::string EMPTY_SCENARIO_UUID = "acdcef12-1111-2222-3333-444455558888";
 const std::string TEST_SCENARIO_UUID = "12345678-9999-0000-1111-ababbabaabab";
+const std::string INVALID_SCENARIO_UUID = "11111111-0000-0000-1111-ababbabaabab";
 
 class RouteParametersFixtureTests : public BaseParametersFixtureTests
 {
@@ -57,6 +58,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("time_of_trip", "", TrRouting::ParameterException::Type::MISSING_TIME_OF_TRIP),
         std::make_tuple("time_of_trip", "-3", TrRouting::ParameterException::Type::MISSING_TIME_OF_TRIP),
         std::make_tuple("scenario_id", EMPTY_SCENARIO_UUID, TrRouting::ParameterException::Type::EMPTY_SCENARIO),
+        std::make_tuple("scenario_id", "SOMEGARBAGE", TrRouting::ParameterException::Type::INVALID_SCENARIO),
+        std::make_tuple("scenario_id", INVALID_SCENARIO_UUID, TrRouting::ParameterException::Type::INVALID_SCENARIO),
         std::make_tuple("origin", "45", TrRouting::ParameterException::Type::INVALID_ORIGIN),
         std::make_tuple("origin", "foo,bar", TrRouting::ParameterException::Type::INVALID_ORIGIN),
         std::make_tuple("destination", "-73", TrRouting::ParameterException::Type::INVALID_DESTINATION),


### PR DESCRIPTION
Currently, if we send a scenario id but that ID is not in the available cache data, we return the error MISSING_SCENARIO, which is missleading.

We add a new error code INVALID_SCENARIO, that will be returned if the scenario_id is not a valid uuid, or it's not present in our data source

Fixes: #295