### PR TITLE
Move the Combination generation loop to a function

### DIFF
--- a/connection_scan_algorithm/include/line_combinations.hpp
+++ b/connection_scan_algorithm/include/line_combinations.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <map>
+#include <vector>
+
+#include "combinations.hpp"
+#include "line.hpp"
+
+namespace TrRouting
+{
+  using LineVector = std::vector<std::reference_wrapper<const Line>>;
+  using CombinationMap = std::map<LineVector, bool>;
+
+  /**
+     True if every line of `subset` is present in `lines`. An empty `subset` is
+     always contained.
+   */
+  inline bool containsAllLines(const LineVector & lines, const LineVector & subset)
+  {
+    for (const auto & line : subset)
+    {
+      if (std::find(lines.begin(), lines.end(), line) == lines.end())
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+     True if the lines of `candidate` represent a subset of a line combination
+     presention in the list of combinations
+
+     For example: if combinations has lines [1,2] and [2,3], the function will
+     return true for a candidate of [2,3,4]. It will return false for a candidate
+     of [1,3] as in both cases there's a new line in the candidate.
+   */
+  inline bool isSupersetOfAnyCombinations(const LineVector & candidate,
+                                          const std::vector<LineVector> & combinations)
+  {
+    for (const auto & combination : combinations)
+    {
+      if (containsAllLines(candidate, combination))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+     Generate combinations of 1 line, then 2 lines, up to the total amount of
+     lines in `foundLines`. Each generated combination is extended with `prefix`
+     (the lines already excluded by the alternative that produced `foundLines`,
+     empty for the first generation) and sorted.
+
+     A combination is appended to `allCombinations` only if it has not been seen
+     before and does not match a failed combination. Combinations rejected by the
+     failed check are still recorded in `alreadyCalculatedCombinations`, so a
+     later generation does not evaluate them again.
+
+     @param foundLines Lines used by the alternative we are branching from
+     @param prefix Lines already excluded, added to every generated combination
+     @param failedCombinations Combinations known to yield no route
+     @param allCombinations Container the accepted combinations are appended to
+     @param alreadyCalculatedCombinations Bookkeeping of every combination seen
+   */
+  inline void generateCombinations(const LineVector & foundLines,
+                                   const LineVector & prefix,
+                                   const std::vector<LineVector> & failedCombinations,
+                                   std::vector<LineVector> & allCombinations,
+                                   CombinationMap & alreadyCalculatedCombinations)
+  {
+    for (size_t k = 1; k <= foundLines.size(); k++)
+    {
+      Combinations<std::reference_wrapper<const Line>> combinations(foundLines, k);
+      for (auto newCombination : combinations)
+      {
+        // Copy lines from previous combinations
+        std::copy(prefix.begin(), prefix.end(), std::back_inserter(newCombination));
+        std::stable_sort(newCombination.begin(), newCombination.end());
+        if (!alreadyCalculatedCombinations.emplace(newCombination, true).second)
+        {
+          continue;
+        }
+        // Do not add the new line combination if there's a subset of it in a previsouly
+        // failed calculation of a combination.
+        if (!isSupersetOfAnyCombinations(newCombination, failedCombinations))
+        {
+          allCombinations.push_back(newCombination);
+        }
+      }
+    }
+  }
+}

--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -10,6 +10,7 @@
 #include "point.hpp"
 #include "transit_data.hpp"
 #include "alternative_filter.hpp"
+#include "line_combinations.hpp"
 
 namespace {
   // Placed in anynymous namespace so it's local to this file
@@ -86,14 +87,11 @@ namespace TrRouting
 
   AlternativesResult Calculator::alternativesRouting(const RouteParameters &parameters)
   {
-    using LineVector = std::vector<std::reference_wrapper<const Line>>;
+
     std::vector< LineVector >  allCombinations;
     std::vector< LineVector >  failedCombinations;
-    bool                             combinationMatchesWithFailed {false};
-    bool                             combinationMatchesWithAtLeastOneFailed {false};
-    std::map<LineVector, bool> alreadyCalculatedCombinations;
-    std::map<LineVector, bool> alreadyFoundLines;
-    std::map<LineVector, int>  foundLinesTravelTimeSeconds;
+    CombinationMap alreadyCalculatedCombinations;
+    CombinationMap alreadyFoundLines;
     int maxTravelTime;
     int alternativeSequence = 1;
     int alternativesCalculatedCount = 1;
@@ -157,23 +155,12 @@ namespace TrRouting
     LineVector foundLines = routingResult.accept(visitor);
     std::stable_sort(foundLines.begin(),foundLines.end());
     alreadyFoundLines[foundLines]           = true;
-    foundLinesTravelTimeSeconds[foundLines] = routingResult.totalTravelTime;
     lastFoundedAtNum = 1;
 
     spdlog::debug("fastest line ids: {}", LinesToString(foundLines));
 
     // Generate combination of group of 1 line, then 2 lines up to the total amount of lines
-    for (size_t k = 1; k <= foundLines.size(); k++)
-    {
-      Combinations<std::reference_wrapper<const Line>> combinations(foundLines, k);
-
-      for (auto newCombination : combinations)
-      {
-        std::stable_sort(newCombination.begin(), newCombination.end());
-        allCombinations.push_back(newCombination);
-        alreadyCalculatedCombinations[newCombination] = true;
-      }
-    }
+    generateCombinations(foundLines, {}, failedCombinations, allCombinations, alreadyCalculatedCombinations);
 
     // Process all combinations and calculate new route with those excluded
     for (size_t i = 0; i < allCombinations.size(); i++)
@@ -211,45 +198,8 @@ namespace TrRouting
 
             lastFoundedAtNum = alternativesCalculatedCount;
             alreadyFoundLines[foundLines] = true;
-            foundLinesTravelTimeSeconds[foundLines] = alternativeCalcResult.totalTravelTime;
-            for (size_t k = 1; k <= foundLines.size(); k++)
-            {
-              Combinations<std::reference_wrapper<const Line>> combinations(foundLines, k);
-              for (auto newCombination : combinations)
-              {
-                // Add the lines currently exclused (combination) to the newly generated combinations
-                // from the line in the latest alternative
-                std::copy(combination.begin(), combination.end(),
-                          std::back_inserter(newCombination));
-                std::stable_sort(newCombination.begin(), newCombination.end());
-                if (alreadyCalculatedCombinations.count(newCombination) == 0)
-                {
-                  combinationMatchesWithAtLeastOneFailed = false;
-                  for (auto failedCombination : failedCombinations)
-                  {
-                    combinationMatchesWithFailed = true;
-                    for (auto failedLine : failedCombination)
-                    {
-                      if (std::find(newCombination.begin(), newCombination.end(), failedLine) == newCombination.end())
-                      {
-                        combinationMatchesWithFailed = false;
-                        break;
-                      }
-                    }
-                    if (combinationMatchesWithFailed)
-                    {
-                      combinationMatchesWithAtLeastOneFailed = true;
-                      break;
-                    }
-                  }
-                  if (!combinationMatchesWithAtLeastOneFailed)
-                  {
-                    allCombinations.push_back(newCombination);
-                  }
-                  alreadyCalculatedCombinations[newCombination] = true;
-                }
-              }
-            }
+            // Generate new combinations from the new foundlines
+            generateCombinations(foundLines, combination, failedCombinations, allCombinations, alreadyCalculatedCombinations);
 
             alternativeSequence++;
 
@@ -261,14 +211,6 @@ namespace TrRouting
 
         alternativesCalculatedCount++;
       }
-    }
-
-    int i {0};
-    for (auto flines : alreadyFoundLines)
-    {          
-      spdlog::debug("{}. {} travel time minutes: {}", i, LinesToString(flines.first),
-                    (foundLinesTravelTimeSeconds[flines.first] / 60));
-      i++;          
     }
 
     // Print failed combinations

--- a/include/combinations.hpp
+++ b/include/combinations.hpp
@@ -1,3 +1,4 @@
+#pragma once
 // combinations.hpp 
 // from https://stackoverflow.com/a/25497877
 // With later  modifications to adapt for std::reference_wrapper

--- a/tests/connection_scan_algorithm/Makefile.am
+++ b/tests/connection_scan_algorithm/Makefile.am
@@ -21,7 +21,8 @@ csa_test_SOURCES = gtest.cpp \
     parameters/route_param_test.cpp \
     parameters/accessibility_param_test.cpp \
     combinations_test.cpp \
-    alternative_filter_test.cpp
+    alternative_filter_test.cpp \
+    line_combinations_test.cpp
 
 csa_test_LDADD = $(top_srcdir)/tests/libgtest.la ../../connection_scan_algorithm/src/libcsa.la
 

--- a/tests/connection_scan_algorithm/line_combinations_test.cpp
+++ b/tests/connection_scan_algorithm/line_combinations_test.cpp
@@ -1,0 +1,178 @@
+#include <deque>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+
+#include "gtest/gtest.h"
+#include "agency.hpp"
+#include "line.hpp"
+#include "line_combinations.hpp"
+#include "mode.hpp"
+
+// Tests for the combination generation used by the alternatives routing. The
+// helpers only ever look at line identity, so plain Line objects are enough
+// here and no transit data needs to be loaded.
+
+namespace TrRouting
+{
+  // Using by gtest. So a failed EXPECT prints line shortnames
+  // instead of a raw byte dump
+  void PrintTo(const std::reference_wrapper<const Line> & line, std::ostream * os)
+  {
+    *os << line.get().shortname;
+  }
+}
+
+class LineCombinationsFixtureTests : public ::testing::Test
+{
+protected:
+  LineCombinationsFixtureTests() :
+    agency({boost::uuids::random_generator()(), "AGE", "Test agency", boost::uuids::nil_uuid()}),
+    mode("bus", "Bus", 3, 3),
+    lineA(makeLine("A")),
+    lineB(makeLine("B")),
+    lineC(makeLine("C")) {}
+
+  TrRouting::Agency agency;
+  TrRouting::Mode mode;
+  // std::deque keeps references stable as lines are added, which std::vector
+  // would not
+  std::deque<TrRouting::Line> lines;
+  // Created in this order, so their uids are increasing and a sorted
+  // combination lists them alphabetically
+  const TrRouting::Line & lineA;
+  const TrRouting::Line & lineB;
+  const TrRouting::Line & lineC;
+
+  const TrRouting::Line & makeLine(const std::string & shortname)
+  {
+    lines.emplace_back(boost::uuids::random_generator()(), agency, mode, shortname, shortname, 0);
+    return lines.back();
+  }
+
+  static bool contains(const std::vector<TrRouting::LineVector> & combinations,
+                       const TrRouting::LineVector & expected)
+  {
+    return std::find(combinations.begin(), combinations.end(), expected) != combinations.end();
+  }
+};
+
+TEST_F(LineCombinationsFixtureTests, ContainsAllLinesWithEmptySubset)
+{
+  EXPECT_TRUE(TrRouting::containsAllLines({lineA}, {}));
+  EXPECT_TRUE(TrRouting::containsAllLines({}, {}));
+}
+
+TEST_F(LineCombinationsFixtureTests, ContainsAllLinesWithSubset)
+{
+  EXPECT_TRUE(TrRouting::containsAllLines({lineA, lineB}, {lineA}));
+  EXPECT_TRUE(TrRouting::containsAllLines({lineA, lineB}, {lineA, lineB}));
+}
+
+TEST_F(LineCombinationsFixtureTests, ContainsAllLinesWithMissingLine)
+{
+  EXPECT_FALSE(TrRouting::containsAllLines({lineA, lineB}, {lineC}));
+  // A smaller container cannot contain a larger subset
+  EXPECT_FALSE(TrRouting::containsAllLines({lineA}, {lineA, lineB}));
+}
+
+TEST_F(LineCombinationsFixtureTests, NothingMatchesEmptyCombinations)
+{
+  EXPECT_FALSE(TrRouting::isSupersetOfAnyCombinations({lineA}, {}));
+}
+
+TEST_F(LineCombinationsFixtureTests, ExactCombinationMatches)
+{
+  std::vector<TrRouting::LineVector> combinations {{lineA, lineB}};
+
+  EXPECT_TRUE(TrRouting::isSupersetOfAnyCombinations({lineA, lineB}, combinations));
+}
+
+TEST_F(LineCombinationsFixtureTests, SupersetOfCombinationMatches)
+{
+  std::vector<TrRouting::LineVector> combinations {{lineA}};
+
+  // Excluding A and B on top of a failing exclusion of A can only fail as well
+  EXPECT_TRUE(TrRouting::isSupersetOfAnyCombinations({lineA, lineB}, combinations));
+}
+
+TEST_F(LineCombinationsFixtureTests, SubsetOfCombinationDoesNotMatch)
+{
+  std::vector<TrRouting::LineVector> combinations {{lineA, lineB}};
+
+  // Excluding fewer lines may still find a route, so it must stay a candidate
+  EXPECT_FALSE(TrRouting::isSupersetOfAnyCombinations({lineA}, combinations));
+  EXPECT_FALSE(TrRouting::isSupersetOfAnyCombinations({lineC}, combinations));
+}
+
+TEST_F(LineCombinationsFixtureTests, GeneratesEverySubsetOfFoundLines)
+{
+  std::vector<TrRouting::LineVector> allCombinations;
+  TrRouting::CombinationMap alreadyCalculatedCombinations;
+
+  TrRouting::generateCombinations({lineA, lineB}, {}, {}, allCombinations, alreadyCalculatedCombinations);
+
+  ASSERT_EQ(3u, allCombinations.size());
+  EXPECT_TRUE(contains(allCombinations, {lineA}));
+  EXPECT_TRUE(contains(allCombinations, {lineB}));
+  EXPECT_TRUE(contains(allCombinations, {lineA, lineB}));
+  EXPECT_EQ(3u, alreadyCalculatedCombinations.size());
+}
+
+TEST_F(LineCombinationsFixtureTests, GeneratesNothingFromEmptyFoundLines)
+{
+  std::vector<TrRouting::LineVector> allCombinations;
+  TrRouting::CombinationMap alreadyCalculatedCombinations;
+
+  TrRouting::generateCombinations({}, {}, {}, allCombinations, alreadyCalculatedCombinations);
+
+  EXPECT_EQ(0u, allCombinations.size());
+  EXPECT_EQ(0u, alreadyCalculatedCombinations.size());
+}
+
+TEST_F(LineCombinationsFixtureTests, AlreadyCalculatedCombinationsAreNotGeneratedTwice)
+{
+  std::vector<TrRouting::LineVector> allCombinations;
+  TrRouting::CombinationMap alreadyCalculatedCombinations;
+
+  TrRouting::generateCombinations({lineA, lineB}, {}, {}, allCombinations, alreadyCalculatedCombinations);
+  ASSERT_EQ(3u, allCombinations.size());
+
+  TrRouting::generateCombinations({lineA, lineB}, {}, {}, allCombinations, alreadyCalculatedCombinations);
+
+  EXPECT_EQ(3u, allCombinations.size());
+}
+
+TEST_F(LineCombinationsFixtureTests, PrefixIsAddedToEveryGeneratedCombinationAndSorted)
+{
+  std::vector<TrRouting::LineVector> allCombinations;
+  TrRouting::CombinationMap alreadyCalculatedCombinations;
+
+  TrRouting::generateCombinations({lineA, lineB}, {lineC}, {}, allCombinations, alreadyCalculatedCombinations);
+
+  ASSERT_EQ(3u, allCombinations.size());
+  // The comparison is order sensitive, so it also asserts the sort by uid
+  EXPECT_TRUE(contains(allCombinations, {lineA, lineC}));
+  EXPECT_TRUE(contains(allCombinations, {lineB, lineC}));
+  EXPECT_TRUE(contains(allCombinations, {lineA, lineB, lineC}));
+}
+
+TEST_F(LineCombinationsFixtureTests, CombinationsMatchingAFailedOneAreSkipped)
+{
+  std::vector<TrRouting::LineVector> failedCombinations {{lineA}};
+  std::vector<TrRouting::LineVector> allCombinations;
+  TrRouting::CombinationMap alreadyCalculatedCombinations;
+
+  TrRouting::generateCombinations({lineA, lineB}, {}, failedCombinations, allCombinations,
+                                  alreadyCalculatedCombinations);
+
+  // {A} and {A, B} both contain the failed {A}
+  ASSERT_EQ(1u, allCombinations.size());
+  EXPECT_TRUE(contains(allCombinations, {lineB}));
+  // The 3 subsets are all recorded, even the 2 that were rejected, so a later
+  // generation does not have to check them against the failed list again
+  EXPECT_EQ(3u, alreadyCalculatedCombinations.size());
+}


### PR DESCRIPTION
We had somewhat duplicated code to generate the combination after we had found the lines of a routing result. We move those to a function, which make the code more readable. We we able to combine both case into a single function, since the initial case simply have a few parameter empty that makes the checks go away quickly.

Added unit tests to validate the correctness of those functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Routing Improvements**
  - Improved alternative-route evaluation by removing duplicate combinations and skipping options already known to fail.
  - Preserved consistent ordering and filtering while evaluating possible line combinations.

- **Reliability**
  - Added comprehensive coverage for combination generation, filtering, deduplication, failed-option handling, and edge cases.

- **Maintenance**
  - Consolidated combination-processing behavior to provide more consistent routing results.
  - Removed unnecessary diagnostic output during route evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->