### PR TITLE
Refactor the line alternative filter management

### DIFF
--- a/connection_scan_algorithm/include/alternative_filter.hpp
+++ b/connection_scan_algorithm/include/alternative_filter.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "line.hpp"
+#include "connection_set.hpp"
+#include "trip.hpp"
+
+namespace TrRouting
+{
+
+  /**
+     Generic interface to handle configuring and executing a filter to disable some trips to generate alternatives
+     route results
+   */  
+  class AlternativeFilter {
+  public:
+    AlternativeFilter() {}
+    virtual ~AlternativeFilter() = default;
+    /**
+       Apply a filter to a connectionSet and set flags in the trips disabled overlay. The clearing
+       of the trips overlay should be done outside of the filter, so we can apply multiple filter to the same set
+
+       @param tripsDisabled Container to be filled with flags of which trips are no longer available
+       @param connectionSet Current list of trips matching the query scenarios
+
+       @return void (Could be changed to return a bool to represent if something was filtered or not)
+     */
+    virtual void runFilter(std::unordered_map<Trip::uid_t, bool> &tripsDisabled, const ConnectionSet &connectionSet) = 0;
+  };
+
+  /** Alternative Line filter
+      Take a list of line and will disable all trips using that line.
+   */
+  class AlternativeLineFilter : public AlternativeFilter {
+  public:
+    AlternativeLineFilter(const std::vector<std::reference_wrapper<const Line>> &_excludedLines);
+    virtual void runFilter(std::unordered_map<Trip::uid_t, bool> &tripsDisabled, const ConnectionSet &connectionSet) override;
+  protected:
+    /** Simplified copy of the line vector (with only the UIDs) */
+    std::vector<Line::uid_t> excludedLinesUids;
+  };
+    
+}
+
+

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -42,6 +42,7 @@ namespace TrRouting
   class ConnectionSet;
   class Point;
   class GeoFilter;
+  class AlternativeFilter;
 
   class Calculator {
 
@@ -49,13 +50,13 @@ namespace TrRouting
 
     Calculator(const TransitData &_transitData, GeoFilter &_geofilter);
 
-    void reset(CommonParameters &parameters, std::optional<std::reference_wrapper<const Point>> origin, std::optional<std::reference_wrapper<const Point>> destination, bool resetAccessPaths = true, bool resetFilters = true);
+    void reset(CommonParameters &parameters, std::optional<std::reference_wrapper<const Point>> origin, std::optional<std::reference_wrapper<const Point>> destination, bool resetAccessPaths = true, AlternativeFilter *alternativeFilter = nullptr);
     // TODO This function supports both allNodes and simple calculation, which
     // are 2 very different return values. They should be split so it can return
     // a concrete result object instead of pointer (that alternatives could use directly), but still
     // use common calculation functions
     // TODO Once the split is done, we can get rid of the unique_ptr return and have the right concret type returned directly
-    std::unique_ptr<SingleCalculationResult> calculateSingle(RouteParameters &parameters, bool resetAccessPaths = true, bool resetFilters = true);
+    std::unique_ptr<SingleCalculationResult> calculateSingle(RouteParameters &parameters, bool resetAccessPaths = true, AlternativeFilter *alternativeFilter = nullptr);
     std::unique_ptr<AllNodesResult> calculateAllNodes(AccessibilityParameters &parameters);
 
     // Forward and and reverse calculation, in addition to their return values will fill up their JourneysSteps map
@@ -88,7 +89,6 @@ namespace TrRouting
     void initializeCalculationData();
     bool resetAccessFootpaths(const CommonParameters &parameters, const Point& origin);
     bool resetEgressFootpaths(const CommonParameters &parameters, const Point& destination);
-    void resetFilters(const CommonParameters &parameters);
     // Convert the optimization case ID returned by optimizeJourney to a string
     std::string optimizeCasesToString(const std::vector<int> optimizeCases);
     std::unique_ptr<SingleCalculationResult> calculateSingleReverse(RouteParameters &parameters);

--- a/connection_scan_algorithm/src/Makefile.am
+++ b/connection_scan_algorithm/src/Makefile.am
@@ -2,7 +2,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/connection_scan_algorithm/
 
 noinst_LTLIBRARIES = libcsa.la
 
-libcsa_la_SOURCES = alternatives_routing.cpp \
+libcsa_la_SOURCES = alternative_filter.cpp \
+	           alternatives_routing.cpp \
 		   calculator.cpp \
 		   forward_calculation.cpp \
 		   forward_journey.cpp \

--- a/connection_scan_algorithm/src/alternative_filter.cpp
+++ b/connection_scan_algorithm/src/alternative_filter.cpp
@@ -1,0 +1,37 @@
+#include "alternative_filter.hpp"
+
+#include <algorithm>
+
+#include "line.hpp"
+#include "connection_set.hpp"
+#include "trip.hpp"
+
+namespace TrRouting {
+
+  AlternativeLineFilter::AlternativeLineFilter(const std::vector<std::reference_wrapper<const Line>> &_excludedLines)
+    : AlternativeFilter() {
+
+    // Small optimisation, just saving the line UID and later iterating over that instead of going over the full objects
+    excludedLinesUids.reserve(_excludedLines.size());
+    for (const Line & line : _excludedLines) {
+      excludedLinesUids.push_back(line.uid);
+    }
+    
+  }
+  
+  void AlternativeLineFilter::runFilter(std::unordered_map<Trip::uid_t, bool> &tripsDisabled, const ConnectionSet &connectionSet) {
+
+    if (excludedLinesUids.size() > 0) {
+      for (auto & tripIte : connectionSet.getTrips())
+      {
+        const Trip & trip = tripIte.get();
+
+        // If the Trip match any lines in the filter, disable it
+        if (std::find(excludedLinesUids.begin(), excludedLinesUids.end(), trip.line.uid) != excludedLinesUids.end())
+        {
+          tripsDisabled[trip.uid] = true;
+        }
+      }
+    }
+  }
+}

--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -10,6 +10,7 @@
 #include "routing_result.hpp"
 #include "point.hpp"
 #include "transit_data.hpp"
+#include "alternative_filter.hpp"
 
 namespace {
   // Placed in anynymous namespace so it's local to this file
@@ -87,7 +88,6 @@ namespace TrRouting
   AlternativesResult Calculator::alternativesRouting(RouteParameters &parameters)
   {
     using LineVector = std::vector<std::reference_wrapper<const Line>>;
-    LineVector exceptLinesFromParameters = parameters.getExceptLines(); // make a copy of lines that are already disabled in parameters
     std::vector< LineVector >  allCombinations;
     std::vector< LineVector >  failedCombinations;
     bool                             combinationMatchesWithFailed {false};
@@ -187,19 +187,15 @@ namespace TrRouting
       {
         // Generate parameters to send to calculate
         const LineVector combination = allCombinations.at(i);
-        // TODO: The exception should be part of the calculation specific parameters, which do not exist yet
-        alternativeParameters.exceptLines = exceptLinesFromParameters; // reset except lines using parameters
-        for (auto line : combination)
-        {
-          alternativeParameters.exceptLines.push_back(line);
-        }
+
+        AlternativeLineFilter lineFilter(combination);
 
         spdlog::debug("calculating alternative {} from a total of {} ...", alternativeSequence, alternativesCalculatedCount);
         
         spdlog::debug("except lines: {}", LinesToString(combination));
 
         try {
-          result = calculateSingle(alternativeParameters, false, true);
+          result = calculateSingle(alternativeParameters, false, &lineFilter);
 
           SingleCalculationResult& alternativeCalcResult = *result.get();
 

--- a/connection_scan_algorithm/src/calculator.cpp
+++ b/connection_scan_algorithm/src/calculator.cpp
@@ -25,8 +25,8 @@ namespace TrRouting
     );
   }
   
-  std::unique_ptr<SingleCalculationResult> Calculator::calculateSingle(RouteParameters &parameters, bool resetAccessPaths, bool resetFilters) {
-    reset(parameters, *parameters.getOrigin(), *parameters.getDestination(), resetAccessPaths, resetFilters);
+  std::unique_ptr<SingleCalculationResult> Calculator::calculateSingle(RouteParameters &parameters, bool resetAccessPaths, AlternativeFilter *alternativeFilter) {
+    reset(parameters, *parameters.getOrigin(), *parameters.getDestination(), resetAccessPaths, alternativeFilter);
 
     std::unique_ptr<SingleCalculationResult> result;
 
@@ -151,7 +151,6 @@ namespace TrRouting
     reset(parameters, 
         parameters.isForwardCalculation() ? std::make_optional(*parameters.getPlace()) : std::nullopt, 
         parameters.isForwardCalculation() ? std::nullopt : std::make_optional(*parameters.getPlace()),
-        true,
         true
     );
 

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -12,11 +12,12 @@
 #include "transit_data.hpp"
 #include "connection_set.hpp"
 #include "geofilter.hpp"
+#include "alternative_filter.hpp"
 
 namespace TrRouting
 {
 
-  void Calculator::reset(CommonParameters &parameters, std::optional<std::reference_wrapper<const Point>> origin, std::optional<std::reference_wrapper<const Point>> destination, bool resetAccessPaths, bool doResetFilters)
+  void Calculator::reset(CommonParameters &parameters, std::optional<std::reference_wrapper<const Point>> origin, std::optional<std::reference_wrapper<const Point>> destination, bool resetAccessPaths, AlternativeFilter *alternativeFilter)
   {
     
     //TODO Should we just check the size of accessFootpath and egressFootpath instead of adding a flag?
@@ -148,12 +149,15 @@ namespace TrRouting
     
     calculationTime = algorithmCalculationTime.getDurationMicrosecondsNoStop();
 
+    // Save a copy of the current connection set
+    connectionSet = transitData.getConnectionsForScenario(parameters.getScenario());
 
-    // disable trips according to parameters:
+    // Clear the tripsDisabled before applying the filter, so we don't carry previous filter around.
+    tripsDisabled.clear();
 
-    if (doResetFilters)
-    {
-      resetFilters(parameters);
+    // disable trips according for alternatives:
+    if (alternativeFilter) {
+      alternativeFilter->runFilter(tripsDisabled, (*connectionSet));
     }
 
     spdlog::debug("-- filter trips -- {} microseconds ", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);
@@ -186,38 +190,6 @@ namespace TrRouting
     }
 
     return egressFootpathOk;
-  }
-
-  /* Disable trips for alternatives calculations */
-  void Calculator::resetFilters(const CommonParameters &parameters) {
-    spdlog::debug("  resetting filters");
-
-    // TODO med term. Instead of the scenario as cache key, it could be the parameters, with services, lines and agencies
-    connectionSet = transitData.getConnectionsForScenario(parameters.getScenario());
-
-    // This loop is required for alternatives, where parameters have more
-    // exclusions than the scenario (the combinations of lines). It is not
-    // redundant with the one in the connection cache generator
-    tripsDisabled.clear();
-    for (auto & tripIte : connectionSet.get()->getTrips())
-    {
-      const Trip & trip = tripIte.get();
-      bool enabled = true;
-
-      // Currently alternatives only excludes some lines, so that's the only filter needed
-      if (enabled && parameters.getExceptLines().size() > 0)
-      {
-        if (std::find(parameters.getExceptLines().begin(), parameters.getExceptLines().end(), trip.line) != parameters.getExceptLines().end())
-        {
-          enabled = false;
-        }
-      }
-
-      if (!enabled) {
-        tripsDisabled[trip.uid] = true;
-      }
-    }
-
   }
 
 }

--- a/include/line.hpp
+++ b/include/line.hpp
@@ -2,6 +2,7 @@
 #define TR_LINE
 
 #include <string>
+#include <memory>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/include/parameters.hpp
+++ b/include/parameters.hpp
@@ -82,6 +82,7 @@ namespace TrRouting
       int maxInnerTimeOfTripBufferSeconds;
 
       boost::uuids::uuid scenarioUuid;
+      //TODO We don't do anything with those filter at the moment
       std::vector<std::reference_wrapper<const Service>> onlyServices;
       std::vector<std::reference_wrapper<const Line>> onlyLines;
       std::vector<std::reference_wrapper<const Agency>> onlyAgencies;
@@ -89,11 +90,7 @@ namespace TrRouting
       std::vector<std::reference_wrapper<const Node>> onlyNodes;
       //TODO exceptServices is never filled with anything
       std::vector<std::reference_wrapper<const Service>> exceptServices;
-      // FIXME: Temporarily moved to public until calculation specific parameters exist. This is used directly by alternatives routing.
-      // see https://github.com/chairemobilite/trRouting/issues/95
-    public:
       std::vector<std::reference_wrapper<const Line>> exceptLines;
-    private:
       std::vector<std::reference_wrapper<const Agency>> exceptAgencies;
       std::vector<std::reference_wrapper<const Mode>> exceptModes;
       std::vector<std::reference_wrapper<const Node>> exceptNodes;

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/uuid/uuid.hpp>
 #include <vector>
+#include <optional>
 #include "toolbox.hpp" //MAX_INT
 
 namespace TrRouting

--- a/tests/connection_scan_algorithm/Makefile.am
+++ b/tests/connection_scan_algorithm/Makefile.am
@@ -20,7 +20,8 @@ csa_test_SOURCES = gtest.cpp \
     csa_result_to_v2_accessibility_test.cpp \
     parameters/route_param_test.cpp \
     parameters/accessibility_param_test.cpp \
-    combinations_test.cpp
+    combinations_test.cpp \
+    alternative_filter_test.cpp
 
 csa_test_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 

--- a/tests/connection_scan_algorithm/alternative_filter_test.cpp
+++ b/tests/connection_scan_algorithm/alternative_filter_test.cpp
@@ -1,0 +1,280 @@
+#include <errno.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "gtest/gtest.h"
+#include "connection_set_test.hpp"
+#include "connection_set.hpp"
+#include "alternative_filter.hpp"
+#include "line.hpp"
+#include "trip.hpp"
+#include "scenario.hpp"
+
+// Tests for the alternative filters, which mark trips as disabled based on the
+// lines excluded by a given alternative combination.
+//
+// Filters accumulate: runFilter only ever adds to tripsDisabled, so several
+// filters can be applied to the same container.
+
+class AlternativeFilterFixtureTests : public ConnectionSetFixtureTests
+{
+protected:
+  // Mirrors Calculator::isTripDisabled: presence in the map means disabled
+  static bool isDisabled(const std::unordered_map<TrRouting::Trip::uid_t, bool> & tripsDisabled,
+                         const TrRouting::Trip & trip)
+  {
+    return tripsDisabled.find(trip.uid) != tripsDisabled.end();
+  }
+
+  const TrRouting::Line & getLine(const boost::uuids::uuid & uuid) const
+  {
+    return transitData.getLines().at(uuid);
+  }
+
+  const TrRouting::Trip & getTrip(const boost::uuids::uuid & uuid) const
+  {
+    return transitData.getTrips().at(uuid);
+  }
+
+  // All 5 trips of the test data (2 on line SN, 2 on line EW, 1 on line Extra)
+  std::shared_ptr<TrRouting::ConnectionSet> getFullConnectionSet() const
+  {
+    return transitData.getConnectionsForScenario(
+      transitData.getScenarios().at(TestDataFetcher::scenarioUuid));
+  }
+};
+
+// An empty exclusion list should leave every trip enabled
+TEST_F(AlternativeFilterFixtureTests, EmptyExcludeListDisablesNothing)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+  ASSERT_EQ(5u, connectionSet->getTrips().size());
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(0u, tripsDisabled.size());
+}
+
+// Excluding a single line should disable exactly the trips of that line
+TEST_F(AlternativeFilterFixtureTests, SingleExcludedLineDisablesItsTripsOnly)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(2u, tripsDisabled.size());
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1ExtraUuid)));
+}
+
+// Excluding several lines should disable the union of their trips
+TEST_F(AlternativeFilterFixtureTests, MultipleExcludedLinesDisableAllTheirTrips)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  excludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(3u, tripsDisabled.size());
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1ExtraUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+}
+
+// Excluding every line should disable every trip of the connection set
+TEST_F(AlternativeFilterFixtureTests, AllLinesExcludedDisablesAllTrips)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  excludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
+  excludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(connectionSet->getTrips().size(), tripsDisabled.size());
+  for (auto & tripIte : connectionSet->getTrips())
+  {
+    EXPECT_TRUE(isDisabled(tripsDisabled, tripIte.get()));
+  }
+}
+
+// Excluding a line that has no trip in this connection set should be a no-op.
+// Scenario 2 already excludes line EW, so no trip of that line is present
+TEST_F(AlternativeFilterFixtureTests, ExcludedLineAbsentFromConnectionSet)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet =
+    transitData.getConnectionsForScenario(
+      transitData.getScenarios().at(TestDataFetcher::scenario2Uuid));
+  ASSERT_EQ(3u, connectionSet->getTrips().size());
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(0u, tripsDisabled.size());
+}
+
+// Successive filters accumulate: the second filter must add to the results of
+// the first rather than replace them
+TEST_F(AlternativeFilterFixtureTests, SuccessiveFiltersAccumulate)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> firstExcludeLines;
+  firstExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  TrRouting::AlternativeLineFilter firstFilter(firstExcludeLines);
+  firstFilter.runFilter(tripsDisabled, *connectionSet);
+  ASSERT_EQ(2u, tripsDisabled.size());
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> secondExcludeLines;
+  secondExcludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
+  TrRouting::AlternativeLineFilter secondFilter(secondExcludeLines);
+  secondFilter.runFilter(tripsDisabled, *connectionSet);
+
+  // Both the SN trips and the Extra trip must now be disabled
+  EXPECT_EQ(3u, tripsDisabled.size());
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1ExtraUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+}
+
+// Accumulating in either order must give the same result, so that the caller
+// does not have to care about the order the filters are applied in
+TEST_F(AlternativeFilterFixtureTests, AccumulationIsOrderIndependent)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> snExcludeLines;
+  snExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  TrRouting::AlternativeLineFilter snFilter(snExcludeLines);
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> extraExcludeLines;
+  extraExcludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
+  TrRouting::AlternativeLineFilter extraFilter(extraExcludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> snThenExtra;
+  snFilter.runFilter(snThenExtra, *connectionSet);
+  extraFilter.runFilter(snThenExtra, *connectionSet);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> extraThenSn;
+  extraFilter.runFilter(extraThenSn, *connectionSet);
+  snFilter.runFilter(extraThenSn, *connectionSet);
+
+  EXPECT_EQ(snThenExtra.size(), extraThenSn.size());
+  for (auto & tripIte : connectionSet->getTrips())
+  {
+    const TrRouting::Trip & trip = tripIte.get();
+    EXPECT_EQ(isDisabled(snThenExtra, trip), isDisabled(extraThenSn, trip));
+  }
+}
+
+// Overlapping filters must not double count or drop anything
+TEST_F(AlternativeFilterFixtureTests, OverlappingFiltersAccumulateToTheUnion)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> firstExcludeLines;
+  firstExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  firstExcludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
+  TrRouting::AlternativeLineFilter firstFilter(firstExcludeLines);
+  firstFilter.runFilter(tripsDisabled, *connectionSet);
+  ASSERT_EQ(4u, tripsDisabled.size());
+
+  // Line SN is already disabled, line Extra is not
+  std::vector<std::reference_wrapper<const TrRouting::Line>> secondExcludeLines;
+  secondExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  secondExcludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
+  TrRouting::AlternativeLineFilter secondFilter(secondExcludeLines);
+  secondFilter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(5u, tripsDisabled.size());
+}
+
+// The filter must never remove entries it did not add, so that results set by
+// the caller or by a previous filter survive
+TEST_F(AlternativeFilterFixtureTests, ExistingResultsArePreserved)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  tripsDisabled[getTrip(TestDataFetcher::trip1EWUuid).uid] = true;
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(3u, tripsDisabled.size());
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
+}
+
+// An empty exclusion list must be a no-op, in particular it must not clear
+TEST_F(AlternativeFilterFixtureTests, EmptyExcludeListPreservesExistingResults)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  tripsDisabled[getTrip(TestDataFetcher::trip1SNUuid).uid] = true;
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(1u, tripsDisabled.size());
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
+}
+
+// Running the same filter twice must be idempotent: accumulating means the
+// second run re-adds the same uids rather than growing the result
+TEST_F(AlternativeFilterFixtureTests, RunFilterIsIdempotent)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+
+  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  filter.runFilter(tripsDisabled, *connectionSet);
+  ASSERT_EQ(2u, tripsDisabled.size());
+
+  filter.runFilter(tripsDisabled, *connectionSet);
+
+  EXPECT_EQ(2u, tripsDisabled.size());
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+}


### PR DESCRIPTION
We were piggybacking on the original query parameter to add an extra line filter calculate call. We had to expose publicly the exclude line parameter of the object to make this work.

Instead of relying on a quirk of the original paramater, we pass a new AlternativeFilter object to the calculateSingle call. This is passed to the reset call, in place of the usused resetFilter which was always true.

We made a generic interface AlternativeFilter that can be implemented in various way. We currently have an AlternativeLineFilter implemented.

This change make the management of the alternative filtering more obvious and will make it easier to implement variant of the alternative generation algorithm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering alternative routes by excluding selected transit lines.
  * Alternative route calculations now apply line exclusions through a dedicated filtering mechanism.

* **Improvements**
  * Improved route recalculation by consistently resetting disabled trips before applying filters.
  * Restricted direct access to line-exclusion settings for safer configuration.
  * Added reliable handling for empty, overlapping, cumulative, and repeated line exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->