### PR TITLE
Use a monotonic clock for CalculationTime

### DIFF
--- a/src/calculation_time.cpp
+++ b/src/calculation_time.cpp
@@ -17,7 +17,7 @@ namespace TrRouting
   long long CalculationTime::getEpoch()
   {
     calculationEpoch = std::chrono::duration_cast< std::chrono::microseconds >(
-      std::chrono::system_clock::now().time_since_epoch()
+      std::chrono::steady_clock::now().time_since_epoch()
     );
     return calculationEpoch.count();
   }


### PR DESCRIPTION
It's better to use a monotonic clock for duration application like CalculationTime. A system clock could to backward at any time when it is changed. So we switch to std::chrono::steady_clock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Stabilized timers and duration reporting to be unaffected by system time changes (e.g., NTP sync, timezone or daylight saving adjustments), preventing negative or jumpy durations.

- Performance
  - Improved accuracy and consistency of elapsed time calculations across start/stop and step operations, resulting in smoother progress indicators and more reliable timing in logs and UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->