### PR TITLE
Add support to cache accessible nodes via Memcached

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /source
 # Install dependencies in an intermediate image
 RUN apt-get update && \
     apt-get -y --no-install-recommends install build-essential autoconf automake autoconf-archive pkg-config capnproto libcapnp-dev \
-    libboost-all-dev libtool libspdlog-dev nlohmann-json3-dev
+    libboost-all-dev libtool libspdlog-dev nlohmann-json3-dev libmemcached-dev
 
 # Copy and build source    
 COPY . /source    

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ brew install boost
 brew install capnp
 brew install spdlog
 brew install nlohmann-json
+brew install libmemcached
 ```
 
+libmemcached is optional
 ## Ubuntu 24.04 Install
 
 ```
@@ -41,6 +43,7 @@ You if you haven't installed other basic build dependencies, like autoconf, you 
 sudo apt install build-essential autoconf pkg-config
 ```
 
+libmemcached-dev is optional
 ## Compilation
 trRouting use autoconf/automake as its build system. A recap of the usual commands: 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ https://chairemobilite.github.io/trRouting/
 [5]: https://github.com/Project-OSRM/osrm-backend/blob/master/docs/profiles.md "OSRM profiles"
 [6]: https://github.com/Project-OSRM/osrm-backend/wiki/Running-OSRM "Running OSRM"
 
+### Memcached support
+trRouting have the ability to cache some of the accessible node calculation results. To do so, it can
+use an external memcached daemon.
+You tell trRouting to do this by passing the --useMemcached parameter. By default it will
+try to access memcached on the default port, 11211 on the localhost. You can pass an hostname/port
+to the useMemcached parameter like so: --useMemcached=localhost:11111
+
+The memcached support will only be compiled if the configure script can detect libmemcached on
+the system, hence why it's marked as optional in the instructions bellow
+
 ## Mac OS X Install with homebrew
 ```
 brew install boost

--- a/configure.ac
+++ b/configure.ac
@@ -32,23 +32,31 @@ PKG_CHECK_MODULES(SPDLOG, spdlog)
 
 PKG_CHECK_MODULES(JSON, nlohmann_json)
 
-# Check for libmemcached
+# Check for libmemcached and libmemcachedutil
 AC_ARG_WITH([memcached],
     [AS_HELP_STRING([--with-memcached],
         [enable memcached support @<:@default=check@:>@])],
     [],
     [with_memcached=check])
 
+# Default to not having memcached
+have_memcached=no
+
 AS_IF(
     [test "x$with_memcached" != xno],
     [PKG_CHECK_MODULES([MEMCACHED], [libmemcached],
-        [have_memcached=yes
-         AC_DEFINE([HAVE_MEMCACHED], [1], [Define if libmemcached is available])],
-        [have_memcached=no
-         AS_IF([test "x$with_memcached" != xcheck],
-               [AC_MSG_FAILURE([--with-memcached was given, but libmemcached was not found])])])],
-    [have_memcached=no])
+        [# Now check for libmemcachedutil
+         AC_CHECK_LIB([memcachedutil], [memcached_pool_create],
+            [have_memcached=yes
+             AC_DEFINE([HAVE_MEMCACHED], [1], [Define if libmemcached and libmemcachedutil are available])
+             MEMCACHED_LIBS="$MEMCACHED_LIBS -lmemcachedutil"],
+            [# Both libraries are required
+             AS_IF([test "x$with_memcached" != xcheck],
+                   [AC_MSG_FAILURE([--with-memcached was given, but libmemcachedutil was not found])])])],
+        [AS_IF([test "x$with_memcached" != xcheck],
+               [AC_MSG_FAILURE([--with-memcached was given, but libmemcached was not found])])])])
 
+# Set memcached conditional
 AM_CONDITIONAL([HAVE_MEMCACHED], [test "x$have_memcached" = xyes])
 
 # TODO: Add link to doc of this override flag

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ AX_BOOST_SYSTEM # For include/asio_compatibility.hpp
 AX_BOOST_REGEX # For include/server_http.hpp
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_DATE_TIME # For include/service.hpp
+AX_BOOST_SERIALIZATION # For memcached serialization
 
 AX_PTHREAD # Explicitely checking, needed by std::thread
 
@@ -31,17 +32,42 @@ PKG_CHECK_MODULES(SPDLOG, spdlog)
 
 PKG_CHECK_MODULES(JSON, nlohmann_json)
 
+# Check for libmemcached
+AC_ARG_WITH([memcached],
+    [AS_HELP_STRING([--with-memcached],
+        [enable memcached support @<:@default=check@:>@])],
+    [],
+    [with_memcached=check])
+
+AS_IF(
+    [test "x$with_memcached" != xno],
+    [PKG_CHECK_MODULES([MEMCACHED], [libmemcached],
+        [have_memcached=yes
+         AC_DEFINE([HAVE_MEMCACHED], [1], [Define if libmemcached is available])],
+        [have_memcached=no
+         AS_IF([test "x$with_memcached" != xcheck],
+               [AC_MSG_FAILURE([--with-memcached was given, but libmemcached was not found])])])],
+    [have_memcached=no])
+
+AM_CONDITIONAL([HAVE_MEMCACHED], [test "x$have_memcached" = xyes])
+
 # TODO: Add link to doc of this override flag
 CPPFLAGS+=" -DBOOST_BIND_GLOBAL_PLACEHOLDERS"
 
 CPPFLAGS+=" $BOOST_CPPFLAGS $CAPNP_CFLAGS $PTHREAD_CFLAGS $SPDLOG_CFLAGS $JSON_CLAGS"
+# Add memcached flags if available
+AS_IF([test "x$have_memcached" = xyes],
+      [CPPFLAGS+=" $MEMCACHED_CFLAGS"])
 
 # Add BOOST flags
-LDFLAGS+=" $BOOST_LDFLAGS $BOOST_REGEX_LIB $BOOST_SYSTEM_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_DATE_TIME_LIB"
+LDFLAGS+=" $BOOST_LDFLAGS $BOOST_REGEX_LIB $BOOST_SYSTEM_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_DATE_TIME_LIB $BOOST_SERIALIZATION_LIB"
 # Add various flags
 LDFLAGS+=" $PTHREAD_LIBS"
 LDFLAGS+=" $CAPNP_LIBS"
 LDFLAGS+=" $SPDLOG_LIBS"
+# Add memcached flags if available
+AS_IF([test "x$have_memcached" = xyes],
+      [LDFLAGS+=" $MEMCACHED_LIBS"])
 
 CXXFLAGS+=" -Wall -Wextra"
 

--- a/connection_scan_algorithm/include/program_options.hpp
+++ b/connection_scan_algorithm/include/program_options.hpp
@@ -27,6 +27,8 @@ namespace TrRouting
     std::string osrmWalkingHost;
     std::string osrmCyclingHost;
     std::string osrmDrivingHost;
+    bool useMemcached;
+    std::string memcachedServers;
 
     ProgramOptions();
     void parseOptions(int argc, char** argv);

--- a/connection_scan_algorithm/src/program_options.cpp
+++ b/connection_scan_algorithm/src/program_options.cpp
@@ -34,6 +34,8 @@ namespace TrRouting {
       ("osrmCyclingHost",                                   boost::program_options::value<std::string>()->default_value("localhost"), "osrm cycling host");
     options.add_options()
       ("osrmDrivingHost",                                   boost::program_options::value<std::string>()->default_value("localhost"), "osrm driving host");
+    options.add_options()
+      ("useMemcached",                                     boost::program_options::value<std::string>()->implicit_value("localhost:11211"), "Enable memcached caching with optional server string");
 
   }
 
@@ -55,6 +57,8 @@ namespace TrRouting {
     osrmWalkingHost      = "localhost";
     osrmCyclingHost      = "localhost";
     osrmDrivingHost      = "localhost";
+    useMemcached         = false;
+    memcachedServers     = "localhost:11211";
 
     if(variablesMap.count("help")) {
       std::cout << options << std::endl;
@@ -133,6 +137,11 @@ namespace TrRouting {
     if(variablesMap.count("osrmDrivingHost") == 1)
     {
       osrmDrivingHost = variablesMap["osrmDrivingHost"].as<std::string>();
+    }
+    if(variablesMap.count("useMemcached") == 1)
+    {
+      useMemcached = true;
+      memcachedServers = variablesMap["useMemcached"].as<std::string>();
     }
 
   }

--- a/connection_scan_algorithm/src/program_options.cpp
+++ b/connection_scan_algorithm/src/program_options.cpp
@@ -35,7 +35,7 @@ namespace TrRouting {
     options.add_options()
       ("osrmDrivingHost",                                   boost::program_options::value<std::string>()->default_value("localhost"), "osrm driving host");
     options.add_options()
-      ("useMemcached",                                     boost::program_options::value<std::string>()->implicit_value("localhost:11211"), "Enable memcached caching with optional server string");
+      ("useMemcached",                                     boost::program_options::value<std::string>()->implicit_value("localhost:11211"), "Enable memcached caching. You can specify a non-default memcached server to use by adding an optional hostname:port string");
 
   }
 

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -29,6 +29,9 @@
 #include "transit_data.hpp"
 #include "osrmgeofilter.hpp"
 #include "euclideangeofilter.hpp"
+#ifdef HAVE_MEMCACHED
+  #include "memcachedgeofilter.hpp"
+#endif
 
 using namespace TrRouting;
 
@@ -136,6 +139,18 @@ int main(int argc, char** argv) {
     geoFilter = new OsrmGeoFilter("walking", programOptions.osrmWalkingHost, programOptions.osrmWalkingPort);
     spdlog::info("Using OSRM for access/egress node time/distance");
   }
+
+  // Wrap the geoFilter with memcached if requested and available
+  if (programOptions.useMemcached) {
+    #ifdef HAVE_MEMCACHED
+      geoFilter =  new TrRouting::MemcachedGeoFilter(geoFilter, programOptions.memcachedServers);
+      spdlog::info("Using memcached for caching GeoFilter results with server(s): {}", programOptions.memcachedServers);
+      // Don't delete the original filter, as it's now managed by the cached filter
+    #else
+      spdlog::warn("Memcached support was requested but is not available (not compiled in). Continuing without caching.");
+    #endif
+  }
+
 
   spdlog::info("preparing server with {} threads...", programOptions.numberOfThreads);
 

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -142,15 +142,14 @@ int main(int argc, char** argv) {
 
   // Wrap the geoFilter with memcached if requested and available
   if (programOptions.useMemcached) {
-    #ifdef HAVE_MEMCACHED
-      geoFilter =  new TrRouting::MemcachedGeoFilter(geoFilter, programOptions.memcachedServers);
-      spdlog::info("Using memcached for caching GeoFilter results with server(s): {}", programOptions.memcachedServers);
-      // Don't delete the original filter, as it's now managed by the cached filter
-    #else
-      spdlog::warn("Memcached support was requested but is not available (not compiled in). Continuing without caching.");
-    #endif
+  #ifdef HAVE_MEMCACHED
+    geoFilter =  new TrRouting::MemcachedGeoFilter(geoFilter, programOptions.memcachedServers, 3600, programOptions.numberOfThreads);
+    spdlog::info("Using memcached for caching GeoFilter results with server(s): {}", programOptions.memcachedServers);
+    // Don't delete the original filter, as it's now managed by the cached filter
+  #else
+    spdlog::warn("Memcached support was requested but is not available (not compiled in). Continuing without caching.");
+  #endif
   }
-
 
   spdlog::info("preparing server with {} threads...", programOptions.numberOfThreads);
 

--- a/include/memcachedgeofilter.hpp
+++ b/include/memcachedgeofilter.hpp
@@ -3,7 +3,9 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <mutex>
 #include <libmemcached/memcached.h>
+#include <libmemcached/util.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/serialization/vector.hpp>
 #include "serialization_boost_uuid.hpp" // Custom serialization for boost::uuid
@@ -42,10 +44,11 @@ struct SerializableNodeTimeDistance {
 // Memcached-backed implementation of GeoFilter
 class MemcachedGeoFilter : public GeoFilter {
 private:
-    memcached_st *memc;
+    memcached_pool_st *memcPool;
     GeoFilter* baseGeoFilter;
     uint32_t cacheExpirySeconds;
-    
+    std::mutex poolMutex; // Mutex for thread safety of pool operations
+
     // Helper function to generate a cache key
     std::string generateCacheKey(const Point &point, 
                                 int maxWalkingTravelTime,
@@ -67,12 +70,15 @@ private:
         const std::vector<SerializableNodeTimeDistance> &serializableResults,
         const std::map<boost::uuids::uuid, Node> &nodes);
 
+    // Initialize the connection pool with specified size
+  void initializePool(size_t poolSize, const std::string& memcachedServersStr);
 public:
     // Constructor with configurable memcached servers and cache expiry
     MemcachedGeoFilter(
         GeoFilter* baseGeoFilter,
         const std::string& memcachedServers = "localhost:11211",
-        uint32_t cacheExpiry = 3600
+        uint32_t cacheExpiry = 3600,
+        size_t poolSize = 0  // 0 means auto-detect thread count
     );
     
     // Destructor

--- a/include/memcachedgeofilter.hpp
+++ b/include/memcachedgeofilter.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <vector>
+#include <map>
+#include <string>
+#include <libmemcached/memcached.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/serialization/vector.hpp>
+#include "serialization_boost_uuid.hpp" // Custom serialization for boost::uuid
+
+#include "geofilter.hpp"
+#include "node.hpp"
+
+namespace TrRouting {
+
+// Serializable version of NodeTimeDistance for caching
+struct SerializableNodeTimeDistance {
+    boost::uuids::uuid nodeUuid;  // Using uuid instead of node reference
+    int time;
+    int distance;
+    
+    // Default constructor (required for deserialization)
+    SerializableNodeTimeDistance() : time(0), distance(0) {}
+    
+    // Conversion from NodeTimeDistance
+    SerializableNodeTimeDistance(const NodeTimeDistance& ntd)
+        : nodeUuid(ntd.node.uuid),  // Using the actual uuid field
+          time(ntd.time),
+          distance(ntd.distance)
+    {
+    }
+    
+    // Serialization support
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int /* version */) {
+        ar & nodeUuid;
+        ar & time;
+        ar & distance;
+    }
+};
+
+// Memcached-backed implementation of GeoFilter
+class MemcachedGeoFilter : public GeoFilter {
+private:
+    memcached_st *memc;
+    GeoFilter* baseGeoFilter;
+    uint32_t cacheExpirySeconds;
+    
+    // Helper function to generate a cache key
+    std::string generateCacheKey(const Point &point, 
+                                int maxWalkingTravelTime,
+                                float walkingSpeedMetersPerSecond,
+                                bool reversed);
+    
+    // Serialize a vector of SerializableNodeTimeDistance to a string
+    std::string serializeResults(const std::vector<SerializableNodeTimeDistance> &results);
+    
+    // Deserialize a string to a vector of SerializableNodeTimeDistance
+    std::vector<SerializableNodeTimeDistance> deserializeResults(const std::string &data);
+    
+    // Convert NodeTimeDistance to SerializableNodeTimeDistance for caching
+    std::vector<SerializableNodeTimeDistance> convertToSerializable(
+        const std::vector<NodeTimeDistance> &results);
+    
+    // Convert SerializableNodeTimeDistance back to NodeTimeDistance
+    std::vector<NodeTimeDistance> convertFromSerializable(
+        const std::vector<SerializableNodeTimeDistance> &serializableResults,
+        const std::map<boost::uuids::uuid, Node> &nodes);
+
+public:
+    // Constructor with configurable memcached servers and cache expiry
+    MemcachedGeoFilter(
+        GeoFilter* baseGeoFilter,
+        const std::string& memcachedServers = "localhost:11211",
+        uint32_t cacheExpiry = 3600
+    );
+    
+    // Destructor
+    ~MemcachedGeoFilter();
+    
+    // Implementation of the GeoFilter interface method
+    std::vector<NodeTimeDistance> getAccessibleNodesFootpathsFromPoint(
+        const Point &point,
+        const std::map<boost::uuids::uuid, Node> &nodes,
+        int maxWalkingTravelTime,
+        float walkingSpeedMetersPerSecond,
+        bool reversed = false) override;
+    
+    // Flush the cache
+    bool flushCache();
+};
+
+} // namespace TrRouting

--- a/include/serialization_boost_uuid.hpp
+++ b/include/serialization_boost_uuid.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/serialization/split_free.hpp>
+
+// Add serialization support for boost::uuids::uuid
+namespace boost {
+namespace serialization {
+
+template<class Archive>
+inline void save(Archive & ar, const boost::uuids::uuid & uuid, const unsigned int /* version */)
+{
+    // UUID is just 16 bytes, so we can serialize it as a binary blob
+    ar & make_array(uuid.data, uuid.size());
+}
+
+template<class Archive>
+inline void load(Archive & ar, boost::uuids::uuid & uuid, const unsigned int /* version */)
+{
+    // Load the UUID data
+    ar & make_array(uuid.data, uuid.size());
+}
+
+template<class Archive>
+inline void serialize(Archive & ar, boost::uuids::uuid & uuid, const unsigned int version)
+{
+    split_free(ar, uuid, version);
+}
+
+} // namespace serialization
+} // namespace boost

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,4 +26,9 @@ transit_data.cpp
 #places_cache_fetcher.cpp \
 #households_cache_fetcher.cpp 
 
+# Conditionally add memcached-related files if libmemcached is available
+if HAVE_MEMCACHED
+trRouting_SOURCES += memcachedgeofilter.cpp
+endif
+
 trRouting_LDADD = ../connection_scan_algorithm/src/libcsa.la

--- a/src/memcachedgeofilter.cpp
+++ b/src/memcachedgeofilter.cpp
@@ -5,38 +5,75 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
+#include <thread>
 #include "point.hpp"
 #include "node.hpp"
 #include "spdlog/spdlog.h"
 
 namespace TrRouting {
 
+  // Initialize the connection pool with specified size
+  void MemcachedGeoFilter::initializePool(size_t poolSize, const std::string& memcachedServersStr) {
+    std::lock_guard<std::mutex> lock(poolMutex);
+
+    // Auto-detect thread count if poolSize is 0
+    if (poolSize == 0) {
+      unsigned int detected = std::thread::hardware_concurrency();
+      // Ensure at least 2 connections
+      poolSize = std::max(static_cast<size_t>(detected), static_cast<size_t>(2));
+      spdlog::info("Auto-detected thread count for connection pool: {}", poolSize);
+    }
+
+    // Configure connection string with all servers
+    // Format: --SERVER=server1:port1 --SERVER=server2:port2
+    std::string poolOptions = "--POOL-MIN=" + std::to_string(poolSize / 2) +
+      " --POOL-MAX=" + std::to_string(poolSize);
+
+    // Add all servers from the servers string
+    std::istringstream serverStream(memcachedServersStr);
+    std::string server;
+    while (std::getline(serverStream, server, ',')) {
+      // Trim whitespace if any
+      server.erase(0, server.find_first_not_of(" \t"));
+      server.erase(server.find_last_not_of(" \t") + 1);
+
+      if (!server.empty()) {
+        poolOptions += " --SERVER=" + server;
+      }
+    }
+
+    spdlog::debug("Creating memcached pool with options: {}", poolOptions);
+
+    // Create the pool
+    memcPool = memcached_pool(poolOptions.c_str(), poolOptions.length());
+
+    if (memcPool == NULL) {
+      spdlog::error("Failed to create memcached connection pool");
+    } else {
+      spdlog::info("Created memcached connection pool with initial size {} and max size {}",
+                  poolSize / 2, poolSize);
+    }
+  }
+
   // MemcachedGeoFilter constructor
   MemcachedGeoFilter::MemcachedGeoFilter(
                                          GeoFilter* baseGeoFilter,
                                          const std::string& memcachedServers,
-                                         uint32_t cacheExpiry
-                                         ) : baseGeoFilter(baseGeoFilter), cacheExpirySeconds(cacheExpiry)
+                                         uint32_t cacheExpiry,
+                                         size_t poolSize
+                                         ) : baseGeoFilter(baseGeoFilter),
+                                             cacheExpirySeconds(cacheExpiry)
   {
-    // Initialize memcached
-    memc = memcached_create(NULL);
-    
-    // Parse server list
-    memcached_server_st *servers = NULL;
-    servers = memcached_servers_parse(memcachedServers.c_str());
-    
-    // Add servers to the memcached handle
-    memcached_server_push(memc, servers);
-    memcached_server_list_free(servers);
-    
-    // Configure behaviors for optimal performance
-    memcached_behavior_set(memc, MEMCACHED_BEHAVIOR_NO_BLOCK, 1);
-    memcached_behavior_set(memc, MEMCACHED_BEHAVIOR_TCP_NODELAY, 1);
+    // Initialize the connection pool
+    initializePool(poolSize, memcachedServers);
   }
 
   // Destructor
   MemcachedGeoFilter::~MemcachedGeoFilter() {
-    memcached_free(memc);
+    std::lock_guard<std::mutex> lock(poolMutex);
+    if (memcPool) {
+      memcached_pool_destroy(memcPool);
+    }
   }
 
   // Helper function to generate a cache key
@@ -127,7 +164,7 @@ namespace TrRouting {
     return results;
   }
 
-  // Implementation of the main interface method
+  // Thread-safe implementation of the main interface method using connection pool
   std::vector<NodeTimeDistance> MemcachedGeoFilter::getAccessibleNodesFootpathsFromPoint(
                                                                                          const Point &point,
                                                                                          const std::map<boost::uuids::uuid, Node> &nodes,
@@ -139,8 +176,24 @@ namespace TrRouting {
     std::string cacheKey = generateCacheKey(
                                             point, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
     
+    // Check if pool is available
+    if (!memcPool) {
+      spdlog::error("Memcached connection pool is not initialized");
+      return baseGeoFilter->getAccessibleNodesFootpathsFromPoint(
+        point, nodes, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
+    }
+
+    // Acquire a connection from the pool
+    memcached_return_t rc;
+    memcached_st *memc = memcached_pool_fetch(memcPool, NULL, &rc);
+
+    if (memc == NULL) {
+      spdlog::error("Failed to acquire connection from pool: {}", memcached_strerror(NULL, rc));
+      return baseGeoFilter->getAccessibleNodesFootpathsFromPoint(
+        point, nodes, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
+    }
+
     // Try to get from cache
-    memcached_return rc;
     size_t valueLength;
     uint32_t flags;
     
@@ -153,6 +206,8 @@ namespace TrRouting {
                                        &rc
                                        );
     
+    std::vector<NodeTimeDistance> results;
+
     if (rc == MEMCACHED_SUCCESS && cachedResult != NULL) {
       spdlog::debug("Memcached cache hit ({}) - {}", cacheKey, valueLength);
       // Cache hit
@@ -164,45 +219,90 @@ namespace TrRouting {
         auto serializableResults = deserializeResults(resultData);
         
         // Convert back to NodeTimeDistance objects with proper references
-        return convertFromSerializable(serializableResults, nodes);
+        results = convertFromSerializable(serializableResults, nodes);
       } catch (const std::exception& e) {
         // If deserialization fails, log error and fall through to compute result
         spdlog::warn("Cache deserialization error: {}", e.what());
+        // Reset results to empty to trigger calculation
+        results.clear();
       }
     }
     
     // Cache miss or error, compute the result using the base provider
-    std::vector<NodeTimeDistance> results = baseGeoFilter->getAccessibleNodesFootpathsFromPoint(
-      point, nodes, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
-    
-    // Convert to serializable format and serialize
-    auto serializableResults = convertToSerializable(results);
-    std::string serializedResults = serializeResults(serializableResults);
-    
-    if (!serializedResults.empty()) {
-      // Store in cache
-      rc = memcached_set(
-                         memc,
-                         cacheKey.c_str(),
-                         cacheKey.length(),
-                         serializedResults.c_str(),
-                         serializedResults.length(),
-                         cacheExpirySeconds,
-                         (uint32_t)0
-                         );
+    if (results.empty()) {
+      results = baseGeoFilter->getAccessibleNodesFootpathsFromPoint(
+        point, nodes, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
 
-      if (rc != MEMCACHED_SUCCESS) {
-        spdlog::warn("Failed to store footpaths in cache: {}", memcached_strerror(memc, rc));
+      // Convert to serializable format and serialize
+      auto serializableResults = convertToSerializable(results);
+      std::string serializedResults = serializeResults(serializableResults);
+
+      if (!serializedResults.empty()) {
+        // Store in cache
+        rc = memcached_set(
+                           memc,
+                           cacheKey.c_str(),
+                           cacheKey.length(),
+                           serializedResults.c_str(),
+                           serializedResults.length(),
+                           cacheExpirySeconds,
+                           (uint32_t)0
+                           );
+
+        if (rc != MEMCACHED_SUCCESS) {
+          spdlog::warn("Failed to store footpaths in cache: {}", memcached_strerror(memc, rc));
+        }
       }
     }
     
+    // Return the connection to the pool
+    rc = memcached_pool_release(memcPool, memc);
+    if (rc != MEMCACHED_SUCCESS) {
+      spdlog::warn("Failed to return connection to pool: {}", memcached_strerror(NULL, rc));
+      // We have to free the connection if we can't return it to the pool
+      memcached_free(memc);
+    }
+
     return results;
   }
 
-  // Flush the cache
+  // Thread-safe flush the cache
   bool MemcachedGeoFilter::flushCache() {
-    memcached_return rc = memcached_flush(memc, 0);
-    return (rc == MEMCACHED_SUCCESS);
+    std::lock_guard<std::mutex> lock(poolMutex);
+
+    if (!memcPool) {
+      spdlog::error("Memcached connection pool is not initialized");
+      return false;
+    }
+
+    // Get a connection from the pool
+    memcached_return_t rc;
+    memcached_st *memc = memcached_pool_fetch(memcPool, NULL, &rc);
+
+    if (memc == NULL) {
+      spdlog::error("Failed to acquire connection from pool for cache flush: {}",
+                   memcached_strerror(NULL, rc));
+      return false;
+    }
+
+    // Flush the cache
+    rc = memcached_flush(memc, 0);
+    bool success = (rc == MEMCACHED_SUCCESS);
+
+    if (!success) {
+      spdlog::error("Failed to flush cache: {}", memcached_strerror(memc, rc));
+    }
+
+    // Return the connection to the pool
+    memcached_return_t pushRc = memcached_pool_release(memcPool, memc);
+    if (pushRc != MEMCACHED_SUCCESS) {
+      spdlog::warn("Failed to return connection to pool after flush: {}",
+                  memcached_strerror(NULL, pushRc));
+      // We have to free the connection if we can't return it to the pool
+      memcached_free(memc);
+    }
+
+    return success;
   }
   
 } // namespace TrRouting

--- a/src/memcachedgeofilter.cpp
+++ b/src/memcachedgeofilter.cpp
@@ -1,0 +1,208 @@
+#include "memcachedgeofilter.hpp"
+#include <sstream>
+#include <iomanip>
+#include <iostream>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
+#include "point.hpp"
+#include "node.hpp"
+#include "spdlog/spdlog.h"
+
+namespace TrRouting {
+
+  // MemcachedGeoFilter constructor
+  MemcachedGeoFilter::MemcachedGeoFilter(
+                                         GeoFilter* baseGeoFilter,
+                                         const std::string& memcachedServers,
+                                         uint32_t cacheExpiry
+                                         ) : baseGeoFilter(baseGeoFilter), cacheExpirySeconds(cacheExpiry)
+  {
+    // Initialize memcached
+    memc = memcached_create(NULL);
+    
+    // Parse server list
+    memcached_server_st *servers = NULL;
+    servers = memcached_servers_parse(memcachedServers.c_str());
+    
+    // Add servers to the memcached handle
+    memcached_server_push(memc, servers);
+    memcached_server_list_free(servers);
+    
+    // Configure behaviors for optimal performance
+    memcached_behavior_set(memc, MEMCACHED_BEHAVIOR_NO_BLOCK, 1);
+    memcached_behavior_set(memc, MEMCACHED_BEHAVIOR_TCP_NODELAY, 1);
+  }
+
+  // Destructor
+  MemcachedGeoFilter::~MemcachedGeoFilter() {
+    memcached_free(memc);
+  }
+
+  // Helper function to generate a cache key
+  std::string MemcachedGeoFilter::generateCacheKey(
+                                                   const Point &point, 
+                                                   int maxWalkingTravelTime,
+                                                   float walkingSpeedMetersPerSecond,
+                                                   bool reversed
+                                                   )
+  {
+    std::stringstream ss;
+    // Create a unique key based on the function parameters
+    ss << "footpaths:" 
+       << std::fixed << std::setprecision(6) << point.latitude << ":"  // Using actual field names
+       << std::fixed << std::setprecision(6) << point.longitude << ":" // from Point class
+       << maxWalkingTravelTime << ":"
+       << walkingSpeedMetersPerSecond << ":"
+       << (reversed ? "1" : "0");
+    return ss.str();
+  }
+
+  // Serialize a vector of SerializableNodeTimeDistance to a string
+  std::string MemcachedGeoFilter::serializeResults(
+                                                   const std::vector<SerializableNodeTimeDistance> &results
+                                                   )
+  {
+    try {
+      std::stringstream ss;
+      boost::archive::binary_oarchive oa(ss);
+      oa << results;
+      return ss.str();
+    } catch (const std::exception& e) {
+      spdlog::error("Serialization error: {}", e.what());
+      return "";
+    }
+  }
+
+  // Deserialize a string to a vector of SerializableNodeTimeDistance
+  std::vector<SerializableNodeTimeDistance> MemcachedGeoFilter::deserializeResults(
+                                                                                   const std::string &data
+                                                                                   )
+  {
+    try {
+      std::vector<SerializableNodeTimeDistance> results;
+      std::stringstream ss(data);
+      boost::archive::binary_iarchive ia(ss);
+      ia >> results;
+      return results;
+    } catch (const std::exception& e) {
+      spdlog::error("Deserialization error: {}", e.what());
+      return std::vector<SerializableNodeTimeDistance>();
+    }
+  }
+
+  // Convert NodeTimeDistance to SerializableNodeTimeDistance for caching
+  std::vector<SerializableNodeTimeDistance> MemcachedGeoFilter::convertToSerializable(
+                                                                                      const std::vector<NodeTimeDistance> &results
+                                                                                      )
+  {
+    std::vector<SerializableNodeTimeDistance> serializableResults;
+    serializableResults.reserve(results.size());
+    
+    for (const auto& result : results) {
+      serializableResults.emplace_back(result);
+    }
+    
+    return serializableResults;
+  }
+
+  // Convert SerializableNodeTimeDistance back to NodeTimeDistance
+  std::vector<NodeTimeDistance> MemcachedGeoFilter::convertFromSerializable(
+                                                                            const std::vector<SerializableNodeTimeDistance> &serializableResults,
+                                                                            const std::map<boost::uuids::uuid, Node> &nodes
+                                                                            )
+  {
+    std::vector<NodeTimeDistance> results;
+    results.reserve(serializableResults.size());
+    
+    for (const auto& serialResult : serializableResults) {
+      // Find the node in the nodes map
+      auto nodeIter = nodes.find(serialResult.nodeUuid);
+      if (nodeIter != nodes.end()) {
+        // Create a new NodeTimeDistance using the node reference constructor
+        results.emplace_back(nodeIter->second, serialResult.time, serialResult.distance);
+      }
+    }
+    
+    return results;
+  }
+
+  // Implementation of the main interface method
+  std::vector<NodeTimeDistance> MemcachedGeoFilter::getAccessibleNodesFootpathsFromPoint(
+                                                                                         const Point &point,
+                                                                                         const std::map<boost::uuids::uuid, Node> &nodes,
+                                                                                         int maxWalkingTravelTime,
+                                                                                         float walkingSpeedMetersPerSecond,
+                                                                                         bool reversed
+                                                                                         ) {
+    // Generate cache key
+    std::string cacheKey = generateCacheKey(
+                                            point, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
+    
+    // Try to get from cache
+    memcached_return rc;
+    size_t valueLength;
+    uint32_t flags;
+    
+    char *cachedResult = memcached_get(
+                                       memc, 
+                                       cacheKey.c_str(), 
+                                       cacheKey.length(), 
+                                       &valueLength, 
+                                       &flags, 
+                                       &rc
+                                       );
+    
+    if (rc == MEMCACHED_SUCCESS && cachedResult != NULL) {
+      spdlog::debug("Memcached cache hit ({}) - {}", cacheKey, valueLength);
+      // Cache hit
+      std::string resultData(cachedResult, valueLength);
+      free(cachedResult);
+      
+      try {
+        // Deserialize the cached result
+        auto serializableResults = deserializeResults(resultData);
+        
+        // Convert back to NodeTimeDistance objects with proper references
+        return convertFromSerializable(serializableResults, nodes);
+      } catch (const std::exception& e) {
+        // If deserialization fails, log error and fall through to compute result
+        spdlog::warn("Cache deserialization error: {}", e.what());
+      }
+    }
+    
+    // Cache miss or error, compute the result using the base provider
+    std::vector<NodeTimeDistance> results = baseGeoFilter->getAccessibleNodesFootpathsFromPoint(
+      point, nodes, maxWalkingTravelTime, walkingSpeedMetersPerSecond, reversed);
+    
+    // Convert to serializable format and serialize
+    auto serializableResults = convertToSerializable(results);
+    std::string serializedResults = serializeResults(serializableResults);
+    
+    if (!serializedResults.empty()) {
+      // Store in cache
+      rc = memcached_set(
+                         memc,
+                         cacheKey.c_str(),
+                         cacheKey.length(),
+                         serializedResults.c_str(),
+                         serializedResults.length(),
+                         cacheExpirySeconds,
+                         (uint32_t)0
+                         );
+
+      if (rc != MEMCACHED_SUCCESS) {
+        spdlog::warn("Failed to store footpaths in cache: {}", memcached_strerror(memc, rc));
+      }
+    }
+    
+    return results;
+  }
+
+  // Flush the cache
+  bool MemcachedGeoFilter::flushCache() {
+    memcached_return rc = memcached_flush(memc, 0);
+    return (rc == MEMCACHED_SUCCESS);
+  }
+  
+} // namespace TrRouting


### PR DESCRIPTION
Related to issue #271
In the V1 API, Transition had the possibility to send a list of accessible nodes with a request. The intent for this was to speedup calculation for frequently requested points.

Instead of letting the client send us cache information, we are adding support for TrRouting to handle the caching directly using Memcached.

When enabled with --useMemcached command-line option, trRouting will compute a key with the point and caracteristic of the accessible node request (max walking time, speed, direction). If the data was already computed, it will be fetched from the memcached instance, otherwise it will do the calculation and store the result for later use.

It's implemented as a GeoFilter and receive a geofilter in its constructor, so it can be used with both the OSRMGeoFilter and the Euclidean one.

In our test, a request to OSRM was taking aroung 50-100ms, and with the caching we got the result in less than 1ms. Not a huge saving for a single calculation, but still a save. This will be mostly benefical with computations that often check the same points, like with Transition's simulations. Other type of batch calculation could gain from it if they have recuring access or egress points.

We currently cache the result for 1h in memcached, to not have stale results and conserve memory over time.

The compilation of this extension is optional. If you don't have libmemcached installed, it won't compile it. The CLI option is always available and will only display a warning if it was not compiled.

Tested with both OSRM and Euclidean filters, with and without Memcached (including the case when memcached was shutdown)