### PR TITLE
Update docker build to use Debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 WORKDIR /source
 # Install dependencies in an intermediate image
 RUN apt-get update && \


### PR DESCRIPTION
Debian Trixie is the latest stable release since august 2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image to a newer stable version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->