### PR TITLE
Add permission to coderabbit retry top workflow

### DIFF
--- a/.github/workflows/coderabbit-retry.yml
+++ b/.github/workflows/coderabbit-retry.yml
@@ -11,4 +11,8 @@ on:
 jobs:
   retry:
     name: Process rate-limited reviews
+    permissions:
+      pull-requests: write
+      contents: read
     uses: chairemobilite/transition/.github/workflows/coderabbit-retry.yml@main
+    secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow configuration to explicitly grant the required permissions for pull request retry actions.
  * Continued delegating execution to the shared retry workflow while securely inheriting the needed secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->