### PR TITLE
osrmgeofilter: properly handle `null` distances/durations

### DIFF
--- a/src/osrmgeofilter.cpp
+++ b/src/osrmgeofilter.cpp
@@ -97,13 +97,21 @@ namespace TrRouting {
         int distanceMeters;
         for (int i = 1; i < numberOfDurations; i++) // ignore first (duration with itself)
         {
-          travelTimeSeconds = (int)ceil((float)responseJson["durations"][0][i]);
-          if (travelTimeSeconds <= maxWalkingTravelTime)
+          // Check if the duration and distance values are null before attempting to convert them
+          if (!responseJson["durations"][0][i].is_null() && !responseJson["distances"][0][i].is_null())
           {
-            distanceMeters = (int)ceil((float)responseJson["distances"][0][i]);
-            accessibleNodesFootpaths.push_back(NodeTimeDistance(birdDistanceAccessibleNodeIndexes[i - 1],
+            travelTimeSeconds = (int)ceil((float)responseJson["durations"][0][i]);
+            if (travelTimeSeconds <= maxWalkingTravelTime)
+            {
+              distanceMeters = (int)ceil((float)responseJson["distances"][0][i]);
+              accessibleNodesFootpaths.push_back(NodeTimeDistance(birdDistanceAccessibleNodeIndexes[i - 1],
                                                                 travelTimeSeconds,
                                                                 distanceMeters));
+            }
+          }
+          else
+          {
+            spdlog::debug("skipping node at index {} due to null duration or distance from OSRM", i);
           }
         }
       }


### PR DESCRIPTION
fixes #327

When a node is not routable by osrm, the distances and/or durations returned by the table query can be `null`. When that is the case, we ignore this node. The `osrm` profiles have been investigated, some parameters of the profile may make a node effectively inaccessible, either because it is too far from the network, or the possible routes are not accessible, so the returned `null` value are valid and represent un-routable points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to skip invalid travel time or distance values and avoid processing null results.
  * Now logs when invalid duration/distance is encountered to aid debugging.
  * Ensures only nodes within the allowed walking time are included.

* **Refactor**
  * Moved and streamlined travel-time calculation to occur after validation to avoid unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->