### PR TITLE
Dedup coordinate in OSRM queries

### DIFF
--- a/src/osrmgeofilter.cpp
+++ b/src/osrmgeofilter.cpp
@@ -1,3 +1,7 @@
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "osrmgeofilter.hpp"
 #include <nlohmann/json.hpp>
 #include "point.hpp"
@@ -6,6 +10,22 @@
 #include "spdlog/spdlog.h"
 
 namespace TrRouting {
+
+  namespace {
+    /* A node that passed the bird distance filter, paired with the column it
+       maps to in the OSRM table response. Nodes sharing coordinates share a
+       column, so this is not simply the node's rank in the request. */
+    struct PotentialAccessibleNode {
+      std::reference_wrapper<const Node> node;
+      std::size_t osrmPosition;
+    };
+    
+    // By default, to_string convert a double to a string with 6 decimal digits
+    // TODO Add a unit test to ensure the formatting always have the right precisions (default might change in future standards)
+    std::string formatOsrmCoordinates(const Point &point) {
+      return std::to_string(point.longitude) + "," + std::to_string(point.latitude);
+    }
+  }
 
   OsrmGeoFilter::OsrmGeoFilter(const std::string &amode, const std::string &ahost, const std::string &aport) :
     mode(amode),
@@ -20,7 +40,17 @@ namespace TrRouting {
                                                                                     float walkingSpeedMetersPerSecond,
                                                                                     bool reversed)
   {
-    std::vector<std::reference_wrapper<const Node>> birdDistanceAccessibleNodeIndexes;
+    // All the nodes within bird distance,
+    // each carrying the OSRM response column it should be read from.
+    std::vector<PotentialAccessibleNode> potentialAccessibleNodes;
+    // Coordinate string (exactly as sent to OSRM) -> column in the response.
+    // Keying on the formatted string rather than the doubles means two nodes
+    // whose coordinates differ below the 6 decimals we transmit still collapse
+    // to one destination, which is what OSRM would have received anyway.
+    std::unordered_map<std::string, std::size_t> osrmPositionByCoordinates;
+    // Column 0 of the response is the origin point, so node columns start at 1
+    std::size_t nextOsrmPosition = 1;
+
     std::vector<NodeTimeDistance> accessibleNodesFootpaths;
 
     auto lengthOfOneDegree = calculateLengthOfOneDegree(point);
@@ -29,7 +59,7 @@ namespace TrRouting {
 
     spdlog::debug("osrm with host {} and port {}", host, port);
 
-    std::string queryString = "/table/v1/" + mode + "/" + std::to_string(point.longitude) + "," + std::to_string(point.latitude);
+    std::string queryString = "/table/v1/" + mode + "/" + formatOsrmCoordinates(point);
 
     // We first filter the nodes with euclidean distance using the common distance calculation
     // to only send a subset of nodes to OSRM. We do not reuse the EuclideanGeoFilter directly, since
@@ -40,14 +70,25 @@ namespace TrRouting {
 
       if (distanceMetersSquared <= maxDistanceMetersSquared)
       {
-        birdDistanceAccessibleNodeIndexes.push_back(node);
-        queryString += ";" + std::to_string(node.point.get()->longitude) + "," + std::to_string(node.point.get()->latitude);
+        std::string coordinates = formatOsrmCoordinates(*node.point.get());
+
+        auto inserted = osrmPositionByCoordinates.emplace(coordinates, nextOsrmPosition);
+        // The second element of the returned pair of emplace indicate if a new element needed to be inserted,
+        // so a true flag means it was a new element.
+        if (inserted.second)
+        {
+          // First node seen at these coordinates: it gets its own destination
+          queryString += ";" + coordinates;
+          nextOsrmPosition++;
+        }
+
+        potentialAccessibleNodes.push_back({std::cref(node), inserted.first->second});
       }
     }
 
     // If we don't have any node accessible with the euclidean distance, don't bother calculating
     // the exact distance with OSRM
-    if (birdDistanceAccessibleNodeIndexes.size() == 0) {
+    if (potentialAccessibleNodes.size() == 0) {
       // Return the empty vector
       spdlog::debug("There was no node potentially accessible, we did not ask OSRM");
       return accessibleNodesFootpaths;
@@ -86,36 +127,48 @@ namespace TrRouting {
 
     if (responseJson["durations"] != nullptr && responseJson["distances"] != nullptr && responseJson["durations"][0] != nullptr && responseJson["distances"][0] != nullptr)
     {
-      int numberOfDurations = responseJson["durations"][0].size();
-      int numberOfDistances = responseJson["distances"][0].size();
+      std::size_t numberOfDurations = responseJson["durations"][0].size();
+      std::size_t numberOfDistances = responseJson["distances"][0].size();
 
-      if (numberOfDurations > 0 && numberOfDistances > 0)
+      // We asked for the origin plus one destination per distinct coordinate.
+      // Anything else means we cannot trust the column mapping, so bail out
+      // rather than read the wrong walking times.
+      if (numberOfDurations != nextOsrmPosition || numberOfDistances != nextOsrmPosition)
       {
-        int travelTimeSeconds;
-        int distanceMeters;
-        for (int i = 1; i < numberOfDurations; i++) // ignore first (duration with itself)
+        spdlog::error("OSRM returned {} durations and {} distances, expected {}; ignoring the response",
+                      numberOfDurations, numberOfDistances, nextOsrmPosition);
+        return accessibleNodesFootpaths;
+      }
+
+      int travelTimeSeconds;
+      int distanceMeters;
+      // Iterate over the nodes rather than over the response columns, since
+      // co-located nodes share a column
+      for (const auto & potentialNode : potentialAccessibleNodes)
+      {
+        std::size_t position = potentialNode.osrmPosition;
+
+        // Check if the duration and distance values are null before attempting to convert them
+        if (!responseJson["durations"][0][position].is_null() && !responseJson["distances"][0][position].is_null())
         {
-          // Check if the duration and distance values are null before attempting to convert them
-          if (!responseJson["durations"][0][i].is_null() && !responseJson["distances"][0][i].is_null())
+          travelTimeSeconds = (int)ceil((float)responseJson["durations"][0][position]);
+          if (travelTimeSeconds <= maxWalkingTravelTime)
           {
-            travelTimeSeconds = (int)ceil((float)responseJson["durations"][0][i]);
-            if (travelTimeSeconds <= maxWalkingTravelTime)
-            {
-              distanceMeters = (int)ceil((float)responseJson["distances"][0][i]);
-              accessibleNodesFootpaths.push_back(NodeTimeDistance(birdDistanceAccessibleNodeIndexes[i - 1],
-                                                                travelTimeSeconds,
-                                                                distanceMeters));
-            }
+            distanceMeters = (int)ceil((float)responseJson["distances"][0][position]);
+            accessibleNodesFootpaths.push_back(NodeTimeDistance(potentialNode.node,
+                                                              travelTimeSeconds,
+                                                              distanceMeters));
           }
-          else
-          {
-            spdlog::debug("skipping node at index {} due to null duration or distance from OSRM", i);
-          }
+        }
+        else
+        {
+          spdlog::debug("skipping node at index {} due to null duration or distance from OSRM", position);
         }
       }
     }
 
-    spdlog::debug("fetched osrm footpaths ({} footpaths found)",  accessibleNodesFootpaths.size());
+    spdlog::debug("fetched osrm footpaths ({} footpaths found, {} nodes sent as {} distinct osrm destinations)",
+                  accessibleNodesFootpaths.size(), potentialAccessibleNodes.size(), nextOsrmPosition - 1);
 
     return accessibleNodesFootpaths;
   }


### PR DESCRIPTION
We have case where Transition have nodes with similar or exact same coordinate. (Probably from multiple GTFS import where node merging was disabled.)

That causes OSRM queries to take longer. By deduplicating, we reduce significantly the processing time. For example:
106 -> 54    orig    50.60 ms   dedup    27.87 ms (saving 22 ms)
134 -> 84    orig    81.34 ms   dedup    50.67 ms (saving 30 ms)

To do so, we keep the list of potential accessible nodes as filtering by euclidean distance with an index pointing to it's position in the OSRM query. We keep a map of the query coordinates converted as string to find the duplication.

We then check for each potential nodes if we had a results and generate the resulting accessible nodes list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved walking-route accessibility calculations when multiple destinations share coordinates.
  * Prevented duplicate destinations from being submitted for route-time and distance calculations.
  * Added safer handling for incomplete, invalid, or unavailable routing results.
  * Ensured only destinations with valid results within the configured walking-time limit are included.
  * Improved calculation consistency and efficiency for destinations sharing locations.
  * Improved validation and mapping of routing results to destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->