### PR TITLE
Enable automatic retry of stalled coderabbit reviews

### DIFF
--- a/.github/workflows/coderabbit-retry.yml
+++ b/.github/workflows/coderabbit-retry.yml
@@ -1,0 +1,14 @@
+# Atttempt retry on stalled coderabbit review
+# See file in Transition repo
+
+on:
+  schedule:
+    # Every 3 hours, offset from Transition
+    - cron: '0 4-11/3 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  retry:
+    name: Process rate-limited reviews
+    uses: chairemobilite/transition/.github/workflows/coderabbit-retry.yml@main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # trRouting
 Transit routing server app written in C++ using the Connection Scan Algorithm including flexible parameters.
 
+TODODODOD
 ## Performance
 With random origin and destination (multiple accessible stops at origin and destination): ~150 ms for access and egress footpaths calculation, ~8 ms for CSA two-way calculation (tested with montreal area GTFS data including all urban and suburban transit agencies, with transfer footpaths between stops of 10 minutes walking or less) on a MacPro 2013 with single thread used (you can start multiple servers and execute parallel requests).
 


### PR DESCRIPTION
Reuse the workflow in the Transition repo.

Tested with the workflow_dispatch via gh workflow run coderabbit-retry.yml --ref retrycoderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated process that periodically retries rate-limited code reviews.
  * Added an option to run the retry process manually.

* **Documentation**
  * Updated the README with a minor text addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->