### PR TITLE
route: calculate best departure time first in reverse calculation

### DIFF
--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -154,7 +154,7 @@ namespace TrRouting
 
     //params.departureTimeSeconds = departureTimeSeconds;
 
-    spdlog::debug("  fastestTravelTimeSeconds: {}", routingResult.totalTravelTime);
+    spdlog::debug("  fastestTravelTimeSeconds: {} Maximum alternative travel time: {}", routingResult.totalTravelTime, maxTravelTime);
 
     // Get the best result and extract the lines from it
     // We will generate all the combinations of those lines and redo the calculation

--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -24,21 +24,72 @@ namespace TrRouting
       parameters.isForwardCalculation()
     );
   }
+
+  
   
   std::unique_ptr<SingleCalculationResult> Calculator::calculateSingle(RouteParameters &parameters, bool resetAccessPaths, bool resetFilters) {
     reset(parameters, *parameters.getOrigin(), *parameters.getDestination(), resetAccessPaths, resetFilters);
 
     std::unique_ptr<SingleCalculationResult> result;
+    RouteParameters* calculationParametersPtr = &parameters;
+    std::unique_ptr<RouteParameters> forwardParametersHolder;
 
-    if (departureTimeSeconds > -1 && parameters.isForwardCalculation())
+    // Reverse calculation requested (with arrival time): First get the best
+    // departure time for this trip, before doing a normal forward calculation
+    // that is known to work and fully tested. We could not simply use the
+    // calculateSingleReverse as previously as it assumes the arrival time is
+    // the best one and will tend to use any paths that gets to destination,
+    // even if it arrives later
+    if (arrivalTimeSeconds > -1 && !parameters.isForwardCalculation())
     {
-      
+      // TODO maybe we can do something different in that case, like a query flag
+      // we need to make all trips usable when not coming from forward result because reverse calculation, by default, checks for usableTrips
+      for (auto && tripIte : transitData.getTrips()) {
+        const Trip & trip = tripIte.second;
+        tripsQueryOverlay[trip.uid].usable = true;
+      }
+      std::optional<std::reference_wrapper<const Node>> bestAccessNode;
+      std::unordered_map<Node::uid_t, JourneyStep> reverseAccessJourneysSteps;
+
+      auto resultCalculation = reverseCalculation(parameters, reverseAccessJourneysSteps);
+      if (resultCalculation) {
+        // Transform the query to a forward one with the new departure time
+        departureTimeSeconds = std::get<0>(*resultCalculation);
+        bestAccessNode = std::get<1>(*resultCalculation);
+
+        spdlog::debug("-- first reverse calculation -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
+        calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
+
+        forwardParametersHolder = std::make_unique<RouteParameters>(
+          std::make_unique<Point>(parameters.getOrigin()->latitude, parameters.getOrigin()->longitude),
+          std::make_unique<Point>(parameters.getDestination()->latitude, parameters.getDestination()->longitude),
+          parameters.getScenario(),
+          departureTimeSeconds,
+          parameters.getMinWaitingTimeSeconds(),
+          parameters.getMaxTotalTravelTimeSeconds(),
+          parameters.getMaxAccessWalkingTravelTimeSeconds(),
+          parameters.getMaxEgressWalkingTravelTimeSeconds(),
+          parameters.getMaxTransferWalkingTravelTimeSeconds(),
+          parameters.getMaxFirstWaitingTimeSeconds(),
+          parameters.isWithAlternatives(),
+          true);
+        calculationParametersPtr = forwardParametersHolder.get();
+        // Do not reset filters for this second reset, otherwise any disabled line/trip will be enabled again and we'll get the same alternative over and over.
+        // FIXME: That other TODO above, where the tripsQueryOverlay is all set to usable looks fishy and forces to not reset the filter here. I, tahini, cannot really explain why and that is not good.
+        reset(*calculationParametersPtr, *calculationParametersPtr->getOrigin(), *calculationParametersPtr->getDestination(), resetAccessPaths, false);
+
+        spdlog::debug("best departure time after reverse journey: {}", departureTimeSeconds);
+      }
+    }
+
+    if (departureTimeSeconds > -1 && calculationParametersPtr->isForwardCalculation())
+    {
       int bestArrivalTime {MAX_INT};
       std::optional<std::reference_wrapper<const Node>> bestEgressNode;
       //TODO With the TODO later that forwardJourneyStep is not necessary, we can also drop this variable
       std::unordered_map<Node::uid_t, JourneyStep> forwardEgressJourneysSteps;
 
-      auto resultCalculation = forwardCalculation(parameters, forwardEgressJourneysSteps);
+      auto resultCalculation = forwardCalculation(*calculationParametersPtr, forwardEgressJourneysSteps);
       if (resultCalculation.has_value()) {
         bestArrivalTime = std::get<0>(*resultCalculation);
         bestEgressNode = std::get<1>(*resultCalculation);
@@ -58,35 +109,23 @@ namespace TrRouting
           nodesReverseTentativeTime[egressFootpath.node.uid] = arrivalTimeSeconds - egressFootpath.time;
         }
 
-        result = calculateSingleReverse(parameters);
+        result = calculateSingleReverse(*calculationParametersPtr);
           
       }
       else
       {
         //TODO This will always throw an exception since to get here bestEgressNode must be invalid
         //TODO We can probably just remove the function forwardJourneyStep completely
-        result = forwardJourneyStep(parameters, bestEgressNode, forwardEgressJourneysSteps);
+        result = forwardJourneyStep(*calculationParametersPtr, bestEgressNode, forwardEgressJourneysSteps);
 
         assert(false); // See TODO
         spdlog::debug("-- forward journey -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
         calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
           
       }
+      return result;
     }
-    else if (arrivalTimeSeconds > -1)
-    {
-      departureTimeSeconds = -1;
-      //TODO maybe we can do something different in that case, like a query flag
-      // we need to make all trips usable when not coming from forward result because reverse calculation, by default, checks for usableTrips
-      for (auto && tripIte : transitData.getTrips()) {
-        const Trip & trip = tripIte.second;
-        tripsQueryOverlay[trip.uid].usable = true;
-      }
-      result = calculateSingleReverse(parameters);
-
-    }
-
-    return result;
+    throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
   }
 
   // To be called only by calculateSingle, depends on preparations steps done there

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -303,6 +303,53 @@ TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationArrivalTime)
         egressTime);
 }
 
+// Test case developed to reproduce
+// https://github.com/chairemobilite/trRouting/issues/298 There are 2
+// alternatives, who both start at the same time. One with a transfer to the
+// extra line arrives at 10:25, while the other walks longer and arrives at
+// 10:30. The one with transfer should always be preferred.
+TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationArrivalTimeWith2Alternatives)
+{
+    int arrivalTime = getTimeInSeconds(10, 35);
+    int travelTimeInVehicle = 720; // north line and extra line
+    // This is where mocking would be interesting. Those were taken from the first run of the test
+    int accessTime = 469;
+    int egressTime = 48;
+    int expectedTransitDepartureTime = getTimeInSeconds(10);
+    int expectedNbTransfers = 1;
+    int expectedTransferWaitingTime = 120 + DEFAULT_MIN_WAITING_TIME; // 2 minutes wait + min waiting time before boarding
+    int expectedTransferWalkingTime = 480;
+
+    TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
+        std::make_unique<TrRouting::Point>(45.5242, -73.5817),
+        std::make_unique<TrRouting::Point>(45.55372, -73.61859),
+        //std::make_unique<TrRouting::Point>(45.54888, -73.62364), // Closer to extra1, forces transfer
+        transitData.getScenarios().at(TestDataFetcher::scenarioUuid),
+        arrivalTime,
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MAX_TOTAL_TIME,
+        DEFAULT_MAX_ACCESS_TRAVEL_TIME,
+        DEFAULT_MAX_EGRESS_TRAVEL_TIME,
+        DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
+        DEFAULT_FIRST_WAITING_TIME,
+        false,
+        false
+    );
+
+    std::unique_ptr<TrRouting::RoutingResult> result = calculateOd(testParameters);
+    assertSuccessResults(*result.get(),
+        -1,
+        expectedTransitDepartureTime,
+        travelTimeInVehicle,
+        accessTime,
+        egressTime,
+        expectedNbTransfers,
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MIN_WAITING_TIME + expectedTransferWaitingTime,
+        expectedTransferWaitingTime,
+        expectedTransferWalkingTime);
+}
+
 // Test from OD With access/egress, origin is further south of South2, in the line axis, destination slightly north-west of midpoint
 // Specify each parameter with a value that allows the result
 TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationWithAllParams)


### PR DESCRIPTION
fixes #298

The `calculateSingleReverse` function assumes that the best arrival time was found and egress footpaths were set to this value before doing calculation. That is not the case with reverse calculation, where the arrival time is arbitrarily after the best possible arrival time and the algorithm was quite creative on the trip end. To avoid this, we first do a reverse calculation to get the best departure time, then do a normal forward calculation with that time. That arrival time will be automatically adjusted.

Add a unit test to reproduce the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - All-nodes queries now support arrival-time searches (reverse routing enabled).

- Bug Fixes
  - Improved reliability and quality of arrival-time routing by converting reverse guidance into a forward search when appropriate.
  - Ensures the preferred alternative is chosen when two options start simultaneously, improving transfer handling.

- Tests
  - Added a scenario validating arrival-time routing with two simultaneous alternatives and expected transfer behavior.

- Chores
  - Enhanced debug logging to include maximum alternative travel time for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->