### PR TITLE
route: calculate route with arrival time symetrically with departure

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -86,6 +86,7 @@ namespace TrRouting
     // Convert the optimization case ID returned by optimizeJourney to a string
     std::string optimizeCasesToString(const std::vector<int> optimizeCases);
     std::unique_ptr<SingleCalculationResult> calculateSingleReverse(RouteParameters &parameters);
+    std::unique_ptr<SingleCalculationResult> calculateSingleForward(RouteParameters &parameters);
 
     CalculationTime algorithmCalculationTime;
     //TODO set it mutable so it can be changed/reset?

--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -154,7 +154,7 @@ namespace TrRouting
 
     //params.departureTimeSeconds = departureTimeSeconds;
 
-    spdlog::debug("  fastestTravelTimeSeconds: {}", routingResult.totalTravelTime);
+    spdlog::debug("  fastestTravelTimeSeconds: {} Maximum alternative travel time: {}", routingResult.totalTravelTime, maxTravelTime);
 
     // Get the best result and extract the lines from it
     // We will generate all the combinations of those lines and redo the calculation

--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -62,16 +62,66 @@ namespace TrRouting
     }
     else if (arrivalTimeSeconds > -1)
     {
-      departureTimeSeconds = -1;
-      //TODO maybe we can do something different in that case, like a query flag
+      std::unordered_map<Node::uid_t, JourneyStep> reverseAccessJourneysSteps;
+
+      // TODO maybe we can do something different in that case, like a query flag
       // we need to make all trips usable when not coming from forward result because reverse calculation, by default, checks for usableTrips
       for (auto && tripIte : transitData.getTrips()) {
         const Trip & trip = tripIte.second;
         tripsQueryOverlay[trip.uid].usable = true;
       }
-      result = calculateSingleReverse(parameters);
+
+      auto resultCalculation = reverseCalculation(parameters, reverseAccessJourneysSteps);
+      spdlog::debug("-- reverse calculation -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
+      calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
+      if (resultCalculation.has_value()) {
+        int bestDepartureTime = std::get<0>(*resultCalculation);
+        std::reference_wrapper<const Node> bestAccessNode = std::get<1>(*resultCalculation);
+
+        spdlog::debug("bestDepartureTime after reverse journey: {}", bestDepartureTime);
+          
+        departureTimeSeconds = bestDepartureTime;
+          
+        for (auto & accessFootpath : accessFootpaths) // reset nodes reverse tentative times with new arrival time:
+        {
+          nodesTentativeTime[accessFootpath.node.uid] = departureTimeSeconds + accessFootpath.time;
+        }
+
+        result = calculateSingleForward(parameters);
+      }
+      else
+      {
+        // There's service at access/egress but no routing found
+        spdlog::debug("no routing found in reverse trip calculation");
+        throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
+      }
 
     }
+
+    return result;
+  }
+
+  // To be called only by calculateSingle, depends on preparations steps done there
+  std::unique_ptr<SingleCalculationResult> Calculator::calculateSingleForward(RouteParameters &parameters) {
+
+    std::unique_ptr<SingleCalculationResult> result;
+
+    int bestArrivalTime {MAX_INT};
+    std::optional<std::reference_wrapper<const Node>> bestEgressNode;
+    std::unordered_map<Node::uid_t, JourneyStep> forwardEgressJourneysSteps;
+
+    auto resultCalculation = forwardCalculation(parameters, forwardEgressJourneysSteps);
+    if (resultCalculation) {
+      bestArrivalTime = std::get<0>(*resultCalculation);
+      bestEgressNode = std::get<1>(*resultCalculation);
+    }
+
+    spdlog::debug("-- forward calculation --  {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
+    calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
+    result = forwardJourneyStep(parameters, bestEgressNode, forwardEgressJourneysSteps);
+
+    spdlog::debug("-- forward journey -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
+    calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
 
     return result;
   }

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -89,11 +89,41 @@ namespace TrRouting
           )
           {
             // TODO: add constrain for sameLineTransfer (check trip allowSameLineTransfers)
-            if ((*connection).get().canBoard() && (!tripEnterConnection.has_value()) )
+            if ((*connection).get().canBoard())
             {
-              currentTripQueryOverlay.usable = true;
-              currentTripQueryOverlay.enterConnection = *connection;
-              currentTripQueryOverlay.enterConnectionTransferTravelTime = forwardJourneysSteps.at(nodeDeparture.uid).getTransferTravelTime();
+               // Extract journeyStep once from map
+               const JourneyStep & stepAtDeparture = forwardJourneysSteps.at(nodeDeparture.uid);
+               if (!tripEnterConnection.has_value()) // <= to make sure we get the same result as forward calculation, which uses >
+               {
+                currentTripQueryOverlay.usable = true;
+                currentTripQueryOverlay.enterConnection = *connection;
+                currentTripQueryOverlay.enterConnectionTransferTravelTime = forwardJourneysSteps.at(nodeDeparture.uid).getTransferTravelTime();
+               }
+               else if (
+                        // This 'if' checks if the previous journey step leading
+                        // to the departure node of this journey has a transfer
+                        // time lesser than the one to enter the current trip.
+                        // If so, the current connection becomes the new trip
+                        // entry connection if departure time is feasible. This
+                        // has the effect of minimizing the transfer time.
+                        // Otherwise, the waiting time will be filled by walking
+                        // to another bus stop or by taking a short transit
+                        // trips that will come back to this point eventually.
+                        stepAtDeparture.getFinalExitConnection().has_value()
+                        &&
+                        stepAtDeparture.getTransferTravelTime() >= 0
+                        && 
+                        stepAtDeparture.getTransferTravelTime() < currentTripQueryOverlay.enterConnectionTransferTravelTime
+                        )
+               {
+                 short previousStepMinWaitingTimeSeconds = stepAtDeparture.getFinalEnterConnection().value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
+ 
+                 if (connectionDepartureTime - previousStepMinWaitingTimeSeconds >= nodeDepartureTentativeTime)
+                 {
+                   currentTripQueryOverlay.enterConnection = *connection;
+                   currentTripQueryOverlay.enterConnectionTransferTravelTime = stepAtDeparture.getTransferTravelTime();
+                 }
+               }
             }
             
             if ((*connection).get().canUnboard() && currentTripQueryOverlay.enterConnection.has_value())

--- a/connection_scan_algorithm/src/forward_journey.cpp
+++ b/connection_scan_algorithm/src/forward_journey.cpp
@@ -44,7 +44,6 @@ namespace TrRouting
       int waitingTime              {-1}; int accessWaitingTime      {-1};
 
       // recreate journey:
-
       JourneyStep resultingNodeJourneyStep = forwardEgressJourneysSteps.at(resultingNode.uid);
 
       std::optional<std::reference_wrapper<const Node>> bestAccessNode;
@@ -58,7 +57,7 @@ namespace TrRouting
       journey.push_back(JourneyStep(std::nullopt,
                                     std::nullopt,
                                     std::nullopt,
-                                    nodesEgress.at(resultingNode.uid).distance,
+                                    nodesEgress.at(resultingNode.uid).time,
                                     false,
                                     nodesEgress.at(resultingNode.uid).distance));
 
@@ -68,6 +67,9 @@ namespace TrRouting
                                      nodesAccess.at(bestAccessNode.value().get().uid).time,
                                      false,
                                      nodesAccess.at(bestAccessNode.value().get().uid).distance));
+      std::vector<int> optimizeCases = optimizeJourney(journey);
+
+      spdlog::debug("-- {} optimization case used {} ", optimizeCases.size(), optimizeCasesToString(optimizeCases) );
 
       size_t i = 0;
       size_t journeyStepsCount = journey.size();
@@ -150,7 +152,7 @@ namespace TrRouting
                                                                              boardingSequence,
                                                                              boardingSequence,
                                                                              journeyStepNodeDeparture,
-                                                                             minimizedDepartureTime,
+                                                                             departureTime,
                                                                              waitingTime
                                                                              ));
 

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -97,6 +97,10 @@ namespace TrRouting
               {
                 journeyConnectionMinWaitingTimeSeconds = reverseStepAtArrival.getFinalEnterConnection().value().get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
 
+                // FIXME Understand why we need to add the
+                // journeyConnectionMinWaitingTimeSeconds here as we are at the
+                // arrival time. But without it, it exits the trip and re-enters
+                // it right away.
                 if (connectionArrivalTime + journeyConnectionMinWaitingTimeSeconds <= nodeArrivalTentativeTime)
                 {
                   currentTripQueryOverlay.exitConnection = *connection;

--- a/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
+++ b/tests/connection_scan_algorithm/csa_route_calculation_test.cpp
@@ -303,6 +303,52 @@ TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationArrivalTime)
         egressTime);
 }
 
+// Test case developed to reproduce
+// https://github.com/chairemobilite/trRouting/issues/298 There are 2
+// alternatives, who both start at the same time. One with a transfer to the
+// extra line arrives at 10:25, while the other walks longer and arrives at
+// 10:30. The one with transfer should always be preferred.
+TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationArrivalTimeWith2Alternatives)
+{
+    int arrivalTime = getTimeInSeconds(10, 35);
+    int travelTimeInVehicle = 720; // north line and extra line
+    // This is where mocking would be interesting. Those were taken from the first run of the test
+    int accessTime = 469;
+    int egressTime = 48;
+    int expectedTransitDepartureTime = getTimeInSeconds(10);
+    int expectedNbTransfers = 1;
+    int expectedTransferWaitingTime = 120 + DEFAULT_MIN_WAITING_TIME; // 2 minutes wait + min waiting time before boarding
+    int expectedTransferWalkingTime = 480;
+
+    TrRouting::RouteParameters testParameters = TrRouting::RouteParameters(
+        std::make_unique<TrRouting::Point>(45.5242, -73.5817),
+        std::make_unique<TrRouting::Point>(45.55372, -73.61859),
+        transitData.getScenarios().at(TestDataFetcher::scenarioUuid),
+        arrivalTime,
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MAX_TOTAL_TIME,
+        DEFAULT_MAX_ACCESS_TRAVEL_TIME,
+        DEFAULT_MAX_EGRESS_TRAVEL_TIME,
+        DEFAULT_MAX_TRANSFER_TRAVEL_TIME,
+        DEFAULT_FIRST_WAITING_TIME,
+        false,
+        false
+    );
+
+    std::unique_ptr<TrRouting::RoutingResult> result = calculateOd(testParameters);
+    assertSuccessResults(*result.get(),
+        -1,
+        expectedTransitDepartureTime,
+        travelTimeInVehicle,
+        accessTime,
+        egressTime,
+        expectedNbTransfers,
+        DEFAULT_MIN_WAITING_TIME,
+        DEFAULT_MIN_WAITING_TIME + expectedTransferWaitingTime,
+        expectedTransferWaitingTime,
+        expectedTransferWalkingTime);
+}
+
 // Test from OD With access/egress, origin is further south of South2, in the line axis, destination slightly north-west of midpoint
 // Specify each parameter with a value that allows the result
 TEST_F(SingleRouteCalculationFixtureTests, SimpleODCalculationWithAllParams)


### PR DESCRIPTION
fixes #298

Fix a time instead of distance in the `forwardJourneyStep` method.

Use a similar approach with arrival time calculations as the departure time one: first get the best access time by a reverse calculation, then find the best arrival time for this departure time, thus optimizing the arrival of the route. Then retrieve the journey steps required for the route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated forward calculation path for single-route queries.
  - Introduced local journey optimization profiling to inform route selection.

- **Bug Fixes**
  - Improved boarding and transfer selection via transfer-time-based reassignment.
  - Corrected time metric usage in journey steps for more accurate timings.
  - Clarified behavior when no route is found.

- **Tests**
  - Added an arrival-time scenario with two alternatives to validate preferred transfer routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->