### PR TITLE
Enable automatic retry of stalled coderabbit reviews

### DIFF
--- a/.github/workflows/coderabbit-retry.yml
+++ b/.github/workflows/coderabbit-retry.yml
@@ -1,0 +1,14 @@
+# Atttempt retry on stalled coderabbit review
+# See file in Transition repo
+
+on:
+  schedule:
+    # Every 3 hours, offset from Transition
+    - cron: '0 4-11/3 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  retry:
+    name: Process rate-limited reviews
+    uses: chairemobilite/transition/.github/workflows/coderabbit-retry.yml@main


### PR DESCRIPTION
Reuse the workflow in the Transition repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to retry stalled code review processes on a recurring schedule.
  * Added a manual trigger option to initiate the same retry process on demand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->