### PR TITLE
Use a permanent thread local Calculation object

### DIFF
--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -77,6 +77,13 @@ namespace TrRouting
 
     std::vector<int>        optimizeJourney(std::deque<JourneyStep> &journey);
 
+    // Start the timer used by the per-step debug timing logs. The constructor
+    // does this for a fresh Calculator; a reused one needs it called once at
+    // each request boundary. Deliberately not done in reset(), since
+    // alternativesRouting() resets once per alternative while the timer is
+    // meant to span the whole request.
+    void startRequestTimer() { algorithmCalculationTime.start(); }
+
   private:
     void initializeCalculationData();
     bool resetAccessFootpaths(const CommonParameters &parameters, const Point& origin);

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -28,13 +28,13 @@ namespace TrRouting
     if (resetAccessPaths)
     {
       accessFootpaths.clear();
-      accessFootpaths.shrink_to_fit();
       egressFootpaths.clear();
-      egressFootpaths.shrink_to_fit();
     }
     tripsQueryOverlay.assign(Trip::getMaxUid()+1, TripQueryData());
     forwardJourneysSteps.clear();
     reverseJourneysSteps.clear();
+    nodesAccess.clear();
+    nodesEgress.clear();
 
     
     departureTimeSeconds = -1;
@@ -72,7 +72,6 @@ namespace TrRouting
 
       int footpathTravelTimeSeconds;
       int footpathDistanceMeters;
-      nodesAccess.clear();
       forwardJourneysSteps.assign(Node::getMaxUid() + 1, JourneyStep());
       nodesTentativeTime.assign(Node::getMaxUid() + 1, MAX_INT); //Assign default values to all indexes
       
@@ -108,7 +107,6 @@ namespace TrRouting
 
       int footpathTravelTimeSeconds;
       int footpathDistanceMeters;
-      nodesEgress.clear();
       reverseJourneysSteps.assign(Node::getMaxUid() + 1, JourneyStep());
       nodesReverseTentativeTime.assign(Node::getMaxUid() + 1, -1); //Assign default values to all indexes
       for (auto & egressFootpath : egressFootpaths)

--- a/connection_scan_algorithm/src/transit_routing_http_server.cpp
+++ b/connection_scan_algorithm/src/transit_routing_http_server.cpp
@@ -150,6 +150,23 @@ static void runCalculation(trantor::ConcurrentTaskQueue &computePool,
     });
 }
 
+// Return the Calculator owned by the calling compute thread, creating it on
+// first use. Constructing a Calculator per request allocated (and immediately
+// freed) network-sized containers, which dominated system time under load.
+// The compute pool threads live for the whole process, and a task always runs
+// to completion on a single thread, so one instance per thread is safe and
+// lets reset() reuse warm allocations instead of faulting in fresh pages.
+// Note: this must not be called from the Drogon IO loop threads, only from
+// tasks queued on the compute pool.
+static Calculator & getThreadCalculator(const TransitData &transitData, GeoFilter &geoFilter)
+{
+  thread_local Calculator calculator(transitData, geoFilter);
+  // Start the timer at the beginning of each request.
+  // TODO Maybe we should move the timer out of the calculator
+  calculator.startRequestTimer();
+  return calculator;
+}
+
 // Register a GET handler for both /path and /path/ to keep the behavior of
 // the previous "[/]?" route regexes
 static void registerGet(const std::string &path, Handler handler)
@@ -340,7 +357,7 @@ int main(int argc, char** argv) {
 
       spdlog::info("-- calculating route request -- {}", currentRequestId);
 
-      Calculator calculator(transitData, *geoFilter);
+      Calculator &calculator = getThreadCalculator(transitData, *geoFilter);
       RouteParameters queryParams = RouteParameters::createRouteODParameter(parametersWithValues, transitData.getScenarios());
 
       try {
@@ -388,7 +405,7 @@ int main(int argc, char** argv) {
 
       spdlog::info("-- calculating summary request -- {}", currentRequestId);
 
-      Calculator calculator(transitData, *geoFilter);
+      Calculator &calculator = getThreadCalculator(transitData, *geoFilter);
       RouteParameters queryParams = RouteParameters::createRouteODParameter(parametersWithValues, transitData.getScenarios());
 
       try {
@@ -436,7 +453,7 @@ int main(int argc, char** argv) {
 
       spdlog::info("-- calculating accessibility request -- {}", currentRequestId);
 
-      Calculator calculator(transitData, *geoFilter);
+      Calculator &calculator = getThreadCalculator(transitData, *geoFilter);
       AccessibilityParameters queryParams = AccessibilityParameters::createAccessibilityParameter(parametersWithValues, transitData.getScenarios());
 
       try {


### PR DESCRIPTION
One of the main performance issue we have is the memory allocation churn of creating and delete the Calculation object for each request. Instead of always reallocating for each object, we can use a local object for each thread. Since we only have one request at a time being handled on a thread, we don't have concurrency issues.

We have to call reset at the start of each request to clear out the data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved transit routing request processing by reusing per-thread calculation resources across requests instead of creating new instances each time.
  * Added request-level timing so performance metrics capture each request’s calculation duration more accurately.
* **Bug Fixes**
  * Improved calculation state cleanup during resets by clearing egress footpaths and access/egress node state earlier, reducing the risk of stale routing data affecting subsequent computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->