### PR TITLE
alternatives: consolidate loop condition and max alternative check

### DIFF
--- a/connection_scan_algorithm/src/alternatives_routing.cpp
+++ b/connection_scan_algorithm/src/alternatives_routing.cpp
@@ -95,7 +95,7 @@ namespace TrRouting
     int maxTravelTime;
     int alternativeSequence = 1;
     int alternativesCalculatedCount = 1;
-    int maxAlternatives = parameters.getMaxAlternatives();
+    const int maxAlternatives = parameters.getMaxAlternatives();
     int lastFoundedAtNum = 0;
 
     spdlog::debug("alternatives parameters:");
@@ -163,54 +163,55 @@ namespace TrRouting
     generateCombinations(foundLines, {}, failedCombinations, allCombinations, alreadyCalculatedCombinations);
 
     // Process all combinations and calculate new route with those excluded
-    for (size_t i = 0; i < allCombinations.size(); i++)
+    const int maxValidAlternatives = parameters.getMaxValidAlternatives();
+    for (size_t i = 0;
+         i < allCombinations.size()
+           && alternativesCalculatedCount < maxAlternatives
+           && alternativeSequence - 1 < maxValidAlternatives;
+         i++)
     {
-      if (alternativesCalculatedCount < maxAlternatives && alternativeSequence - 1 < parameters.getMaxValidAlternatives())
-      {
-        // Generate parameters to send to calculate
-        const LineVector combination = allCombinations.at(i);
+      // Generate parameters to send to calculate
+      const LineVector combination = allCombinations.at(i);
 
-        AlternativeLineFilter lineFilter(combination);
+      AlternativeLineFilter lineFilter(combination);
 
-        spdlog::debug("calculating alternative {} from a total of {} ...", alternativeSequence, alternativesCalculatedCount);
+      spdlog::debug("calculating alternative {} from a total of {} ...", alternativeSequence, alternativesCalculatedCount);
         
-        spdlog::debug("except lines: {}", LinesToString(combination));
+      spdlog::debug("except lines: {}", LinesToString(combination));
 
-        try {
-          result = calculateSingle(alternativeParameters, false, &lineFilter);
+      try {
+        result = calculateSingle(alternativeParameters, false, &lineFilter);
 
-          SingleCalculationResult& alternativeCalcResult = *result.get();
+        SingleCalculationResult& alternativeCalcResult = *result.get();
 
-          // Extract lines from new results. If the result is valid, add it to the alternative list
-          // and then generation new lines combinations to try other alternatives
-          LineVisitor alternativeVisitor = LineVisitor();
-          foundLines = alternativeCalcResult.accept(alternativeVisitor);
-          std::stable_sort(foundLines.begin(), foundLines.end());
+        // Extract lines from new results. If the result is valid, add it to the alternative list
+        // and then generation new lines combinations to try other alternatives
+        LineVisitor alternativeVisitor = LineVisitor();
+        foundLines = alternativeCalcResult.accept(alternativeVisitor);
+        std::stable_sort(foundLines.begin(), foundLines.end());
 
-          if (foundLines.size() > 0 && alreadyFoundLines.count(foundLines) == 0)
-          {
-            alternatives.alternatives.push_back(std::move(result));
+        if (foundLines.size() > 0 && alreadyFoundLines.count(foundLines) == 0)
+        {
+          alternatives.alternatives.push_back(std::move(result));
 
-            spdlog::debug("travelTimeSeconds: {}  line Uuids: {}",
-                          alternativeCalcResult.totalTravelTime,
-                          LinesToString(foundLines));
-            
+          spdlog::debug("travelTimeSeconds: {}  line Uuids: {}",
+                        alternativeCalcResult.totalTravelTime,
+                        LinesToString(foundLines));
 
             lastFoundedAtNum = alternativesCalculatedCount;
             alreadyFoundLines[foundLines] = true;
             // Generate new combinations from the new foundlines
             generateCombinations(foundLines, combination, failedCombinations, allCombinations, alreadyCalculatedCombinations);
 
-            alternativeSequence++;
+          alternativeSequence++;
 
-          }
-        } catch (NoRoutingFoundException& e) {
-
-          failedCombinations.push_back(combination);
         }
+      } catch (NoRoutingFoundException& e) {
 
-        alternativesCalculatedCount++;
+        failedCombinations.push_back(combination);
       }
+
+      alternativesCalculatedCount++;
     }
 
     // Print failed combinations


### PR DESCRIPTION
Small optimisation, the loop was iterating through all the combination, even if we had reached the max alternative count. The if was evaluated and skipped the rest of the calculation, but we were still looping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved alternative route processing by stopping earlier when configured limits are reached.
  * Reduced redundant calculations during route alternative evaluation.
* **Behavior**
  * Route calculation results, combinations, and failure handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->