### PR TITLE
Disable idle connection kickoff in drogon

### DIFF
--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -470,6 +470,9 @@ int main(int argc, char** argv) {
   drogon::app()
     .addListener("0.0.0.0", programOptions.port)
     .setThreadNum(4) // IO event loops only; calculations run on the compute pool
+    .setIdleConnectionTimeout(1200)  // by default drogon kick an idle connection after 60 seconds
+                                     // but we have calculation that can run longer
+                                     // For now set a really long time to still clean up stale connections
     .registerBeginningAdvice([]() {
       spdlog::info("ready.");
     })


### PR DESCRIPTION
By default, drogon would kill a connection that is idle for 60 seconds. It's quite common for calculation to take more time than that, so we don't want this behavior.

We could consider in the future to set it to a really high value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of long-running transit routing requests by keeping idle HTTP connections open long enough for calculations to finish, reducing premature disconnects during inactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->