### PR TITLE
Merge TripsDisabled into TripsQueryOverlay

### DIFF
--- a/connection_scan_algorithm/include/alternative_filter.hpp
+++ b/connection_scan_algorithm/include/alternative_filter.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <unordered_map>
 #include <vector>
 
 #include "line.hpp"
@@ -19,15 +18,15 @@ namespace TrRouting
     AlternativeFilter() {}
     virtual ~AlternativeFilter() = default;
     /**
-       Apply a filter to a connectionSet and set flags in the trips disabled overlay. The clearing
+       Apply a filter to a connectionSet and set the disabled flag in the trips query overlay. The clearing
        of the trips overlay should be done outside of the filter, so we can apply multiple filter to the same set
 
-       @param tripsDisabled Container to be filled with flags of which trips are no longer available
+       @param tripsQueryOverlay Per query trip scratch data, indexed by Trip::uid, in which the disabled flags are set
        @param connectionSet Current list of trips matching the query scenarios
 
        @return void (Could be changed to return a bool to represent if something was filtered or not)
      */
-    virtual void runFilter(std::unordered_map<Trip::uid_t, bool> &tripsDisabled, const ConnectionSet &connectionSet) = 0;
+    virtual void runFilter(std::vector<TripQueryData> &tripsQueryOverlay, const ConnectionSet &connectionSet) = 0;
   };
 
   /** Alternative Line filter
@@ -36,7 +35,7 @@ namespace TrRouting
   class AlternativeLineFilter : public AlternativeFilter {
   public:
     AlternativeLineFilter(const std::vector<std::reference_wrapper<const Line>> &_excludedLines);
-    virtual void runFilter(std::unordered_map<Trip::uid_t, bool> &tripsDisabled, const ConnectionSet &connectionSet) override;
+    virtual void runFilter(std::vector<TripQueryData> &tripsQueryOverlay, const ConnectionSet &connectionSet) override;
   protected:
     /** Simplified copy of the line vector (with only the UIDs) */
     std::vector<Line::uid_t> excludedLinesUids;

--- a/connection_scan_algorithm/include/calculator.hpp
+++ b/connection_scan_algorithm/include/calculator.hpp
@@ -113,11 +113,10 @@ namespace TrRouting
     std::unordered_map<Node::uid_t, NodeTimeDistance> nodesAccess; // travel time/distance from origin to accessible nodes
     std::unordered_map<Node::uid_t, NodeTimeDistance> nodesEgress; // travel time/distance to reach destination;
 
-    // Field used at the time of the query, mostly for alternatives, which deactivate some of the scenario trips. Typically, there are less disabled trips and enabled ones, so we keep only those
-    // Since the number of disabled trip is more commonly low, the map query is fast
-    std::unordered_map<Trip::uid_t, bool> tripsDisabled;
-    bool isTripDisabled(Trip::uid_t uid) const { return tripsDisabled.find(uid) != tripsDisabled.end(); }
-    std::vector<TripQueryData> tripsQueryOverlay; // Store additionnal trip info during a query processing, indexed by Trip::uid
+    // Store additionnal trip info during a query processing, indexed by Trip::uid. This includes the `disabled`
+    // flag used by alternatives to deactivate some of the scenario trips, which lives here rather than in a
+    // separate map so the connection scan reads it from the entry it already loaded.
+    std::vector<TripQueryData> tripsQueryOverlay;
     // A subset of the connections that are used for the current query.
     std::shared_ptr<ConnectionSet> connectionSet;
 

--- a/connection_scan_algorithm/src/alternative_filter.cpp
+++ b/connection_scan_algorithm/src/alternative_filter.cpp
@@ -19,7 +19,7 @@ namespace TrRouting {
     
   }
   
-  void AlternativeLineFilter::runFilter(std::unordered_map<Trip::uid_t, bool> &tripsDisabled, const ConnectionSet &connectionSet) {
+  void AlternativeLineFilter::runFilter(std::vector<TripQueryData> &tripsQueryOverlay, const ConnectionSet &connectionSet) {
 
     if (excludedLinesUids.size() > 0) {
       for (auto & tripIte : connectionSet.getTrips())
@@ -29,7 +29,7 @@ namespace TrRouting {
         // If the Trip match any lines in the filter, disable it
         if (std::find(excludedLinesUids.begin(), excludedLinesUids.end(), trip.line.uid) != excludedLinesUids.end())
         {
-          tripsDisabled[trip.uid] = true;
+          tripsQueryOverlay.at(trip.uid).disabled = true;
         }
       }
     }

--- a/connection_scan_algorithm/src/forward_calculation.cpp
+++ b/connection_scan_algorithm/src/forward_calculation.cpp
@@ -36,11 +36,11 @@ namespace TrRouting
       {
         const Trip & trip = (*connection).get().getTrip();
 
-        // Cache the current query data overlay si we don't check the hashmap every time
+        // Cache the current query data overlay si we don't check the vector every time
         auto & currentTripQueryOverlay = tripsQueryOverlay.at(trip.uid);
 
         // enabled trips only here:
-        if (!isTripDisabled(trip.uid))
+        if (!currentTripQueryOverlay.disabled)
         {
           connectionDepartureTime         = (*connection).get().getDepartureTime();
           connectionMinWaitingTimeSeconds = (*connection).get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());
@@ -244,11 +244,11 @@ namespace TrRouting
       {
         const Trip & trip = (*connection).get().getTrip();
 
-        // Cache the current query data overlay si we don't check the hashmap every time
+        // Cache the current query data overlay si we don't check the vector every time
         auto & currentTripQueryOverlay = tripsQueryOverlay.at(trip.uid);
 
         // enabled trips only here:
-        if (!isTripDisabled(trip.uid))
+        if (!currentTripQueryOverlay.disabled)
         {
           connectionDepartureTime         = (*connection).get().getDepartureTime();
           connectionMinWaitingTimeSeconds = (*connection).get().getMinWaitingTimeOrDefault(parameters.getMinWaitingTimeSeconds());

--- a/connection_scan_algorithm/src/initializations.cpp
+++ b/connection_scan_algorithm/src/initializations.cpp
@@ -45,7 +45,6 @@ namespace TrRouting
     forwardJourneysSteps.clear();
     reverseJourneysSteps.clear();
 
-    tripsDisabled.clear();
     tripsQueryOverlay.clear();
 
     spdlog::info("{} connections", transitData.getConnectionCount());;

--- a/connection_scan_algorithm/src/resets.cpp
+++ b/connection_scan_algorithm/src/resets.cpp
@@ -152,12 +152,10 @@ namespace TrRouting
     // Save a copy of the current connection set
     connectionSet = transitData.getConnectionsForScenario(parameters.getScenario());
 
-    // Clear the tripsDisabled before applying the filter, so we don't carry previous filter around.
-    tripsDisabled.clear();
-
-    // disable trips according for alternatives:
+    // disable trips according for alternatives. The disabled flags were already cleared by the
+    // tripsQueryOverlay.assign() above, so we don't carry the previous filter around.
     if (alternativeFilter) {
-      alternativeFilter->runFilter(tripsDisabled, (*connectionSet));
+      alternativeFilter->runFilter(tripsQueryOverlay, (*connectionSet));
     }
 
     spdlog::debug("-- filter trips -- {} microseconds ", algorithmCalculationTime.getDurationMicrosecondsNoStop() - calculationTime);

--- a/connection_scan_algorithm/src/reverse_calculation.cpp
+++ b/connection_scan_algorithm/src/reverse_calculation.cpp
@@ -45,7 +45,7 @@ namespace TrRouting
         
         // enabled trips only here:
         auto & currentTripQueryOverlay = tripsQueryOverlay.at(trip.uid);
-        if (currentTripQueryOverlay.usable && !isTripDisabled(trip.uid))
+        if (currentTripQueryOverlay.usable && !currentTripQueryOverlay.disabled)
         {
 
           connectionArrivalTime           = (*connection).get().getArrivalTime();
@@ -268,7 +268,7 @@ namespace TrRouting
         // enabled trips only here:
         auto & currentTripQueryOverlay = tripsQueryOverlay.at(trip.uid);
         // FIXME Determine with the new connection cache if a trip could be disabled in the all nodes path
-        if ((currentTripQueryOverlay.usable) && !isTripDisabled(trip.uid))
+        if ((currentTripQueryOverlay.usable) && !currentTripQueryOverlay.disabled)
         {
           connectionArrivalTime           = (*connection).get().getArrivalTime();
 

--- a/include/trip.hpp
+++ b/include/trip.hpp
@@ -66,6 +66,7 @@ namespace TrRouting
 
     TripQueryData()
       : usable(false),
+        disabled(false),
         enterConnection(std::nullopt),
         enterConnectionTransferTravelTime(MAX_INT),
         exitConnection(std::nullopt),
@@ -74,6 +75,9 @@ namespace TrRouting
 
     }
     bool usable; // after forward calculation, keep a list of usable trips in time range for reverse calculation
+    // Trip deactivated for the current query, mostly for alternatives which exclude some of the scenario trips.
+    // Kept next to `usable` so both flags are on the cache line already loaded by the connection scan.
+    bool disabled;
     std::optional<std::reference_wrapper<const Connection>> enterConnection; // index of the entering connection
     int enterConnectionTransferTravelTime;
     std::optional<std::reference_wrapper<const Connection>> exitConnection; // index of the exiting connection

--- a/tests/connection_scan_algorithm/alternative_filter_test.cpp
+++ b/tests/connection_scan_algorithm/alternative_filter_test.cpp
@@ -1,4 +1,6 @@
 #include <errno.h>
+#include <algorithm>
+#include <vector>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
@@ -13,17 +15,28 @@
 // Tests for the alternative filters, which mark trips as disabled based on the
 // lines excluded by a given alternative combination.
 //
-// Filters accumulate: runFilter only ever adds to tripsDisabled, so several
-// filters can be applied to the same container.
+// Filters accumulate: runFilter only ever sets disabled flags, so several
+// filters can be applied to the same overlay.
 
 class AlternativeFilterFixtureTests : public ConnectionSetFixtureTests
 {
 protected:
-  // Mirrors Calculator::isTripDisabled: presence in the map means disabled
-  static bool isDisabled(const std::unordered_map<TrRouting::Trip::uid_t, bool> & tripsDisabled,
+  // A fresh overlay, sized and zeroed the same way Calculator::reset does it
+  static std::vector<TrRouting::TripQueryData> makeOverlay()
+  {
+    return std::vector<TrRouting::TripQueryData>(TrRouting::Trip::getMaxUid() + 1);
+  }
+
+  static bool isDisabled(const std::vector<TrRouting::TripQueryData> & tripsQueryOverlay,
                          const TrRouting::Trip & trip)
   {
-    return tripsDisabled.find(trip.uid) != tripsDisabled.end();
+    return tripsQueryOverlay.at(trip.uid).disabled;
+  }
+
+  static size_t countDisabled(const std::vector<TrRouting::TripQueryData> & tripsQueryOverlay)
+  {
+    return std::count_if(tripsQueryOverlay.begin(), tripsQueryOverlay.end(),
+                         [](const TrRouting::TripQueryData & data) { return data.disabled; });
   }
 
   const TrRouting::Line & getLine(const boost::uuids::uuid & uuid) const
@@ -53,10 +66,10 @@ TEST_F(AlternativeFilterFixtureTests, EmptyExcludeListDisablesNothing)
   std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
   TrRouting::AlternativeLineFilter filter(excludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  filter.runFilter(tripsDisabled, *connectionSet);
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(0u, tripsDisabled.size());
+  EXPECT_EQ(0u, countDisabled(tripsQueryOverlay));
 }
 
 // Excluding a single line should disable exactly the trips of that line
@@ -68,15 +81,15 @@ TEST_F(AlternativeFilterFixtureTests, SingleExcludedLineDisablesItsTripsOnly)
   excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
   TrRouting::AlternativeLineFilter filter(excludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  filter.runFilter(tripsDisabled, *connectionSet);
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(2u, tripsDisabled.size());
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1ExtraUuid)));
+  EXPECT_EQ(2u, countDisabled(tripsQueryOverlay));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1ExtraUuid)));
 }
 
 // Excluding several lines should disable the union of their trips
@@ -89,15 +102,15 @@ TEST_F(AlternativeFilterFixtureTests, MultipleExcludedLinesDisableAllTheirTrips)
   excludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
   TrRouting::AlternativeLineFilter filter(excludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  filter.runFilter(tripsDisabled, *connectionSet);
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(3u, tripsDisabled.size());
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1ExtraUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+  EXPECT_EQ(3u, countDisabled(tripsQueryOverlay));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1ExtraUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2EWUuid)));
 }
 
 // Excluding every line should disable every trip of the connection set
@@ -111,13 +124,13 @@ TEST_F(AlternativeFilterFixtureTests, AllLinesExcludedDisablesAllTrips)
   excludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
   TrRouting::AlternativeLineFilter filter(excludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  filter.runFilter(tripsDisabled, *connectionSet);
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(connectionSet->getTrips().size(), tripsDisabled.size());
+  EXPECT_EQ(connectionSet->getTrips().size(), countDisabled(tripsQueryOverlay));
   for (auto & tripIte : connectionSet->getTrips())
   {
-    EXPECT_TRUE(isDisabled(tripsDisabled, tripIte.get()));
+    EXPECT_TRUE(isDisabled(tripsQueryOverlay, tripIte.get()));
   }
 }
 
@@ -134,10 +147,10 @@ TEST_F(AlternativeFilterFixtureTests, ExcludedLineAbsentFromConnectionSet)
   excludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
   TrRouting::AlternativeLineFilter filter(excludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  filter.runFilter(tripsDisabled, *connectionSet);
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(0u, tripsDisabled.size());
+  EXPECT_EQ(0u, countDisabled(tripsQueryOverlay));
 }
 
 // Successive filters accumulate: the second filter must add to the results of
@@ -146,26 +159,26 @@ TEST_F(AlternativeFilterFixtureTests, SuccessiveFiltersAccumulate)
 {
   std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
 
   std::vector<std::reference_wrapper<const TrRouting::Line>> firstExcludeLines;
   firstExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
   TrRouting::AlternativeLineFilter firstFilter(firstExcludeLines);
-  firstFilter.runFilter(tripsDisabled, *connectionSet);
-  ASSERT_EQ(2u, tripsDisabled.size());
+  firstFilter.runFilter(tripsQueryOverlay, *connectionSet);
+  ASSERT_EQ(2u, countDisabled(tripsQueryOverlay));
 
   std::vector<std::reference_wrapper<const TrRouting::Line>> secondExcludeLines;
   secondExcludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
   TrRouting::AlternativeLineFilter secondFilter(secondExcludeLines);
-  secondFilter.runFilter(tripsDisabled, *connectionSet);
+  secondFilter.runFilter(tripsQueryOverlay, *connectionSet);
 
   // Both the SN trips and the Extra trip must now be disabled
-  EXPECT_EQ(3u, tripsDisabled.size());
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1ExtraUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
-  EXPECT_FALSE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+  EXPECT_EQ(3u, countDisabled(tripsQueryOverlay));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1ExtraUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2EWUuid)));
 }
 
 // Accumulating in either order must give the same result, so that the caller
@@ -182,15 +195,15 @@ TEST_F(AlternativeFilterFixtureTests, AccumulationIsOrderIndependent)
   extraExcludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
   TrRouting::AlternativeLineFilter extraFilter(extraExcludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> snThenExtra;
+  std::vector<TrRouting::TripQueryData> snThenExtra = makeOverlay();
   snFilter.runFilter(snThenExtra, *connectionSet);
   extraFilter.runFilter(snThenExtra, *connectionSet);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> extraThenSn;
+  std::vector<TrRouting::TripQueryData> extraThenSn = makeOverlay();
   extraFilter.runFilter(extraThenSn, *connectionSet);
   snFilter.runFilter(extraThenSn, *connectionSet);
 
-  EXPECT_EQ(snThenExtra.size(), extraThenSn.size());
+  EXPECT_EQ(countDisabled(snThenExtra), countDisabled(extraThenSn));
   for (auto & tripIte : connectionSet->getTrips())
   {
     const TrRouting::Trip & trip = tripIte.get();
@@ -203,23 +216,23 @@ TEST_F(AlternativeFilterFixtureTests, OverlappingFiltersAccumulateToTheUnion)
 {
   std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
 
   std::vector<std::reference_wrapper<const TrRouting::Line>> firstExcludeLines;
   firstExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
   firstExcludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
   TrRouting::AlternativeLineFilter firstFilter(firstExcludeLines);
-  firstFilter.runFilter(tripsDisabled, *connectionSet);
-  ASSERT_EQ(4u, tripsDisabled.size());
+  firstFilter.runFilter(tripsQueryOverlay, *connectionSet);
+  ASSERT_EQ(4u, countDisabled(tripsQueryOverlay));
 
   // Line SN is already disabled, line Extra is not
   std::vector<std::reference_wrapper<const TrRouting::Line>> secondExcludeLines;
   secondExcludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
   secondExcludeLines.push_back(getLine(TestDataFetcher::lineExtraUuid));
   TrRouting::AlternativeLineFilter secondFilter(secondExcludeLines);
-  secondFilter.runFilter(tripsDisabled, *connectionSet);
+  secondFilter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(5u, tripsDisabled.size());
+  EXPECT_EQ(5u, countDisabled(tripsQueryOverlay));
 }
 
 // The filter must never remove entries it did not add, so that results set by
@@ -228,18 +241,18 @@ TEST_F(AlternativeFilterFixtureTests, ExistingResultsArePreserved)
 {
   std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  tripsDisabled[getTrip(TestDataFetcher::trip1EWUuid).uid] = true;
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  tripsQueryOverlay.at(getTrip(TestDataFetcher::trip1EWUuid).uid).disabled = true;
 
   std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
   excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
   TrRouting::AlternativeLineFilter filter(excludeLines);
-  filter.runFilter(tripsDisabled, *connectionSet);
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(3u, tripsDisabled.size());
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2SNUuid)));
+  EXPECT_EQ(3u, countDisabled(tripsQueryOverlay));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2SNUuid)));
 }
 
 // An empty exclusion list must be a no-op, in particular it must not clear
@@ -247,15 +260,15 @@ TEST_F(AlternativeFilterFixtureTests, EmptyExcludeListPreservesExistingResults)
 {
   std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  tripsDisabled[getTrip(TestDataFetcher::trip1SNUuid).uid] = true;
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  tripsQueryOverlay.at(getTrip(TestDataFetcher::trip1SNUuid).uid).disabled = true;
 
   std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
   TrRouting::AlternativeLineFilter filter(excludeLines);
-  filter.runFilter(tripsDisabled, *connectionSet);
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(1u, tripsDisabled.size());
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1SNUuid)));
+  EXPECT_EQ(1u, countDisabled(tripsQueryOverlay));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1SNUuid)));
 }
 
 // Running the same filter twice must be idempotent: accumulating means the
@@ -268,13 +281,62 @@ TEST_F(AlternativeFilterFixtureTests, RunFilterIsIdempotent)
   excludeLines.push_back(getLine(TestDataFetcher::lineEWUuid));
   TrRouting::AlternativeLineFilter filter(excludeLines);
 
-  std::unordered_map<TrRouting::Trip::uid_t, bool> tripsDisabled;
-  filter.runFilter(tripsDisabled, *connectionSet);
-  ASSERT_EQ(2u, tripsDisabled.size());
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
+  ASSERT_EQ(2u, countDisabled(tripsQueryOverlay));
 
-  filter.runFilter(tripsDisabled, *connectionSet);
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
 
-  EXPECT_EQ(2u, tripsDisabled.size());
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip1EWUuid)));
-  EXPECT_TRUE(isDisabled(tripsDisabled, getTrip(TestDataFetcher::trip2EWUuid)));
+  EXPECT_EQ(2u, countDisabled(tripsQueryOverlay));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_TRUE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2EWUuid)));
+}
+
+// The disabled flag now shares TripQueryData with the rest of the per query trip
+// scratch data, so the filter must not disturb the other fields
+TEST_F(AlternativeFilterFixtureTests, RunFilterLeavesOtherOverlayFieldsUntouched)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet = getFullConnectionSet();
+
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+  for (auto & tripIte : connectionSet->getTrips())
+  {
+    tripsQueryOverlay.at(tripIte.get().uid).usable = true;
+  }
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
+
+  ASSERT_EQ(2u, countDisabled(tripsQueryOverlay));
+  for (auto & tripIte : connectionSet->getTrips())
+  {
+    const TrRouting::TripQueryData & data = tripsQueryOverlay.at(tripIte.get().uid);
+    EXPECT_TRUE(data.usable);
+    EXPECT_FALSE(data.enterConnection.has_value());
+    EXPECT_FALSE(data.exitConnection.has_value());
+    EXPECT_EQ(TrRouting::MAX_INT, data.enterConnectionTransferTravelTime);
+    EXPECT_EQ(TrRouting::MAX_INT, data.exitConnectionTransferTravelTime);
+  }
+}
+
+// Trips outside the connection set must keep their default state, since the
+// overlay is sized for every trip but the filter only walks the scenario trips
+TEST_F(AlternativeFilterFixtureTests, TripsOutsideConnectionSetAreNotTouched)
+{
+  std::shared_ptr<TrRouting::ConnectionSet> connectionSet =
+    transitData.getConnectionsForScenario(
+      transitData.getScenarios().at(TestDataFetcher::scenario2Uuid));
+
+  std::vector<TrRouting::TripQueryData> tripsQueryOverlay = makeOverlay();
+
+  std::vector<std::reference_wrapper<const TrRouting::Line>> excludeLines;
+  excludeLines.push_back(getLine(TestDataFetcher::lineSNUuid));
+  TrRouting::AlternativeLineFilter filter(excludeLines);
+  filter.runFilter(tripsQueryOverlay, *connectionSet);
+
+  // Line EW is excluded from scenario 2, so its trips must stay enabled
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip1EWUuid)));
+  EXPECT_FALSE(isDisabled(tripsQueryOverlay, getTrip(TestDataFetcher::trip2EWUuid)));
 }


### PR DESCRIPTION
    By adding the disabled information into the trip query overlay, we reduce
    the amount of time spent on memory lookup. We already need to fetch
    the tripsQueryOverlay, so adding a single flag add a little bit of memory, but reduce
    overall time in the calculation hot path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved alternative-route processing to generate and filter line combinations more consistently.
  * Added support for tracking disabled trips directly within each query.
* **Bug Fixes**
  * Preserved existing trip availability and filtering state across calculations.
  * Prevented duplicate or previously failed route combinations.
* **Tests**
  * Added comprehensive coverage for line-combination generation and alternative-trip filtering.
* **Maintenance**
  * Improved header inclusion safeguards and removed unused code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->