### PR TITLE
Print scenario IDs on startup

### DIFF
--- a/src/scenarios_cache_fetcher.cpp
+++ b/src/scenarios_cache_fetcher.cpp
@@ -87,6 +87,8 @@ namespace TrRouting
 
         ts[scenarioUuid].name           = capnpT.getName();
         ts[scenarioUuid].simulationUuid = simulationUuid.empty() ? uuidNilGenerator() : uuidGenerator(simulationUuid);
+        // Print scenario ID on data load for an easier way to find a test scenario without relying on Transition
+        spdlog::info("Serving scenario {} ({})", uuid, ts[scenarioUuid].name);
         
         for (std::string serviceUuidStr : capnpT.getServicesUuids())
         {


### PR DESCRIPTION
To make it easier to debug or benchmark with a specific cache file, we print the scenario IDs on startup. That way, we can find the scenario without have to import the file in Transition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added additional diagnostic logging when loading scenarios from the cache, including scenario identifiers and names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->