### PR TITLE
csa: throw no routing found in calculator if no best time

### DIFF
--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -32,45 +32,32 @@ namespace TrRouting
 
     if (departureTimeSeconds > -1 && parameters.isForwardCalculation())
     {
-      
-      int bestArrivalTime {MAX_INT};
-      std::optional<std::reference_wrapper<const Node>> bestEgressNode;
-      //TODO With the TODO later that forwardJourneyStep is not necessary, we can also drop this variable
       std::unordered_map<Node::uid_t, JourneyStep> forwardEgressJourneysSteps;
 
       auto resultCalculation = forwardCalculation(parameters, forwardEgressJourneysSteps);
-      if (resultCalculation.has_value()) {
-        bestArrivalTime = std::get<0>(*resultCalculation);
-        bestEgressNode = std::get<1>(*resultCalculation);
-      }
-
       spdlog::debug("-- forward calculation -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
       calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
-        
-      if (bestArrivalTime < MAX_INT)
-      {
+
+      if (resultCalculation.has_value()) {
+        int bestArrivalTime = std::get<0>(*resultCalculation);
+        std::reference_wrapper<const Node> bestEgressNode = std::get<1>(*resultCalculation);
+
         spdlog::debug("bestArrivalTime after forward journey: {}", bestArrivalTime);
-          
+
         arrivalTimeSeconds = bestArrivalTime;
-          
+
         for (auto & egressFootpath : egressFootpaths) // reset nodes reverse tentative times with new arrival time:
         {
           nodesReverseTentativeTime[egressFootpath.node.uid] = arrivalTimeSeconds - egressFootpath.time;
         }
 
         result = calculateSingleReverse(parameters);
-          
       }
       else
       {
-        //TODO This will always throw an exception since to get here bestEgressNode must be invalid
-        //TODO We can probably just remove the function forwardJourneyStep completely
-        result = forwardJourneyStep(parameters, bestEgressNode, forwardEgressJourneysSteps);
-
-        assert(false); // See TODO
-        spdlog::debug("-- forward journey -- {} microseconds", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
-        calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
-          
+        // There's service at access/egress but no routing found
+        spdlog::debug("no routing found in forward trip calculation");
+        throw NoRoutingFoundException(NoRoutingReason::NO_ROUTING_FOUND);
       }
     }
     else if (arrivalTimeSeconds > -1)


### PR DESCRIPTION
Instead of letting the `reverseJourneyStep` function do it, as we already know this is what is going to happen, just throw the exception right away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When no route is found the app now returns a clear error instead of triggering an internal assertion, preventing crashes and improving reliability in edge cases.
  * Removed unused fallback processing and noisy timing/debug logs in this scenario to reduce log clutter and avoid misleading diagnostics.
  * Ensures consistent propagation of “no route found” outcomes across the app for better user feedback and overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->