### PR TITLE
Set SO_REUSEPORT on socket to share port for multiple process

### DIFF
--- a/connection_scan_algorithm/include/program_options.hpp
+++ b/connection_scan_algorithm/include/program_options.hpp
@@ -29,6 +29,7 @@ namespace TrRouting
     std::string osrmDrivingHost;
     bool useMemcached;
     std::string memcachedServers;
+    bool        enableReusePort;
 
     ProgramOptions();
     void parseOptions(int argc, char** argv);

--- a/connection_scan_algorithm/src/program_options.cpp
+++ b/connection_scan_algorithm/src/program_options.cpp
@@ -36,7 +36,8 @@ namespace TrRouting {
       ("osrmDrivingHost",                                   boost::program_options::value<std::string>()->default_value("localhost"), "osrm driving host");
     options.add_options()
       ("useMemcached",                                     boost::program_options::value<std::string>()->implicit_value("localhost:11211"), "Enable memcached caching. You can specify a non-default memcached server to use by adding an optional hostname:port string");
-
+    options.add_options()
+      ("enableReusePort",                                   boost::program_options::value<bool>()       ->default_value(false), "enable REUSEPORT on the listening socket. This allow to process requests on multiple processes");
   }
 
   void ProgramOptions::parseOptions(int argc, char** argv) {
@@ -59,6 +60,7 @@ namespace TrRouting {
     osrmDrivingHost      = "localhost";
     useMemcached         = false;
     memcachedServers     = "localhost:11211";
+    enableReusePort      = false;
 
     if(variablesMap.count("help")) {
       std::cout << options << std::endl;
@@ -143,7 +145,10 @@ namespace TrRouting {
       useMemcached = true;
       memcachedServers = variablesMap["useMemcached"].as<std::string>();
     }
-
+    if(variablesMap.count("enableReusePort") == 1)
+    {
+      enableReusePort = variablesMap["enableReusePort"].as<bool>();
+    }
   }
 
 }

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -156,6 +156,7 @@ int main(int argc, char** argv) {
   HttpServer server;
   server.config.port = programOptions.port;
   server.config.thread_pool_size = programOptions.numberOfThreads;
+  server.config.reuse_port = programOptions.enableReusePort; // Allow multiple processes to share a port if set
 
   // updateCache:
   server.resource["^/updateCache[/]?$"]["GET"]=[&server, &transitData](std::shared_ptr<HttpServer::Response> serverResponse, std::shared_ptr<HttpServer::Request> request) {

--- a/include/server_http.hpp
+++ b/include/server_http.hpp
@@ -357,6 +357,8 @@ namespace SimpleWeb {
       bool reuse_address = true;
       /// Make use of RFC 7413 or TCP Fast Open (TFO)
       bool fast_open = false;
+      /// Set to true to allow multiple process to bind to the port
+      bool reuse_port = false;
     };
     /// Set before calling start().
     Config config;
@@ -422,6 +424,13 @@ namespace SimpleWeb {
           throw;
       }
       acceptor->set_option(asio::socket_base::reuse_address(config.reuse_address));
+      if(config.reuse_port) {
+#if defined(__linux__) && defined(SO_REUSEPORT)
+        using reuse_port_option = asio::detail::socket_option::boolean<SOL_SOCKET, SO_REUSEPORT>;
+        error_code ec;
+        acceptor->set_option(reuse_port_option(true), ec);
+#endif
+      }
       if(config.fast_open) {
 #if defined(__linux__) && defined(TCP_FASTOPEN)
         const int qlen = 5; // This seems to be the value that is used in other examples.


### PR DESCRIPTION
This let's use start multiple trRouting on the same port We discovered that the current asyncio lib used for handling http connection saturate at 24 cores-threads. Running multiple trRouting in parallel gives a better performance (but uses more memory)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable port-reuse option for HTTP servers. When enabled (disabled by default) this allows multiple server processes on Linux to bind the same port, improving deployment flexibility and resource utilization. Configuration exposed via the program's options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->