### PR TITLE
Remove unused variable from data structure

### DIFF
--- a/include/agency.hpp
+++ b/include/agency.hpp
@@ -15,7 +15,6 @@ namespace TrRouting
     boost::uuids::uuid uuid;
     std::string acronym;
     std::string name;
-    std::string internalId;
     boost::uuids::uuid simulationUuid;
 
     const std::string toString() {

--- a/include/line.hpp
+++ b/include/line.hpp
@@ -22,14 +22,12 @@ namespace TrRouting
          const Mode &amode,
          const std::string &ashortname,
          const std::string &alongname,
-         const std::string &ainternalId,
          short aallowSameLineTransfers):
       uuid(auuid),
       agency(aagency),
       mode(amode),
       shortname(ashortname),
       longname(alongname),
-      internalId(ainternalId),
       allowSameLineTransfers(aallowSameLineTransfers),
       uid(++global_uid) {}
 
@@ -38,7 +36,6 @@ namespace TrRouting
     const Mode &mode;
     std::string shortname;
     std::string longname;
-    std::string internalId;
     short allowSameLineTransfers;
     uid_t uid; //Local, temporary unique id, used to speed up lookups
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -22,13 +22,11 @@ namespace TrRouting
          unsigned long long _id,
          const std::string &_code,
          const std::string &_name,
-         const std::string &_internalId,
          std::unique_ptr<Point> _point
          ) : uuid(_uuid),
              id(_id),
              code(_code),
              name(_name),
-             internalId(_internalId),
              uid(++global_uid)
              {
                point = std::move(_point);
@@ -38,7 +36,6 @@ namespace TrRouting
     unsigned long long id;
     std::string code;
     std::string name;
-    std::string internalId;
     uid_t uid; //Local, temporary unique id, used to speed up lookups
     std::unique_ptr<Point> point; //TODO Does this need to be a ptr or could be part of the object?
     std::vector<NodeTimeDistance> transferableNodes;

--- a/include/path.hpp
+++ b/include/path.hpp
@@ -17,7 +17,6 @@ namespace TrRouting
     Path(const boost::uuids::uuid &auuid,
          const Line &aline,
          const std::string &adirection,
-         const std::string &ainternalId,
          const std::vector<std::reference_wrapper<const Node>> &anodesRef,
          const std::vector<std::reference_wrapper<const Trip>> &atripsRef,
          const std::vector<int> &asegmentsTravelTimeSeconds,
@@ -25,7 +24,6 @@ namespace TrRouting
       uuid(auuid),
       line(aline),
       direction(adirection),
-      internalId(ainternalId),
       nodesRef(anodesRef),
       tripsRef(atripsRef),
       segmentsTravelTimeSeconds(asegmentsTravelTimeSeconds),
@@ -36,13 +34,11 @@ namespace TrRouting
     Path(const boost::uuids::uuid &auuid,
          const Line &aline,
          const std::string &adirection,
-         const std::string &ainternalId,
          const std::vector<NodeTimeDistance> &anodesTimeDistance,
          const std::vector<std::reference_wrapper<const Trip>> &atripsRef):
       uuid(auuid),
       line(aline),
       direction(adirection),
-      internalId(ainternalId),
       tripsRef(atripsRef)
       {
         for (const NodeTimeDistance & ntd: anodesTimeDistance) {
@@ -55,7 +51,6 @@ namespace TrRouting
     boost::uuids::uuid uuid;
     const Line &line;
     std::string direction;
-    std::string internalId;
     std::vector<std::reference_wrapper<const Node>> nodesRef;
     std::vector<std::reference_wrapper<const Trip>> tripsRef;
     //TODO Should probably be integrated with nodes as a NodeTimeDistance object. Need

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -42,7 +42,6 @@ namespace TrRouting
     short allowSameLineTransfers;
     std::vector<std::reference_wrapper<const Connection>> forwardConnections;
     std::vector<std::reference_wrapper<const Connection>> reverseConnections;
-    std::vector<int>   connectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]
 
     uid_t uid; //Local, temporary unique id, used to speed up lookups
 

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -24,17 +24,13 @@ namespace TrRouting
           const Path &apath,
           const Mode &amode,
           const Service &aservice,
-          short aallowSameLineTransfers,
-          int atotalCapacity = -1,
-          int aseatedCapacity = -1): uuid(auuid),
+          short aallowSameLineTransfers): uuid(auuid),
                                      agency(aagency),
                                      line(aline),
                                      path(apath),
                                      mode(amode),
                                      service(aservice),
                                      allowSameLineTransfers(aallowSameLineTransfers),
-                                     totalCapacity(atotalCapacity),
-                                     seatedCapacity(aseatedCapacity),
                                      uid(++global_uid) {}
    
     boost::uuids::uuid uuid;
@@ -44,8 +40,6 @@ namespace TrRouting
     const Mode &mode; //TODO Mode is part of Line, we could merge them
     const Service &service;
     short allowSameLineTransfers;
-    int totalCapacity; //Unused
-    int seatedCapacity; //Unused
     std::vector<std::reference_wrapper<const Connection>> forwardConnections;
     std::vector<std::reference_wrapper<const Connection>> reverseConnections;
     std::vector<int>   connectionDepartureTimes; // tripIndex: [connectionIndex (sequence in trip): departureTimeSeconds]

--- a/src/agencies_cache_fetcher.cpp
+++ b/src/agencies_cache_fetcher.cpp
@@ -74,7 +74,6 @@ namespace TrRouting
         t.uuid           = uuidGenerator(uuid);
         t.acronym        = capnpT.getAcronym();
         t.name           = capnpT.getName();
-        t.internalId     = capnpT.getInternalId();
         t.simulationUuid = simulationUuid.empty() ? uuidNilGenerator() : uuidGenerator(simulationUuid);
         ts[t.uuid] = t;
       }

--- a/src/lines_cache_fetcher.cpp
+++ b/src/lines_cache_fetcher.cpp
@@ -71,7 +71,6 @@ namespace TrRouting
                                           modes.at(capnpT.getMode()),
                                           capnpT.getShortname(),
                                           capnpT.getLongname(),
-                                          capnpT.getInternalId(),
                                           capnpT.getAllowSameLineTransfers()));
       }
     }

--- a/src/nodes_cache_fetcher.cpp
+++ b/src/nodes_cache_fetcher.cpp
@@ -78,7 +78,6 @@ namespace TrRouting
                              capnpT.getId(),
                              capnpT.getCode(),
                              capnpT.getName(),
-                             capnpT.getInternalId(),
                              std::move(point)));
       }
     }

--- a/src/paths_cache_fetcher.cpp
+++ b/src/paths_cache_fetcher.cpp
@@ -94,7 +94,6 @@ namespace TrRouting
         ts.emplace(pathUuid, T(pathUuid,
                                lines.at(uuidGenerator(lineUuid)),
                                capnpT.getDirection(),
-                               capnpT.getInternalId(),
                                nodesRef,
                                tripsRef, //TODO This is empty
                                travelTimesSeconds,

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -96,7 +96,6 @@ namespace TrRouting
                 auto departureTimesSeconds = capnpTrip.getNodeDepartureTimesSeconds();
                 auto canBoards             = capnpTrip.getNodesCanBoard();
                 auto canUnboards           = capnpTrip.getNodesCanUnboard();
-                trip.connectionDepartureTimes.resize(nodeTimesCount);
                 // nodeTimesCount - 1, since we process node pairs, we have to stop and the second from last
                 for (unsigned long nodeTimeI = 0; nodeTimeI < nodeTimesCount - 1; nodeTimeI++)
                 {
@@ -115,8 +114,6 @@ namespace TrRouting
                                                      line.mode.isTransferable() ? 0 : -1
                                                      )
                                           );
-
-                    trip.connectionDepartureTimes[nodeTimeI] = departureTimesSeconds[nodeTimeI];
                   } catch (std::out_of_range const& exc) {
                     spdlog::error("Index out of range while parsing connection for trip on line ({}, {})", path.line.longname, boost::uuids::to_string(path.line.uuid));
                     return -1;

--- a/src/trips_and_connections_cache_fetcher.cpp
+++ b/src/trips_and_connections_cache_fetcher.cpp
@@ -84,9 +84,7 @@ namespace TrRouting
                                              path,
                                              line.mode,
                                              service,
-                                             line.allowSameLineTransfers,
-                                             capnpTrip.getTotalCapacity(),
-                                             capnpTrip.getSeatedCapacity()));
+                                             line.allowSameLineTransfers));
                 //Current trip
                 Trip & trip = trips.at(tripUuid);
 

--- a/tests/connection_scan_algorithm/csa_result_to_response_test.cpp
+++ b/tests/connection_scan_algorithm/csa_result_to_response_test.cpp
@@ -17,12 +17,12 @@ void ResultToResponseFixtureTest::SetUp()
     agency->uuid = uuidGenerator(agencyUuid);
     agency->acronym = "AG";
     agency->name = "AgencyName";
-    line = std::make_unique<TrRouting::Line>(uuidGenerator(lineUuid), *agency, *mode, "LI", "LineName", "", 0);
-    path = std::make_unique<TrRouting::Path>(uuidGenerator(pathUuid), *line, "N", "", std::vector<TrRouting::NodeTimeDistance>(), std::vector<std::reference_wrapper<const TrRouting::Trip>>());
+    line = std::make_unique<TrRouting::Line>(uuidGenerator(lineUuid), *agency, *mode, "LI", "LineName", 0);
+    path = std::make_unique<TrRouting::Path>(uuidGenerator(pathUuid), *line, "N", std::vector<TrRouting::NodeTimeDistance>(), std::vector<std::reference_wrapper<const TrRouting::Trip>>());
     service = std::make_unique<TrRouting::Service>();
     trip = std::make_unique<TrRouting::Trip>(uuidGenerator(tripUuid), *agency, *line, *path, *mode, *service, 0);
-    boardingNode = std::make_unique<TrRouting::Node>(uuidGenerator(boardingNodeUuid), 0, "NC", "NodeName", "", std::make_unique<TrRouting::Point>(boardingNodePoint));
-    unboardingNode = std::make_unique<TrRouting::Node>(uuidGenerator(unboardingNodeUuid), 0, "NC1", "NodeName2", "", std::make_unique<TrRouting::Point>(unboardingNodePoint));
+    boardingNode = std::make_unique<TrRouting::Node>(uuidGenerator(boardingNodeUuid), 0, "NC", "NodeName", std::make_unique<TrRouting::Point>(boardingNodePoint));
+    unboardingNode = std::make_unique<TrRouting::Node>(uuidGenerator(unboardingNodeUuid), 0, "NC1", "NodeName2", std::make_unique<TrRouting::Point>(unboardingNodePoint));
 
     testParameters = std::make_unique<TrRouting::RouteParameters>(
         std::make_unique<TrRouting::Point>(45.5269, -73.58912),

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
@@ -313,8 +313,7 @@ int TestDataFetcher::getSchedules(
                                              paths.at(pathSNUuid),
                                              busMode,
                                              services.at(serviceUuid),
-                                             -1,
-                                             0));
+                                             -1));
   int arrivalTimesT1[5] = { getTimeInSeconds(10), getTimeInSeconds(10, 3, 30), getTimeInSeconds(10, 7), getTimeInSeconds(10, 13), getTimeInSeconds(10, 18) };
   int departureTimesT1[5] = { getTimeInSeconds(10), getTimeInSeconds(10, 3, 50), getTimeInSeconds(10, 10), getTimeInSeconds(10, 13, 30), getTimeInSeconds(10, 18) };
 
@@ -327,8 +326,7 @@ int TestDataFetcher::getSchedules(
                                               paths.at(pathSNUuid),
                                               busMode,
                                               services.at(serviceUuid),
-                                              -1,
-                                              0));
+                                              -1));
   int arrivalTimesT2[5] = { getTimeInSeconds(11), getTimeInSeconds(11, 3, 30), getTimeInSeconds(11, 7), getTimeInSeconds(11, 11), getTimeInSeconds(11, 16) };
   int departureTimesT2[5] = { getTimeInSeconds(11), getTimeInSeconds(11, 3, 50), getTimeInSeconds(11, 8), getTimeInSeconds(11, 11, 30), getTimeInSeconds(11, 17) };
   
@@ -341,8 +339,7 @@ int TestDataFetcher::getSchedules(
                                             paths.at(pathEWUuid),
                                             busMode,
                                             services.at(serviceUuid),
-                                            -1,
-                                            0));
+                                            -1));
   
   int arrivalTimesT3[5] = { getTimeInSeconds(9), getTimeInSeconds(9, 2, 30), getTimeInSeconds(9, 4, 40), getTimeInSeconds(9, 7, 30), getTimeInSeconds(9, 10) };
   int departureTimesT3[5] = { getTimeInSeconds(9), getTimeInSeconds(9, 2, 50), getTimeInSeconds(9, 5), getTimeInSeconds(9, 8), getTimeInSeconds(9, 11) };
@@ -358,8 +355,7 @@ int TestDataFetcher::getSchedules(
                                              paths.at(pathEWUuid),
                                              busMode,
                                              services.at(serviceUuid),
-                                             -1,
-                                             0));
+                                             -1));
   
   int arrivalTimesT4[5] = { getTimeInSeconds(10, 2), getTimeInSeconds(10, 4, 30), getTimeInSeconds(10, 7), getTimeInSeconds(10, 11, 30), getTimeInSeconds(10, 14) };
   int departureTimesT4[5] = { getTimeInSeconds(10, 2), getTimeInSeconds(10, 5, 10), getTimeInSeconds(10, 9), getTimeInSeconds(10, 12), getTimeInSeconds(10, 15) };
@@ -373,8 +369,7 @@ int TestDataFetcher::getSchedules(
                                                 paths.at(pathExtraUuid),
                                                 busMode,
                                                 services.at(serviceUuid),
-                                                -1,
-                                                0));
+                                                -1));
   
   int arrivalTimesT5[2] = { getTimeInSeconds(10, 20), getTimeInSeconds(10, 25) };
   int departureTimesT5[2] = { getTimeInSeconds(10, 20), getTimeInSeconds(10,26) };

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
@@ -69,7 +69,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "South2",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.5269,-73.58912)));
   addSelfTransferableNode(array.at(nodeSouth2Uuid));
 
@@ -78,7 +77,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "South1",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.53258,-73.60196)));
   addSelfTransferableNode(array.at(nodeSouth1Uuid));
 
@@ -87,7 +85,6 @@ int TestDataFetcher::getNodes(
                                                   0,
                                                   "",
                                                   "MidPoint",
-                                                  "",
                                                   std::make_unique<TrRouting::Point>(45.53827,-73.614436)));
   addSelfTransferableNode(array.at(nodeMidNodeUuid));
 
@@ -96,7 +93,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "North1",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.54165,-73.62603)));
   addSelfTransferableNode(array.at(nodeNorth1Uuid));
 
@@ -105,7 +101,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "North2",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.54634,-73.64266)));
   addSelfTransferableNode(array.at(nodeNorth2Uuid));
 
@@ -114,7 +109,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "East2",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.55027,-73.60496)));
   addSelfTransferableNode(array.at(nodeEast2Uuid));
 
@@ -123,7 +117,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "East1",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.54249,-73.61199)));
   addSelfTransferableNode(array.at(nodeEast1Uuid));
       
@@ -132,7 +125,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "West1",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.53473,-73.61825)));
   addSelfTransferableNode(array.at(nodeWest1Uuid));
 
@@ -141,7 +133,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "West2",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.52962,-73.62265)));
   addSelfTransferableNode(array.at(nodeWest2Uuid));
 
@@ -151,7 +142,6 @@ int TestDataFetcher::getNodes(
                                                 0,
                                                 "",
                                                 "Extra1",
-                                                "",
                                                 std::make_unique<TrRouting::Point>(45.55316,-73.61894)));
   addSelfTransferableNode(array.at(nodeExtra1Uuid));
 
@@ -180,11 +170,11 @@ int TestDataFetcher::getLines(
   auto & busMode = modes.at("bus");
   const auto & defaultAgency = agencies.at(agencyUuid);
 
-  ts.emplace(lineSNUuid, TrRouting::Line(lineSNUuid, defaultAgency, busMode, "01", "South/North", "", 0));
+  ts.emplace(lineSNUuid, TrRouting::Line(lineSNUuid, defaultAgency, busMode, "01", "South/North", 0));
 
-  ts.emplace(lineEWUuid, TrRouting::Line(lineEWUuid, defaultAgency, busMode, "02", "East/West", "", 0));
+  ts.emplace(lineEWUuid, TrRouting::Line(lineEWUuid, defaultAgency, busMode, "02", "East/West", 0));
   
-  ts.emplace(lineExtraUuid, TrRouting::Line(lineExtraUuid, defaultAgency, busMode, "03", "Extra", "", 0));
+  ts.emplace(lineExtraUuid, TrRouting::Line(lineExtraUuid, defaultAgency, busMode, "03", "Extra", 0));
   return 0;
 }
 
@@ -209,7 +199,6 @@ int TestDataFetcher::getPaths(
   ts.emplace(pathSNUuid, TrRouting::Path(pathSNUuid,
                                          lines.at(lineSNUuid),
                                          "outbound",
-                                         "",
                                          nodesref,
                                          emptyVector));
   // Path's trip data will be filled in the setUpSchedules
@@ -223,7 +212,6 @@ int TestDataFetcher::getPaths(
   ts.emplace(pathEWUuid, TrRouting::Path(pathEWUuid,
                                          lines.at(lineEWUuid),
                                          "outbound",
-                                         "",
                                          nodesref,
                                          emptyVector));
   // Path's trip data will be filled in the setUpSchedules
@@ -234,7 +222,6 @@ int TestDataFetcher::getPaths(
   ts.emplace(pathExtraUuid, TrRouting::Path(pathExtraUuid,
                                             lines.at(lineExtraUuid),
                                             "outbound",
-                                            "",
                                             nodesref,
                                             emptyVector));
   // Path's trip data will be filled in the setUpSchedules

--- a/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
+++ b/tests/connection_scan_algorithm/csa_test_data_fetcher.cpp
@@ -268,8 +268,6 @@ void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<TrR
 {
     path.tripsRef.push_back(trip);
 
-    trip.connectionDepartureTimes.resize(arraySize);
-
     for (int nodeTimeI = 0; nodeTimeI < arraySize - 1; nodeTimeI++) {
         connections.push_back(TrRouting::Connection(
             path.nodesRef[nodeTimeI],
@@ -283,8 +281,6 @@ void addTripData(TrRouting::Trip & trip, TrRouting::Path & path, std::vector<TrR
             trip.allowSameLineTransfers,
             -1
         ));
-
-        trip.connectionDepartureTimes[nodeTimeI] = departureTimes[nodeTimeI];
 
     }
 


### PR DESCRIPTION
Several field were read from capnp but never used, wasting precious bytes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up transit routing data structures by removing unused internal identifier and capacity-tracking fields across the system, reducing overall complexity while preserving core functionality.

* **Tests**
  * Updated test fixtures to align with simplified data structure constructors and definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->