### PR TITLE
csa: update a few debug statements in alternative calculation

### DIFF
--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -269,26 +269,25 @@ namespace TrRouting
         }
 
         alternativesCalculatedCount++;
-
-        if (failedCombinations.size() > 0)
-        {
-          for (auto failedCombination : failedCombinations)
-          {
-            spdlog::debug("failed combinations: {}", LinesToString(failedCombination));
-          }
-        }
       }
     }
 
     int i {0};
     for (auto flines : alreadyFoundLines)
     {          
-      spdlog::debug("{}. {} tt: ", i, LinesToString(flines.first),
+      spdlog::debug("{}. {} travel time minutes: {}", i, LinesToString(flines.first),
                     (foundLinesTravelTimeSeconds[flines.first] / 60));
       i++;          
     }
+
+    // Print failed combinations
+    for (auto failedCombination : failedCombinations)
+    {
+      spdlog::debug("failed combinations: {}", LinesToString(failedCombination));
+    }
     
-    spdlog::debug("last alternative found at: {} on a total of {} calculations", lastFoundedAtNum,  maxAlternatives);
+    spdlog::debug("last alternative found at: {} on a total of {} calculations done. Maximum possible: {}",
+      lastFoundedAtNum,  alternativesCalculatedCount, maxAlternatives);
 
     alternatives.totalAlternativesCalculated = alternativesCalculatedCount;
     return alternatives;


### PR DESCRIPTION
* Move the failed combinations at the end only instead of at every step
* Add the travel time seconds where it should be
* Display the number of alternatives calculated instead of the max

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured all failed combinations are reported after processing completes, improving visibility of outcomes.
* **Refactor**
  * Moved reporting of failed combinations to post-processing to reduce noisy iteration logs and clarify flow.
* **Chores**
  * Clarified travel time log wording to include explicit units.
  * Expanded final progress message to include a "done" status and maximum possible alternatives for clearer status context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->