### PR TITLE
Reduce memory churn by not calling shrink_to_fit

### DIFF
--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -29,9 +29,7 @@ namespace TrRouting
     if (resetAccessPaths)
     {
       accessFootpaths.clear();
-      accessFootpaths.shrink_to_fit();
       egressFootpaths.clear();
-      egressFootpaths.shrink_to_fit();
     }
     tripsQueryOverlay.assign(Trip::getMaxUid()+1, TripQueryData());
     forwardJourneysSteps.clear();

--- a/src/transit_data.cpp
+++ b/src/transit_data.cpp
@@ -161,8 +161,6 @@ namespace TrRouting {
       forwardConnections.push_back(connections[i]);
       reverseConnections.push_back(connections[i]);
     }
-    forwardConnections.shrink_to_fit();
-    reverseConnections.shrink_to_fit();
 
     try
     {

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -31,7 +31,6 @@ namespace TrRouting
   {
     trips.clear();
     connections.clear();
-    connections.shrink_to_fit();
 
     boost::uuids::string_generator uuidGenerator;
     boost::uuids::uuid tripUuid, pathUuid;


### PR DESCRIPTION
On an high thread count, we are getting contention on memory by constantly allocating and deallocating memory. We can save some of that by not calling shrink_to_fit. We might use a bit more memory, but gain on performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted memory management strategy to reduce explicit memory capacity releases during data resets and cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->