### PR TITLE
limit time window at end of trip when time is arrival

### DIFF
--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -143,7 +143,7 @@ namespace TrRouting
       parameters.getMaxAccessWalkingTravelTimeSeconds(),
       parameters.getMaxEgressWalkingTravelTimeSeconds(),
       parameters.getMaxTransferWalkingTravelTimeSeconds(),
-      parameters.getMaxFirstWaitingTimeSeconds(),
+      parameters.getMaxInnerTimeOfTripBufferSeconds(),
       parameters.isForwardCalculation()
     );
     RouteParameters alternativeParameters = RouteParameters(std::make_unique<Point>(origin->latitude, origin->longitude),

--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -20,7 +20,7 @@ namespace TrRouting
       parameters.getMaxAccessWalkingTravelTimeSeconds(),
       parameters.getMaxEgressWalkingTravelTimeSeconds(),
       parameters.getMaxTransferWalkingTravelTimeSeconds(),
-      parameters.getMaxFirstWaitingTimeSeconds(),
+      parameters.getMaxInnerTimeOfTripBufferSeconds(),
       parameters.isForwardCalculation()
     );
   }

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -68,7 +68,7 @@ namespace TrRouting
 
           // TODO Do we need to make sure the departure node exists in the forwardJourneySteps map? For the reverse calculation, we had to in order to fix issue https://github.com/chairemobilite/trRouting/issues/250 The issue may apply to forward too, but we have no example
           auto nodesAccessIte = nodesAccess.find(nodeDeparture.uid);          
-          nodeWasAccessedFromOrigin  = parameters.getMaxFirstWaitingTimeSeconds() > 0 &&
+          nodeWasAccessedFromOrigin  = parameters.getMaxInnerTimeOfTripBufferSeconds() > 0 &&
             nodesAccessIte != nodesAccess.end() &&
             nodesAccessIte->second.time >= 0 &&
             !forwardJourneysSteps.at(nodeDeparture.uid).getFinalEnterConnection().has_value();
@@ -84,7 +84,7 @@ namespace TrRouting
             (
               !nodeWasAccessedFromOrigin
               ||
-              connectionDepartureTime - nodeDepartureTentativeTime <= parameters.getMaxFirstWaitingTimeSeconds()
+              connectionDepartureTime - nodeDepartureTentativeTime <= parameters.getMaxInnerTimeOfTripBufferSeconds()
             )
           )
           {
@@ -277,7 +277,7 @@ namespace TrRouting
           nodeDepartureTentativeTime = nodesTentativeTime.at(nodeDeparture.uid);
 
           auto nodesAccessIte = nodesAccess.find(nodeDeparture.uid);
-          nodeWasAccessedFromOrigin  = parameters.getMaxFirstWaitingTimeSeconds() > 0 &&
+          nodeWasAccessedFromOrigin  = parameters.getMaxInnerTimeOfTripBufferSeconds() > 0 &&
             nodesAccessIte != nodesAccess.end() &&
             nodesAccessIte->second.time >= 0 &&
             !forwardJourneysSteps.at(nodeDeparture.uid).getFinalEnterConnection().has_value();
@@ -293,7 +293,7 @@ namespace TrRouting
             (
               !nodeWasAccessedFromOrigin
               ||
-              connectionDepartureTime - nodeDepartureTentativeTime <= parameters.getMaxFirstWaitingTimeSeconds()
+              connectionDepartureTime - nodeDepartureTentativeTime <= parameters.getMaxInnerTimeOfTripBufferSeconds()
             )
           )
           {

--- a/connection_scan_algorithm/src/parameters/common_parameters.cpp
+++ b/connection_scan_algorithm/src/parameters/common_parameters.cpp
@@ -24,7 +24,7 @@ namespace TrRouting
         maxAccessWalkingTravelTimeSeconds(maxAccessTime),
         maxEgressWalkingTravelTimeSeconds(maxEgressTime),
         maxTransferWalkingTravelTimeSeconds(maxTransferTime),
-        maxFirstWaitingTimeSeconds(maxFirstWaitingTime),
+        maxInnerTimeOfTripBufferSeconds(maxFirstWaitingTime),
         forwardCalculation(forward)
   {
     scenarioUuid = scenario.uuid; //TODO Check if this is used somewhere
@@ -38,7 +38,7 @@ namespace TrRouting
     maxAccessWalkingTravelTimeSeconds(baseParams.maxAccessWalkingTravelTimeSeconds),
     maxEgressWalkingTravelTimeSeconds(baseParams.maxEgressWalkingTravelTimeSeconds),
     maxTransferWalkingTravelTimeSeconds(baseParams.maxTransferWalkingTravelTimeSeconds),
-    maxFirstWaitingTimeSeconds(baseParams.maxFirstWaitingTimeSeconds),
+    maxInnerTimeOfTripBufferSeconds(baseParams.maxInnerTimeOfTripBufferSeconds),
     scenarioUuid(baseParams.scenarioUuid),
     onlyServices(baseParams.onlyServices),
     onlyLines(baseParams.onlyLines),
@@ -78,7 +78,7 @@ namespace TrRouting
     int maxAccessWalkingTravelTimeSeconds = DEFAULT_MAX_ACCESS_TRAVEL_TIME;
     int maxEgressWalkingTravelTimeSeconds = DEFAULT_MAX_EGRESS_TRAVEL_TIME;
     int maxTransferWalkingTravelTimeSeconds = DEFAULT_MAX_TRANSFER_TRAVEL_TIME;
-    int maxFirstWaitingTimeSeconds = DEFAULT_FIRST_WAITING_TIME; // Ignore all connections at access nodes if waiting time would be more than this value.
+    int maxInnerTimeOfTripBufferSeconds = DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER; // Ignore all connections at access nodes (if forwardCalculation) or egress nodes (if reverse) if waiting time would be more than this value.
     bool forwardCalculation = true;
 
     // TODO Replace manually parsing parameters by a library that does this
@@ -171,10 +171,20 @@ namespace TrRouting
       }
       else if (parameterWithValue.first == "max_first_waiting_time")
       {
-        maxFirstWaitingTimeSeconds = CommonParameters::getIntegerValue(parameterWithValue.second);
-        if (maxFirstWaitingTimeSeconds <= 0)
+        // Deprecated parameter, kept for backward compatibility
+        maxInnerTimeOfTripBufferSeconds = CommonParameters::getIntegerValue(parameterWithValue.second);
+        if (maxInnerTimeOfTripBufferSeconds <= 0)
         {
-          maxFirstWaitingTimeSeconds = -1;
+          maxInnerTimeOfTripBufferSeconds = -1;
+        }
+        continue;
+      }
+      else if (parameterWithValue.first == "max_inner_time_of_trip_buffer")
+      {
+        maxInnerTimeOfTripBufferSeconds = CommonParameters::getIntegerValue(parameterWithValue.second);
+        if (maxInnerTimeOfTripBufferSeconds <= 0)
+        {
+          maxInnerTimeOfTripBufferSeconds = -1;
         }
         continue;
       }
@@ -201,7 +211,7 @@ namespace TrRouting
       maxAccessWalkingTravelTimeSeconds,
       maxEgressWalkingTravelTimeSeconds,
       maxTransferWalkingTravelTimeSeconds,
-      maxFirstWaitingTimeSeconds,
+      maxInnerTimeOfTripBufferSeconds,
       forwardCalculation);
   }
 

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -28,6 +28,7 @@ namespace TrRouting
     int  footpathDistance                 {-1};
     int  tentativeAccessNodeDepartureTime {-1};
     bool reachedAtLeastOneAccessNode      {false};
+    bool nodeWasEgressedAtDestination     {false};
     int  bestDepartureTime                {-1};
 
     //TODO could be passed as a parameter
@@ -65,14 +66,35 @@ namespace TrRouting
           tripExitConnection   = currentTripQueryOverlay.exitConnection;
           const Node &nodeArrival = (*connection).get().getArrivalNode();
 
-          // Extract node arrival time
+
+          // Extract node latest possible arrival time
           int nodeArrivalTentativeTime = nodesReverseTentativeTime.at(nodeArrival.uid);
+
+          // TODO Refactor this complex condition. The
+          // maxInnerTimeOfTripBufferSeconds > 0 has nothing to do with whether
+          // the node was egressed at destination. The absence of a final exit
+          // connection in the steps just means we have not found a transit
+          // connection that would lead to destination through this node faster
+          // than by walking. So it is an egressed node.
+          auto nodeEgressIte = nodesEgress.find(nodeArrival.uid);          
+          nodeWasEgressedAtDestination = parameters.getMaxInnerTimeOfTripBufferSeconds() > 0 &&
+            nodeEgressIte != nodesEgress.end() &&
+            nodeEgressIte->second.time >= 0 &&
+            !reverseJourneysSteps.at(nodeArrival.uid).getFinalExitConnection().has_value();
 
           // reachable connections only here:
           if (
+            (
               tripExitConnection.has_value()
-            ||
-            nodeArrivalTentativeTime >= connectionArrivalTime
+              ||
+              nodeArrivalTentativeTime >= connectionArrivalTime
+            )
+            &&
+            (
+              !nodeWasEgressedAtDestination
+              ||
+              nodeArrivalTentativeTime - connectionArrivalTime <= parameters.getMaxInnerTimeOfTripBufferSeconds()
+            )
           )
           {
             
@@ -167,9 +189,9 @@ namespace TrRouting
                       if (
                         departureTimeSeconds == -1
                         ||
-                        parameters.getMaxFirstWaitingTimeSeconds() < connectionMinWaitingTimeSeconds
+                        parameters.getMaxInnerTimeOfTripBufferSeconds() < connectionMinWaitingTimeSeconds
                         ||
-                        connectionDepartureTime - departureTimeSeconds - nodeDepartureInNodesAccessIte->second.time <= parameters.getMaxFirstWaitingTimeSeconds()
+                        connectionDepartureTime - departureTimeSeconds - nodeDepartureInNodesAccessIte->second.time <= parameters.getMaxInnerTimeOfTripBufferSeconds()
                       )
                       {
                         reverseAccessJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(*connection, currentTripQueryOverlay.exitConnection, std::cref(trip), 0, true, 0));
@@ -360,9 +382,9 @@ namespace TrRouting
                       if (
                         departureTimeSeconds == -1
                         ||
-                        parameters.getMaxFirstWaitingTimeSeconds() < connectionMinWaitingTimeSeconds
+                        parameters.getMaxInnerTimeOfTripBufferSeconds() < connectionMinWaitingTimeSeconds
                         ||
-                        connectionDepartureTime - departureTimeSeconds - nodeDepartureInNodesAccessIte->second.time <= parameters.getMaxFirstWaitingTimeSeconds()
+                        connectionDepartureTime - departureTimeSeconds - nodeDepartureInNodesAccessIte->second.time <= parameters.getMaxInnerTimeOfTripBufferSeconds()
                       )
                       {
                         reverseAccessJourneysSteps.insert_or_assign(transferableNode.node.uid, JourneyStep(*connection, currentTripQueryOverlay.exitConnection, std::cref(trip), 0, true, 0));

--- a/docs/APIv2/API.yml
+++ b/docs/APIv2/API.yml
@@ -1,7 +1,13 @@
 openapi: '3.0.2'
 info:
   title: TrRouting
-  version: '2.0-beta'
+  version: '2.1-beta'
+  description: |
+    Transit routing API
+    
+    Version history:
+    - 2.0-beta: Initial API release
+    - 2.1-beta: Added maxInnerTimeOfTripBuffer parameter, to replace deprecated maxFirstWaitingTime
 servers:
   - url: http://localhost:4000
 
@@ -42,6 +48,7 @@ paths:
       - $ref: "parameters.yml#/maxTransferTravelTimeParam"
       - $ref: "parameters.yml#/maxTravelTimeParam"
       - $ref: "parameters.yml#/maxFirstWaitingTime"
+      - $ref: "parameters.yml#/maxInnerTimeOfTripBuffer"
       responses:
         '200':
           description: Successful query, but may not have returned a routing result
@@ -81,6 +88,7 @@ paths:
       - $ref: "parameters.yml#/maxTransferTravelTimeParam"
       - $ref: "parameters.yml#/maxTravelTimeParam"
       - $ref: "parameters.yml#/maxFirstWaitingTime"
+      - $ref: "parameters.yml#/maxInnerTimeOfTripBuffer"
       - in: query
         name: type
         schema:
@@ -129,6 +137,7 @@ paths:
       - $ref: "parameters.yml#/maxTransferTravelTimeParam"
       - $ref: "parameters.yml#/maxTravelTimeParam"
       - $ref: "parameters.yml#/maxFirstWaitingTime"
+      - $ref: "parameters.yml#/maxInnerTimeOfTripBuffer"
       responses:
         '200':
           description: Successful query, but there may be no node
@@ -184,6 +193,7 @@ paths:
       - $ref: "parameters.yml#/maxTransferTravelTimeParam"
       - $ref: "parameters.yml#/maxTravelTimeParam"
       - $ref: "parameters.yml#/maxFirstWaitingTime"
+      - $ref: "parameters.yml#/maxInnerTimeOfTripBuffer"
       responses:
         '200':
           description: Successful query, but there may be no node
@@ -204,4 +214,3 @@ paths:
             application/json:
               schema:
                 $ref: 'odTripsResponse.yml#/od_trips_query_error'
-    

--- a/docs/APIv2/parameters.yml
+++ b/docs/APIv2/parameters.yml
@@ -91,4 +91,19 @@ maxFirstWaitingTime:
   schema:
     type: integer
   required: false
-  description: The maximum time, in seconds, one can wait at first stop/station to consider this trip valid
+  deprecated: true
+  x-deprecated-in-version: "2.1-beta"
+  description: "[DEPRECATED - Use max_inner_time_of_trip_buffer instead] The maximum time, in seconds, one can wait at first stop/station to consider this trip valid"
+maxInnerTimeOfTripBuffer:
+  in: query
+  name: max_inner_time_of_trip_buffer
+  schema:
+    type: integer
+  required: false
+  x-added-in-version: "2.1-beta"
+  description: |
+    Maximum allowed time difference (in seconds) between the requested time and the actual trip time.
+    - For departure time requests (time_type = 0): Maximum allowed waiting time at the first stop before boarding.
+    - For arrival time requests (time_type = 1): Maximum allowed time between the actual arrival and the requested arrival time.
+    If this buffer is exceeded, the trip is considered invalid. Replaces the deprecated max_first_waiting_time parameter.
+    Added in version 2.1-beta.

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -28,7 +28,8 @@ namespace TrRouting
   static const int DEFAULT_MAX_ACCESS_TRAVEL_TIME = 20 * 60;
   static const int DEFAULT_MAX_EGRESS_TRAVEL_TIME = 20 * 60;
   static const int DEFAULT_MAX_TRANSFER_TRAVEL_TIME = 20 * 60;
-  static const int DEFAULT_FIRST_WAITING_TIME = 30 * 60;
+  // 30 minutes: Buffer time added to time_of_trip when searching for first/last connections within the trip
+  static const int DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER = 30 * 60;
 
   class ParameterException : public std::exception
   {
@@ -81,7 +82,7 @@ namespace TrRouting
       int maxAccessWalkingTravelTimeSeconds;
       int maxEgressWalkingTravelTimeSeconds;
       int maxTransferWalkingTravelTimeSeconds;
-      int maxFirstWaitingTimeSeconds;
+      int maxInnerTimeOfTripBufferSeconds;
 
       boost::uuids::uuid scenarioUuid;
       std::vector<std::reference_wrapper<const Service>> onlyServices;
@@ -112,7 +113,7 @@ namespace TrRouting
         int maxAccessTime,
         int maxEgressTime,
         int maxTransferTime,
-        int maxFirstWaitingTime,
+        int maxTimeOfTripBuffer,
         bool forward
       );
       virtual ~CommonParameters() {}
@@ -124,7 +125,16 @@ namespace TrRouting
       int getMaxAccessWalkingTravelTimeSeconds() const { return maxAccessWalkingTravelTimeSeconds; }
       int getMaxEgressWalkingTravelTimeSeconds() const { return maxEgressWalkingTravelTimeSeconds; }
       int getMaxTransferWalkingTravelTimeSeconds() const { return maxTransferWalkingTravelTimeSeconds; }
-      int getMaxFirstWaitingTimeSeconds() const { return maxFirstWaitingTimeSeconds; }
+      /**
+       * @brief Gets the value of the inner time of trip buffer, in seconds
+       *
+       * Get the time of trip buffer in seconds, used to bound initial
+       * connection searches. This buffer will be added to the time of trip if
+       * it is a departure time, or substracted if it is an arrival time.
+       *
+       * @return int 
+       */
+      int getMaxInnerTimeOfTripBufferSeconds() const { return maxInnerTimeOfTripBufferSeconds; }
       bool isForwardCalculation() { return forwardCalculation; }
       const std::vector<std::reference_wrapper<const Service>>& getOnlyServices() const { return onlyServices; }
       const std::vector<std::reference_wrapper<const Service>>& getExceptServices() const { return exceptServices; }

--- a/tests/connection_scan_algorithm/csa_access_map_test.cpp
+++ b/tests/connection_scan_algorithm/csa_access_map_test.cpp
@@ -17,7 +17,7 @@ protected:
     static const int DEFAULT_MAX_ACCESS_TRAVEL_TIME = 20 * 60;
     static const int DEFAULT_MAX_EGRESS_TRAVEL_TIME = 20 * 60;
     static const int DEFAULT_MAX_TRANSFER_TRAVEL_TIME = 20 * 60;
-    static const int DEFAULT_FIRST_WAITING_TIME = 30 * 60;
+    static const int DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER = 30 * 60;
 
 public:
     // Helper method to set parameters and calculate OD trip result. Test cases need only provide parameters and validate the result
@@ -51,7 +51,7 @@ TEST_F(AccessMapFixtureTests, AllNodesQueryNoNodeAtPlace)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         true
     );
 
@@ -81,7 +81,7 @@ TEST_F(AccessMapFixtureTests, AllNodesQueryNoServiceAtPlace)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false
     );
 
@@ -111,7 +111,7 @@ TEST_F(AccessMapFixtureTests, SimpleAllNodesQuery)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         true
     );
 
@@ -175,7 +175,7 @@ TEST_F(AccessMapFixtureTests, SimpleAllNodesQueryBackward)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false
     );
 

--- a/tests/connection_scan_algorithm/csa_result_to_response_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_response_test.cpp
@@ -34,7 +34,7 @@ void ResultToResponseFixtureTest::SetUp()
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );

--- a/tests/connection_scan_algorithm/csa_result_to_response_test.hpp
+++ b/tests/connection_scan_algorithm/csa_result_to_response_test.hpp
@@ -26,7 +26,7 @@ protected:
     inline static const int DEFAULT_MAX_ACCESS_TRAVEL_TIME = 20 * 60;
     inline static const int DEFAULT_MAX_EGRESS_TRAVEL_TIME = 20 * 60;
     inline static const int DEFAULT_MAX_TRANSFER_TRAVEL_TIME = 20 * 60;
-    inline static const int DEFAULT_FIRST_WAITING_TIME = 30 * 60;
+    inline static const int DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER = 30 * 60;
     inline static const int DEFAULT_TIME = 8 * 60 * 60;
     inline static const std::string agencyUuid = "aaaaaaaa-1111-cccc-dddd-eeeeeeffffff";
     inline static const std::string lineUuid = "aaaaaaaa-2222-cccc-dddd-eeeeeeffffff";

--- a/tests/connection_scan_algorithm/csa_result_to_v2_accessibility_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_v2_accessibility_test.cpp
@@ -30,7 +30,7 @@ public:
             DEFAULT_MAX_ACCESS_TRAVEL_TIME,
             DEFAULT_MAX_EGRESS_TRAVEL_TIME,
             DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-            DEFAULT_FIRST_WAITING_TIME,
+            DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
             true
         );
     }
@@ -120,7 +120,7 @@ TEST_F(ResultToV2AccessFixtureTest, TestAllNodesBackwardV2Access)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false
     );
 

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -48,7 +48,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoPath)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -76,7 +76,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtOrigin)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -104,7 +104,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtDestination)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -132,7 +132,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseNoNodeAtOriginAndDest
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -160,7 +160,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseTooEarly)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -189,7 +189,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingBecauseTooEarlyArrival)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         false // reverse journey
     );
@@ -222,7 +222,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NodeToNodeCalculation)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -255,7 +255,7 @@ TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationDepartureTime)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -289,7 +289,7 @@ TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationArrivalTime)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         false
     );
@@ -330,7 +330,7 @@ TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationArrivalTimeWith2Al
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         false
     );
@@ -388,7 +388,7 @@ TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationWithAllParams)
         minWaitingTime);
 }
 
-// Same as SimpleODCalculation, but with max_access_travel_time lower than access time
+// Same as SimpleODCalculationDepartureTime, but with max_access_travel_time lower than access time
 TEST_F(SingleRouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
 {
     int departureTime = getTimeInSeconds(9, 45);
@@ -405,7 +405,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
         accessTime - 5,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -420,7 +420,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingAccessTimeLimit)
     }
 }
 
-// Same as SimpleODCalculation, but with max_egress_travel_time lower than egress time
+// Same as SimpleODCalculationDepartureTime, but with max_egress_travel_time lower than egress time
 TEST_F(SingleRouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
 {
     int departureTime = getTimeInSeconds(9, 45);
@@ -437,7 +437,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         egressTime - 5,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -452,8 +452,8 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingEgressTimeLimit)
     }
 }
 
-// Same as SimpleODCalculation, but with max_first_waiting_time lower than should be
-TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMaxFirstWaitingTime)
+// Same as SimpleODCalculationDepartureTime, but with max_inner_time_of_trip_buffer lower than should be
+TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMaxInnerTimeOfTripBufferDeparture)
 {
     int departureTime = getTimeInSeconds(9, 45);
         // This is where mocking would be interesting. Those were taken from the first run of the test
@@ -485,6 +485,42 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMaxFirstWaitingTime)
     }
 }
 
+// Same as SimpleODCalculationArrivalTime, but with max_inner_time_of_trip_buffer lower than should be
+TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMaxInnerTimeOfTripBufferArrival)
+{
+    int arrivalTime = getTimeInSeconds(11, 15);
+        // This is where mocking would be interesting. Those were taken from the first run of the test
+    int egressTime = 138;
+    int travelTimeInVehicle = 420;
+    int expectedTransitDepartureTime = getTimeInSeconds(11);
+    int tripArrivalTime = expectedTransitDepartureTime + egressTime + travelTimeInVehicle;
+
+    TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
+        std::make_unique<TrRouting::Point>(45.5242, -73.5817),
+        std::make_unique<TrRouting::Point>(45.54, -73.6146),
+        transitData.getScenarios().at(TestDataFetcher::scenarioUuid),
+        arrivalTime,
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MAX_TOTAL_TIME,
+        DEFAULT_MAX_ACCESS_TRAVEL_TIME,
+        DEFAULT_MAX_EGRESS_TRAVEL_TIME,
+        DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
+        // max first waiting time, 5 seconds less than needed
+        arrivalTime - tripArrivalTime - 5,
+        false,
+        false
+    );
+
+    try {
+        calculateOd(testParameters);
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, no exception thrown";
+    } catch (TrRouting::NoRoutingFoundException const & e) {
+        assertNoRouting(e, TrRouting::NoRoutingReason::NO_SERVICE_TO_DESTINATION);
+    } catch(...) {
+        FAIL() << "Expected TrRouting::NoRoutingFoundException, another type was thrown";
+    }
+}
+
 // Same as SimpleODCalculation, but with min_waiting_time higher than available
 TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMinWaitingTime)
 {
@@ -502,7 +538,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingMinWaitingTime)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -533,7 +569,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingTravelTime)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -566,7 +602,7 @@ TEST_F(SingleRouteCalculationFixtureTests, NoRoutingTravelTimeLongerTrip)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.hpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.hpp
@@ -18,7 +18,7 @@ protected:
     static const int DEFAULT_MAX_ACCESS_TRAVEL_TIME = 20 * 60;
     static const int DEFAULT_MAX_EGRESS_TRAVEL_TIME = 20 * 60;
     static const int DEFAULT_MAX_TRANSFER_TRAVEL_TIME = 20 * 60;
-    static const int DEFAULT_FIRST_WAITING_TIME = 30 * 60;
+    static const int DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER = 30 * 60;
 
 public:
     // Helper method to set parameters and calculate OD trip result. Test cases need only provide parameters and validate the result

--- a/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_transfer_alternatives_test.cpp
@@ -56,7 +56,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithTransfer)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -102,7 +102,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithTransferButLineNotEnabled)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -143,7 +143,7 @@ TEST_F(SingleTAndACalculationFixtureTests, NoTransferMinTransferTime)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -184,7 +184,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithWalkingTransfer)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         false,
         true
     );
@@ -223,7 +223,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithAlternatives)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         true,
         true
     );
@@ -294,7 +294,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithAlternativesTooLong)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         true,
         true
     );
@@ -335,7 +335,7 @@ TEST_F(SingleTAndACalculationFixtureTests, TripWithNoRoutingAlternatives)
         DEFAULT_MAX_ACCESS_TRAVEL_TIME,
         DEFAULT_MAX_EGRESS_TRAVEL_TIME,
         DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
-        DEFAULT_FIRST_WAITING_TIME,
+        DEFAULT_MAX_INNER_TIME_OF_TRIP_BUFFER,
         true,
         true
     );

--- a/tests/connection_scan_algorithm/parameters/accessibility_param_test.cpp
+++ b/tests/connection_scan_algorithm/parameters/accessibility_param_test.cpp
@@ -66,7 +66,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("max_egress_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
         std::make_tuple("max_transfer_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
         std::make_tuple("max_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
-        std::make_tuple("max_first_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA)
+        std::make_tuple("max_first_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_inner_time_of_trip_buffer", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA)
     )
 );
 
@@ -126,7 +127,7 @@ TEST_F(AccessibilityParametersFixtureTests, DefaultParameters)
     EXPECT_EQ(queryParams.getMaxAccessWalkingTravelTimeSeconds(), 20 * 60);
     EXPECT_EQ(queryParams.getMaxEgressWalkingTravelTimeSeconds(), 20 * 60);
     EXPECT_EQ(queryParams.getMaxTransferWalkingTravelTimeSeconds(), 20 * 60);
-    EXPECT_EQ(queryParams.getMaxFirstWaitingTimeSeconds(), 30 * 60);
+    EXPECT_EQ(queryParams.getMaxInnerTimeOfTripBufferSeconds(), 30 * 60);
 }
 
 TEST_F(AccessibilityParametersFixtureTests, SetAllParameters)
@@ -145,7 +146,7 @@ TEST_F(AccessibilityParametersFixtureTests, SetAllParameters)
     parametersWithValues.push_back(std::make_pair("max_egress_travel_time", std::to_string(maxEgress)));
     parametersWithValues.push_back(std::make_pair("max_transfer_travel_time", std::to_string(maxTransfer)));
     parametersWithValues.push_back(std::make_pair("max_travel_time", std::to_string(maxTotalTime)));
-    parametersWithValues.push_back(std::make_pair("max_first_waiting_time", std::to_string(maxFirst)));
+    parametersWithValues.push_back(std::make_pair("max_inner_time_of_trip_buffer", std::to_string(maxFirst)));
 
     TrRouting::AccessibilityParameters queryParams = TrRouting::AccessibilityParameters::createAccessibilityParameter(parametersWithValues, scenarios);
     EXPECT_DOUBLE_EQ(queryParams.getPlace()->latitude, 45.5544);
@@ -159,5 +160,5 @@ TEST_F(AccessibilityParametersFixtureTests, SetAllParameters)
     EXPECT_EQ(queryParams.getMaxAccessWalkingTravelTimeSeconds(), maxAccess);
     EXPECT_EQ(queryParams.getMaxEgressWalkingTravelTimeSeconds(), maxEgress);
     EXPECT_EQ(queryParams.getMaxTransferWalkingTravelTimeSeconds(), maxTransfer);
-    EXPECT_EQ(queryParams.getMaxFirstWaitingTimeSeconds(), maxFirst);
+    EXPECT_EQ(queryParams.getMaxInnerTimeOfTripBufferSeconds(), maxFirst);
 }

--- a/tests/connection_scan_algorithm/parameters/route_param_test.cpp
+++ b/tests/connection_scan_algorithm/parameters/route_param_test.cpp
@@ -69,7 +69,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("max_egress_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
         std::make_tuple("max_transfer_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
         std::make_tuple("max_travel_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
-        std::make_tuple("max_first_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA)
+        std::make_tuple("max_first_waiting_time", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA),
+        std::make_tuple("max_inner_time_of_trip_buffer", "nan", TrRouting::ParameterException::Type::INVALID_NUMERICAL_DATA)
     )
 );
 
@@ -137,7 +138,7 @@ TEST_F(RouteParametersFixtureTests, DefaultParameters)
     EXPECT_EQ(queryParams.getMaxAccessWalkingTravelTimeSeconds(), 20 * 60);
     EXPECT_EQ(queryParams.getMaxEgressWalkingTravelTimeSeconds(), 20 * 60);
     EXPECT_EQ(queryParams.getMaxTransferWalkingTravelTimeSeconds(), 20 * 60);
-    EXPECT_EQ(queryParams.getMaxFirstWaitingTimeSeconds(), 30 * 60);
+    EXPECT_EQ(queryParams.getMaxInnerTimeOfTripBufferSeconds(), 30 * 60);
 }
 
 TEST_F(RouteParametersFixtureTests, SetAllParameters)
@@ -158,7 +159,7 @@ TEST_F(RouteParametersFixtureTests, SetAllParameters)
     parametersWithValues.push_back(std::make_pair("max_egress_travel_time", std::to_string(maxEgress)));
     parametersWithValues.push_back(std::make_pair("max_transfer_travel_time", std::to_string(maxTransfer)));
     parametersWithValues.push_back(std::make_pair("max_travel_time", std::to_string(maxTotalTime)));
-    parametersWithValues.push_back(std::make_pair("max_first_waiting_time", std::to_string(maxFirst)));
+    parametersWithValues.push_back(std::make_pair("max_inner_time_of_trip_buffer", std::to_string(maxFirst)));
 
     TrRouting::RouteParameters queryParams = TrRouting::RouteParameters::createRouteODParameter(parametersWithValues, scenarios);
     EXPECT_DOUBLE_EQ(queryParams.getOrigin()->latitude, 45.5544);
@@ -175,5 +176,5 @@ TEST_F(RouteParametersFixtureTests, SetAllParameters)
     EXPECT_EQ(queryParams.getMaxAccessWalkingTravelTimeSeconds(), maxAccess);
     EXPECT_EQ(queryParams.getMaxEgressWalkingTravelTimeSeconds(), maxEgress);
     EXPECT_EQ(queryParams.getMaxTransferWalkingTravelTimeSeconds(), maxTransfer);
-    EXPECT_EQ(queryParams.getMaxFirstWaitingTimeSeconds(), maxFirst);
+    EXPECT_EQ(queryParams.getMaxInnerTimeOfTripBufferSeconds(), maxFirst);
 }


### PR DESCRIPTION
fixes #317

Add unit tests that previously failed, but passed with this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced max_inner_time_of_trip_buffer parameter to control inner trip buffer for departures and arrivals, affecting routing, accessibility, reverse/forward calculations and alternatives handling.
- Documentation
  - API bumped to 2.1-beta; docs include the new parameter and mark the old parameter deprecated with migration notes.
- Refactor
  - Renamed defaults and public parameter names to reflect max_inner_time_of_trip_buffer terminology.
- Tests
  - Updated and added tests to validate the new parameter and adjusted waiting-time semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->